### PR TITLE
fix: render .ipynb notebooks instead of .py in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ plugins:
   - mkdocs-jupyter:
       execute: false
       ignore_h1_titles: true
+      include: ["*.ipynb"]
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

- mkdocs-jupyter was converting both `.py` and `.ipynb` files for each notebook
- Since they share the same URL slug, the `.py` version (code only, no cell outputs) **overwrote** the `.ipynb` version (with executed outputs and embedded plots)
- Add `include: ["*.ipynb"]` to mkdocs-jupyter config so only `.ipynb` files are rendered

This is why no notebook outputs or plots were showing on the docs site.

## Test plan

- [x] Local `mkdocs build` now shows 50 `jp-OutputArea` elements for operator_zoo (was 1)
- [x] Only `.ipynb` files appear in "Converting notebook" logs (no `.py` duplicates)
- [ ] CI passes
- [ ] Deployed site shows notebook cell outputs and plots

🤖 Generated with [Claude Code](https://claude.com/claude-code)