### PR TITLE
feat: add _testing.py utilities and deduplicate test helpers

### DIFF
--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -23,7 +23,9 @@ from gaussx._operators._low_rank_update import LowRankUpdate
 # ---------------------------------------------------------------------------
 
 
-def tree_allclose(x, y, *, rtol: float = 1e-5, atol: float = 1e-8) -> bool | jnp.ndarray:
+def tree_allclose(
+    x, y, *, rtol: float = 1e-5, atol: float = 1e-8
+) -> bool | jnp.ndarray:
     """PyTree-aware approximate equality check.
 
     Wraps ``eqx.tree_equal`` with tolerance support. Matches the

--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -23,7 +23,7 @@ from gaussx._operators._low_rank_update import LowRankUpdate
 # ---------------------------------------------------------------------------
 
 
-def tree_allclose(x, y, *, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+def tree_allclose(x, y, *, rtol: float = 1e-5, atol: float = 1e-8) -> bool | jnp.ndarray:
     """PyTree-aware approximate equality check.
 
     Wraps ``eqx.tree_equal`` with tolerance support. Matches the

--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -1,0 +1,125 @@
+"""Test utilities for gaussx.
+
+Provides helper functions for generating random structured operators
+and comparing results. Intended for use in the gaussx test suite
+and by downstream libraries testing gaussx integration.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+
+from gaussx._operators._block_diag import BlockDiag
+from gaussx._operators._kronecker import Kronecker
+from gaussx._operators._low_rank_update import LowRankUpdate
+
+
+# ---------------------------------------------------------------------------
+# Comparison helpers
+# ---------------------------------------------------------------------------
+
+
+def tree_allclose(x, y, *, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+    """PyTree-aware approximate equality check.
+
+    Wraps ``eqx.tree_equal`` with tolerance support. Matches the
+    pattern used in the lineax test suite.
+    """
+    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Random operator generators
+# ---------------------------------------------------------------------------
+
+
+def random_pd_matrix(key: jax.Array, n: int, *, dtype=jnp.float64) -> jnp.ndarray:
+    """Generate a random positive-definite n x n matrix."""
+    A = jr.normal(key, (n, n), dtype=dtype)
+    return A @ A.T + 0.1 * jnp.eye(n, dtype=dtype)
+
+
+def random_pd_operator(
+    key: jax.Array, n: int, *, dtype=jnp.float64
+) -> lx.MatrixLinearOperator:
+    """Generate a random PSD MatrixLinearOperator."""
+    mat = random_pd_matrix(key, n, dtype=dtype)
+    return lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+
+
+def random_kronecker_pd(
+    key: jax.Array,
+    sizes: tuple[int, ...],
+    *,
+    dtype=jnp.float64,
+) -> Kronecker:
+    """Generate a Kronecker product of random PSD matrices."""
+    keys = jr.split(key, len(sizes))
+    ops = tuple(
+        random_pd_operator(k, n, dtype=dtype) for k, n in zip(keys, sizes, strict=True)
+    )
+    return Kronecker(*ops)
+
+
+def random_block_diag_pd(
+    key: jax.Array,
+    sizes: tuple[int, ...],
+    *,
+    dtype=jnp.float64,
+) -> BlockDiag:
+    """Generate a BlockDiag of random PSD matrices."""
+    keys = jr.split(key, len(sizes))
+    ops = tuple(
+        random_pd_operator(k, n, dtype=dtype) for k, n in zip(keys, sizes, strict=True)
+    )
+    return BlockDiag(*ops)
+
+
+def random_low_rank_update(
+    key: jax.Array,
+    n: int,
+    rank: int,
+    *,
+    dtype=jnp.float64,
+) -> LowRankUpdate:
+    """Generate a random LowRankUpdate with positive diagonal base."""
+    k1, k2, k3 = jr.split(key, 3)
+    d = jnp.abs(jr.normal(k1, (n,), dtype=dtype)) + 0.5
+    U = jr.normal(k2, (n, rank), dtype=dtype) * 0.3
+    diag_vals = jnp.abs(jr.normal(k3, (rank,), dtype=dtype)) + 0.1
+    base = lx.DiagonalLinearOperator(d)
+    return LowRankUpdate(base, U, diag_vals)
+
+
+# ---------------------------------------------------------------------------
+# Dense reference computations
+# ---------------------------------------------------------------------------
+
+
+def dense_solve(op: lx.AbstractLinearOperator, v: jnp.ndarray) -> jnp.ndarray:
+    """Solve via dense materialization (reference implementation)."""
+    return jnp.linalg.solve(op.as_matrix(), v)
+
+
+def dense_logdet(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+    """Log-determinant via dense materialization."""
+    return jnp.linalg.slogdet(op.as_matrix())[1]
+
+
+def dense_inv(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+    """Inverse via dense materialization."""
+    return jnp.linalg.inv(op.as_matrix())
+
+
+def dense_diag(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+    """Diagonal via dense materialization."""
+    return jnp.diag(op.as_matrix())
+
+
+def dense_trace(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+    """Trace via dense materialization."""
+    return jnp.trace(op.as_matrix())

--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -1,8 +1,8 @@
 """Test utilities for gaussx.
 
 Provides helper functions for generating random structured operators
-and comparing results. Intended for use in the gaussx test suite
-and by downstream libraries testing gaussx integration.
+and comparing results. Intended for use in the gaussx test suite and
+other internal tests; not part of the public, stable gaussx API.
 """
 
 from __future__ import annotations
@@ -13,9 +13,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 
-from gaussx._operators._block_diag import BlockDiag
-from gaussx._operators._kronecker import Kronecker
-from gaussx._operators._low_rank_update import LowRankUpdate
+from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 
 
 # ---------------------------------------------------------------------------

--- a/tests/operators/test_block_diag.py
+++ b/tests/operators/test_block_diag.py
@@ -11,10 +11,7 @@ import pytest
 
 from gaussx._operators import BlockDiag
 from gaussx._tags import is_block_diagonal
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+from gaussx._testing import tree_allclose
 
 
 # ---------------------------------------------------------------------------

--- a/tests/operators/test_kronecker.py
+++ b/tests/operators/test_kronecker.py
@@ -11,10 +11,7 @@ import pytest
 
 from gaussx._operators import Kronecker
 from gaussx._tags import is_kronecker
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+from gaussx._testing import tree_allclose
 
 
 class LazyDiagonal(lx.DiagonalLinearOperator):

--- a/tests/operators/test_low_rank_update.py
+++ b/tests/operators/test_low_rank_update.py
@@ -11,10 +11,7 @@ import pytest
 
 from gaussx._operators import LowRankUpdate, low_rank_plus_diag, svd_low_rank_plus_diag
 from gaussx._tags import is_low_rank
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+from gaussx._testing import tree_allclose
 
 
 # ---------------------------------------------------------------------------

--- a/tests/primitives/test_cholesky.py
+++ b/tests/primitives/test_cholesky.py
@@ -9,16 +9,7 @@ import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker
 from gaussx._primitives import cholesky
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _make_pd(getkey, n):
-    """Generate a positive-definite matrix."""
-    A = jr.normal(getkey(), (n, n))
-    return A @ A.T + 0.1 * jnp.eye(n)
+from gaussx._testing import random_pd_matrix, tree_allclose
 
 
 def test_cholesky_diagonal(getkey):
@@ -32,8 +23,8 @@ def test_cholesky_diagonal(getkey):
 
 
 def test_cholesky_block_diag(getkey):
-    A = _make_pd(getkey, 2)
-    B = _make_pd(getkey, 3)
+    A = random_pd_matrix(getkey(), 2)
+    B = random_pd_matrix(getkey(), 3)
     bd = BlockDiag(
         lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag),
         lx.MatrixLinearOperator(B, lx.positive_semidefinite_tag),
@@ -45,8 +36,8 @@ def test_cholesky_block_diag(getkey):
 
 
 def test_cholesky_kronecker(getkey):
-    A = _make_pd(getkey, 2)
-    B = _make_pd(getkey, 3)
+    A = random_pd_matrix(getkey(), 2)
+    B = random_pd_matrix(getkey(), 3)
     K = Kronecker(
         lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag),
         lx.MatrixLinearOperator(B, lx.positive_semidefinite_tag),
@@ -58,7 +49,7 @@ def test_cholesky_kronecker(getkey):
 
 
 def test_cholesky_dense(getkey):
-    A = _make_pd(getkey, 4)
+    A = random_pd_matrix(getkey(), 4)
     op = lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag)
     L = cholesky(op)
     assert isinstance(L, lx.MatrixLinearOperator)

--- a/tests/primitives/test_diag.py
+++ b/tests/primitives/test_diag.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker
 from gaussx._primitives import diag
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _dense_diag(op):
-    return jnp.diag(op.as_matrix())
+from gaussx._testing import dense_diag, tree_allclose
 
 
 def test_diag_diagonal(getkey):
@@ -29,14 +21,14 @@ def test_diag_block_diag(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
     bd = BlockDiag(A, B)
-    assert tree_allclose(diag(bd), _dense_diag(bd))
+    assert tree_allclose(diag(bd), dense_diag(bd))
 
 
 def test_diag_kronecker(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
     K = Kronecker(A, B)
-    assert tree_allclose(diag(K), _dense_diag(K))
+    assert tree_allclose(diag(K), dense_diag(K))
 
 
 def test_diag_dense_fallback(getkey):

--- a/tests/primitives/test_inv.py
+++ b/tests/primitives/test_inv.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
@@ -10,14 +9,7 @@ import lineax as lx
 from gaussx._operators import BlockDiag, Kronecker
 from gaussx._primitives import inv
 from gaussx._primitives._inv import InverseOperator
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _dense_inv(op):
-    return jnp.linalg.inv(op.as_matrix())
+from gaussx._testing import dense_inv, tree_allclose
 
 
 def test_inv_diagonal(getkey):
@@ -25,7 +17,7 @@ def test_inv_diagonal(getkey):
     op = lx.DiagonalLinearOperator(d)
     inv_op = inv(op)
     assert isinstance(inv_op, lx.DiagonalLinearOperator)
-    assert tree_allclose(inv_op.as_matrix(), _dense_inv(op))
+    assert tree_allclose(inv_op.as_matrix(), dense_inv(op))
 
 
 def test_inv_block_diag(getkey):
@@ -34,7 +26,7 @@ def test_inv_block_diag(getkey):
     bd = BlockDiag(A, B)
     inv_op = inv(bd)
     assert isinstance(inv_op, BlockDiag)
-    assert tree_allclose(inv_op.as_matrix(), _dense_inv(bd), rtol=1e-4)
+    assert tree_allclose(inv_op.as_matrix(), dense_inv(bd), rtol=1e-4)
 
 
 def test_inv_kronecker(getkey):
@@ -43,7 +35,7 @@ def test_inv_kronecker(getkey):
     K = Kronecker(A, B)
     inv_op = inv(K)
     assert isinstance(inv_op, Kronecker)
-    assert tree_allclose(inv_op.as_matrix(), _dense_inv(K), rtol=1e-4)
+    assert tree_allclose(inv_op.as_matrix(), dense_inv(K), rtol=1e-4)
 
 
 def test_inv_dense_returns_inverse_operator(getkey):
@@ -67,7 +59,7 @@ def test_inv_dense_as_matrix(getkey):
     mat = jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3)
     op = lx.MatrixLinearOperator(mat)
     inv_op = inv(op)
-    assert tree_allclose(inv_op.as_matrix(), _dense_inv(op))
+    assert tree_allclose(inv_op.as_matrix(), dense_inv(op))
 
 
 def test_inv_roundtrip(getkey):

--- a/tests/primitives/test_logdet.py
+++ b/tests/primitives/test_logdet.py
@@ -9,34 +9,27 @@ import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 from gaussx._primitives import logdet
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _dense_logdet(op):
-    return jnp.linalg.slogdet(op.as_matrix())[1]
+from gaussx._testing import dense_logdet, tree_allclose
 
 
 def test_logdet_diagonal(getkey):
     d = jnp.abs(jr.normal(getkey(), (4,))) + 0.1
     op = lx.DiagonalLinearOperator(d)
-    assert tree_allclose(logdet(op), _dense_logdet(op))
+    assert tree_allclose(logdet(op), dense_logdet(op))
 
 
 def test_logdet_block_diag(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)) + 3 * jnp.eye(2))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3))
     bd = BlockDiag(A, B)
-    assert tree_allclose(logdet(bd), _dense_logdet(bd))
+    assert tree_allclose(logdet(bd), dense_logdet(bd))
 
 
 def test_logdet_kronecker(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)) + 3 * jnp.eye(2))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3))
     K = Kronecker(A, B)
-    assert tree_allclose(logdet(K), _dense_logdet(K), rtol=1e-4)
+    assert tree_allclose(logdet(K), dense_logdet(K), rtol=1e-4)
 
 
 def test_logdet_kronecker_three_factors(getkey):
@@ -44,7 +37,7 @@ def test_logdet_kronecker_three_factors(getkey):
     B = lx.DiagonalLinearOperator(jnp.abs(jr.normal(getkey(), (2,))) + 0.5)
     C = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)) + 3 * jnp.eye(2))
     K = Kronecker(A, B, C)
-    assert tree_allclose(logdet(K), _dense_logdet(K), rtol=1e-4)
+    assert tree_allclose(logdet(K), dense_logdet(K), rtol=1e-4)
 
 
 def test_logdet_low_rank(getkey):
@@ -52,13 +45,13 @@ def test_logdet_low_rank(getkey):
     base = lx.DiagonalLinearOperator(d)
     U = jr.normal(getkey(), (5, 2)) * 0.3
     lr = LowRankUpdate(base, U)
-    assert tree_allclose(logdet(lr), _dense_logdet(lr), rtol=1e-4)
+    assert tree_allclose(logdet(lr), dense_logdet(lr), rtol=1e-4)
 
 
 def test_logdet_dense_fallback(getkey):
     mat = jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3)
     op = lx.MatrixLinearOperator(mat)
-    assert tree_allclose(logdet(op), _dense_logdet(op))
+    assert tree_allclose(logdet(op), dense_logdet(op))
 
 
 def test_logdet_filter_jit(getkey):
@@ -69,4 +62,4 @@ def test_logdet_filter_jit(getkey):
     def f(op):
         return logdet(op)
 
-    assert tree_allclose(f(op), _dense_logdet(op))
+    assert tree_allclose(f(op), dense_logdet(op))

--- a/tests/primitives/test_solve.py
+++ b/tests/primitives/test_solve.py
@@ -9,10 +9,7 @@ import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 from gaussx._primitives import solve
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+from gaussx._testing import dense_solve, tree_allclose
 
 
 class LazyDiagonal(lx.DiagonalLinearOperator):
@@ -20,15 +17,11 @@ class LazyDiagonal(lx.DiagonalLinearOperator):
         raise NotImplementedError("dense materialization unavailable")
 
 
-def _dense_solve(op, v):
-    return jnp.linalg.solve(op.as_matrix(), v)
-
-
 def test_solve_diagonal(getkey):
     d = jnp.abs(jr.normal(getkey(), (4,))) + 0.1
     op = lx.DiagonalLinearOperator(d)
     v = jr.normal(getkey(), (4,))
-    assert tree_allclose(solve(op, v), _dense_solve(op, v))
+    assert tree_allclose(solve(op, v), dense_solve(op, v))
 
 
 def test_solve_block_diag(getkey):
@@ -36,7 +29,7 @@ def test_solve_block_diag(getkey):
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3))
     bd = BlockDiag(A, B)
     v = jr.normal(getkey(), (5,))
-    assert tree_allclose(solve(bd, v), _dense_solve(bd, v))
+    assert tree_allclose(solve(bd, v), dense_solve(bd, v))
 
 
 def test_solve_kronecker(getkey):
@@ -44,7 +37,7 @@ def test_solve_kronecker(getkey):
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3))
     K = Kronecker(A, B)
     v = jr.normal(getkey(), (6,))
-    assert tree_allclose(solve(K, v), _dense_solve(K, v), rtol=1e-4)
+    assert tree_allclose(solve(K, v), dense_solve(K, v), rtol=1e-4)
 
 
 def test_solve_kronecker_lazy_factors(getkey):
@@ -62,14 +55,14 @@ def test_solve_low_rank(getkey):
     U = jr.normal(getkey(), (5, 2)) * 0.1
     lr = LowRankUpdate(base, U)
     v = jr.normal(getkey(), (5,))
-    assert tree_allclose(solve(lr, v), _dense_solve(lr, v), rtol=1e-4)
+    assert tree_allclose(solve(lr, v), dense_solve(lr, v), rtol=1e-4)
 
 
 def test_solve_dense_fallback(getkey):
     mat = jr.normal(getkey(), (3, 3)) + 3 * jnp.eye(3)
     op = lx.MatrixLinearOperator(mat)
     v = jr.normal(getkey(), (3,))
-    assert tree_allclose(solve(op, v), _dense_solve(op, v))
+    assert tree_allclose(solve(op, v), dense_solve(op, v))
 
 
 def test_solve_filter_jit(getkey):
@@ -81,4 +74,4 @@ def test_solve_filter_jit(getkey):
     def f(op, v):
         return solve(op, v)
 
-    assert tree_allclose(f(op, v), _dense_solve(op, v))
+    assert tree_allclose(f(op, v), dense_solve(op, v))

--- a/tests/primitives/test_sqrt.py
+++ b/tests/primitives/test_sqrt.py
@@ -2,22 +2,13 @@
 
 from __future__ import annotations
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker
 from gaussx._primitives import sqrt
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _make_pd(getkey, n):
-    A = jr.normal(getkey(), (n, n))
-    return A @ A.T + 0.1 * jnp.eye(n)
+from gaussx._testing import random_pd_matrix, tree_allclose
 
 
 def test_sqrt_diagonal(getkey):
@@ -31,8 +22,8 @@ def test_sqrt_diagonal(getkey):
 
 
 def test_sqrt_block_diag(getkey):
-    A = _make_pd(getkey, 2)
-    B = _make_pd(getkey, 3)
+    A = random_pd_matrix(getkey(), 2)
+    B = random_pd_matrix(getkey(), 3)
     bd = BlockDiag(
         lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag),
         lx.MatrixLinearOperator(B, lx.positive_semidefinite_tag),
@@ -44,8 +35,8 @@ def test_sqrt_block_diag(getkey):
 
 
 def test_sqrt_kronecker(getkey):
-    A = _make_pd(getkey, 2)
-    B = _make_pd(getkey, 3)
+    A = random_pd_matrix(getkey(), 2)
+    B = random_pd_matrix(getkey(), 3)
     K = Kronecker(
         lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag),
         lx.MatrixLinearOperator(B, lx.positive_semidefinite_tag),
@@ -57,7 +48,7 @@ def test_sqrt_kronecker(getkey):
 
 
 def test_sqrt_dense(getkey):
-    A = _make_pd(getkey, 4)
+    A = random_pd_matrix(getkey(), 4)
     op = lx.MatrixLinearOperator(A, lx.positive_semidefinite_tag)
     S = sqrt(op)
     reconstructed = S.as_matrix() @ S.as_matrix()

--- a/tests/primitives/test_trace.py
+++ b/tests/primitives/test_trace.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker
 from gaussx._primitives import trace
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _dense_trace(op):
-    return jnp.trace(op.as_matrix())
+from gaussx._testing import dense_trace, tree_allclose
 
 
 def test_trace_diagonal(getkey):
@@ -29,14 +21,14 @@ def test_trace_block_diag(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
     bd = BlockDiag(A, B)
-    assert tree_allclose(trace(bd), _dense_trace(bd))
+    assert tree_allclose(trace(bd), dense_trace(bd))
 
 
 def test_trace_kronecker(getkey):
     A = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
     B = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
     K = Kronecker(A, B)
-    assert tree_allclose(trace(K), _dense_trace(K))
+    assert tree_allclose(trace(K), dense_trace(K))
 
 
 def test_trace_dense_fallback(getkey):

--- a/tests/strategies/test_cg.py
+++ b/tests/strategies/test_cg.py
@@ -8,20 +8,12 @@ import jax.random as jr
 import lineax as lx
 
 from gaussx._strategies import CGSolver
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
-
-
-def _make_pd(getkey, n):
-    A = jr.normal(getkey(), (n, n))
-    return A @ A.T + 1.0 * jnp.eye(n)
+from gaussx._testing import random_pd_matrix, tree_allclose
 
 
 def test_solve_psd(getkey):
     cg = CGSolver(rtol=1e-8, atol=1e-8)
-    mat = _make_pd(getkey, 5)
+    mat = random_pd_matrix(getkey(), 5)
     op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
     v = jr.normal(getkey(), (5,))
     expected = jnp.linalg.solve(mat, v)
@@ -42,7 +34,7 @@ def test_solve_diagonal(getkey):
 def test_logdet_psd(getkey):
     """Stochastic logdet should be within ~10% for moderate-size PSD."""
     cg = CGSolver(num_probes=50, lanczos_order=20)
-    mat = _make_pd(getkey, 20)
+    mat = random_pd_matrix(getkey(), 20)
     op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
     key = jr.PRNGKey(42)
     estimated = cg.logdet(op, key=key)
@@ -66,7 +58,7 @@ def test_logdet_diagonal(getkey):
 
 def test_filter_jit_solve(getkey):
     cg = CGSolver(rtol=1e-6, atol=1e-6)
-    mat = _make_pd(getkey, 4)
+    mat = random_pd_matrix(getkey(), 4)
     op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
     v = jr.normal(getkey(), (4,))
 

--- a/tests/strategies/test_dense.py
+++ b/tests/strategies/test_dense.py
@@ -9,10 +9,7 @@ import lineax as lx
 
 from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 from gaussx._strategies import DenseSolver
-
-
-def tree_allclose(x, y, *, rtol=1e-5, atol=1e-8):
-    return eqx.tree_equal(x, y, typematch=True, rtol=rtol, atol=atol)
+from gaussx._testing import tree_allclose
 
 
 def test_solve_diagonal(getkey):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,67 @@
+"""Tests for gaussx._testing helper utilities."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import lineax as lx
+
+from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
+from gaussx._testing import (
+    random_block_diag_pd,
+    random_kronecker_pd,
+    random_low_rank_update,
+    random_pd_matrix,
+    random_pd_operator,
+    tree_allclose,
+)
+
+
+def test_tree_allclose_true():
+    x = jnp.array([1.0, 2.0])
+    assert tree_allclose(x, x)
+
+
+def test_tree_allclose_false():
+    x = jnp.array([1.0, 2.0])
+    y = jnp.array([1.0, 3.0])
+    assert not tree_allclose(x, y)
+
+
+def test_random_pd_matrix_shape_and_pd(getkey):
+    mat = random_pd_matrix(getkey(), 5)
+    assert mat.shape == (5, 5)
+    assert mat.dtype == jnp.float64
+    # Positive definite: all eigenvalues > 0
+    eigs = jnp.linalg.eigvalsh(mat)
+    assert jnp.all(eigs > 0)
+
+
+def test_random_pd_operator(getkey):
+    op = random_pd_operator(getkey(), 4)
+    assert isinstance(op, lx.MatrixLinearOperator)
+    assert op.in_size() == 4
+    assert lx.is_positive_semidefinite(op)
+
+
+def test_random_kronecker_pd(getkey):
+    K = random_kronecker_pd(getkey(), (3, 4))
+    assert isinstance(K, Kronecker)
+    assert K.in_size() == 12
+    # All factors should be PSD
+    for op in K.operators:
+        assert lx.is_positive_semidefinite(op)
+
+
+def test_random_block_diag_pd(getkey):
+    BD = random_block_diag_pd(getkey(), (2, 3, 4))
+    assert isinstance(BD, BlockDiag)
+    assert BD.in_size() == 9
+    for op in BD.operators:
+        assert lx.is_positive_semidefinite(op)
+
+
+def test_random_low_rank_update(getkey):
+    lr = random_low_rank_update(getkey(), 10, 3)
+    assert isinstance(lr, LowRankUpdate)
+    assert lr.in_size() == 10
+    assert lr.rank == 3


### PR DESCRIPTION
## Summary

- Implement `gaussx._testing` with shared test helpers:
  - `tree_allclose` (was copy-pasted 12 times across test files)
  - `random_pd_matrix`, `random_pd_operator` (was `_make_pd`, copied 3 times)
  - `random_kronecker_pd`, `random_block_diag_pd`, `random_low_rank_update`
  - `dense_solve`, `dense_logdet`, `dense_inv`, `dense_diag`, `dense_trace`
- Refactor all 12 test files to import from `gaussx._testing`
- Removes ~60 lines of duplicated helper definitions

## Test plan

- [x] 116 tests pass
- [x] Lint/format clean
- [x] No local `tree_allclose`, `_make_pd`, or `_dense_*` definitions remain in tests/
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)