### PR TITLE
refactor: standardize einops and jaxtyping usage

### DIFF
--- a/src/gaussx/_distributions/_gaussian.py
+++ b/src/gaussx/_distributions/_gaussian.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._primitives._trace import trace
 from gaussx._strategies._base import (
@@ -19,10 +20,10 @@ _LOG_2PI = jnp.log(2.0 * jnp.pi)
 
 def quadratic_form(
     operator: lx.AbstractLinearOperator,
-    x: jnp.ndarray,
+    x: Float[Array, " N"],
     *,
     solver: AbstractSolveStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Compute ``x^T A^{-1} x`` via a single solve.
 
     Args:
@@ -38,11 +39,11 @@ def quadratic_form(
 
 
 def _gaussian_log_prob_residual(
-    residual: jnp.ndarray,
+    residual: Float[Array, " N"],
     cov_operator: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Gaussian log-prob given a pre-computed residual ``value - loc``."""
     N = residual.shape[-1]
     alpha = dispatch_solve(cov_operator, residual, solver)
@@ -52,12 +53,12 @@ def _gaussian_log_prob_residual(
 
 
 def gaussian_log_prob(
-    loc: jnp.ndarray,
+    loc: Float[Array, " N"],
     cov_operator: lx.AbstractLinearOperator,
-    value: jnp.ndarray,
+    value: Float[Array, " N"],
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Multivariate normal log-probability.
 
     Computes::
@@ -85,7 +86,7 @@ def gaussian_entropy(
     cov_operator: lx.AbstractLinearOperator,
     *,
     solver: AbstractLogdetStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Entropy of a multivariate normal ``N(mu, Sigma)``.
 
     Computes::
@@ -108,11 +109,11 @@ def gaussian_entropy(
 
 
 def kl_standard_normal(
-    m: jnp.ndarray,
+    m: Float[Array, " N"],
     S: lx.AbstractLinearOperator,
     *,
     solver: AbstractLogdetStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """KL divergence ``KL(N(m, S) || N(0, I))``.
 
     Computes::

--- a/src/gaussx/_distributions/_mvn.py
+++ b/src/gaussx/_distributions/_mvn.py
@@ -23,6 +23,37 @@ from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
+_BATCH_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+
+
+def _reshape_batch(
+    values: Float[Array, " flat"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch"]:
+    if not batch_shape:
+        return values[0]
+    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
+
+
+def _reshape_samples(
+    values: Float[Array, "flat N"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch N"]:
+    if not batch_shape:
+        return values[0]
+    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    return rearrange(
+        values,
+        f"({batch_pattern}) N -> {batch_pattern} N",
+        **axis_lengths,
+    )
+
+
 class MultivariateNormal(dist.Distribution):
     """Multivariate normal parameterized by a lineax linear operator.
 
@@ -63,7 +94,7 @@ class MultivariateNormal(dist.Distribution):
 
     def __init__(
         self,
-        loc: Float[Array, " N"],
+        loc: Float[Array, "*batch N"],
         cov_operator: lx.AbstractLinearOperator,
         solver: AbstractSolverStrategy | None = None,
         *,
@@ -88,18 +119,18 @@ class MultivariateNormal(dist.Distribution):
         )
 
     @validate_sample
-    def log_prob(self, value: Float[Array, ...]) -> Float[Array, ...]:
+    def log_prob(self, value: Float[Array, "*batch N"]) -> Float[Array, "*batch"]:
         residual = value - self.loc
         leading_shape = residual.shape[:-1]
         residual_flat = rearrange(residual, "... D -> (...) D")
         log_prob_flat = jax.vmap(self._log_prob_single)(residual_flat)
-        return log_prob_flat.reshape(leading_shape)
+        return _reshape_batch(log_prob_flat, leading_shape)
 
     def sample(
         self,
         key: jax.dtypes.prng_key | None,
         sample_shape: tuple[int, ...] = (),
-    ) -> jax.typing.ArrayLike:
+    ) -> Float[Array, "*batch N"]:
         if key is None:
             raise ValueError(
                 "PRNG key must be provided to sample from MultivariateNormal."
@@ -109,14 +140,14 @@ class MultivariateNormal(dist.Distribution):
         eps = jax.random.normal(key, shape=shape)  # type: ignore[arg-type]
         eps_flat = rearrange(eps, "... D -> (...) D")
         samples_flat = jax.vmap(L.mv)(eps_flat)
-        return self.loc + samples_flat.reshape(shape)
+        return self.loc + _reshape_samples(samples_flat, shape[:-1])
 
     @lazy_property
-    def mean(self) -> Float[Array, " N"]:
+    def mean(self) -> Float[Array, "*batch N"]:
         return self.loc
 
     @lazy_property
-    def variance(self) -> Float[Array, " N"]:
+    def variance(self) -> Float[Array, "*batch N"]:
         return jnp.broadcast_to(
             _diag(self.cov_operator), self.batch_shape + self.event_shape
         )

--- a/src/gaussx/_distributions/_mvn.py
+++ b/src/gaussx/_distributions/_mvn.py
@@ -6,7 +6,6 @@ from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
-import jax.typing
 import lineax as lx
 import numpyro.distributions as dist
 from einops import rearrange
@@ -23,7 +22,19 @@ from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
-_BATCH_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+def _axis_names(count: int) -> tuple[str, ...]:
+    names = []
+    for index in range(count):
+        value = index
+        chars = []
+        while True:
+            value, remainder = divmod(value, 26)
+            chars.append(chr(ord("a") + remainder))
+            if value == 0:
+                break
+            value -= 1
+        names.append("".join(reversed(chars)))
+    return tuple(names)
 
 
 def _reshape_batch(
@@ -32,7 +43,7 @@ def _reshape_batch(
 ) -> Float[Array, "*batch"]:
     if not batch_shape:
         return values[0]
-    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    batch_axes = _axis_names(len(batch_shape))
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
     return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
@@ -44,7 +55,7 @@ def _reshape_samples(
 ) -> Float[Array, "*batch N"]:
     if not batch_shape:
         return values[0]
-    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    batch_axes = _axis_names(len(batch_shape))
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
     return rearrange(

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -6,7 +6,6 @@ from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
-import jax.typing
 import lineax as lx
 import numpyro.distributions as dist
 from einops import rearrange
@@ -19,6 +18,37 @@ from gaussx._primitives._inv import inv as _inv
 from gaussx._primitives._solve import solve as _solve
 from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
+
+
+_BATCH_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+
+
+def _reshape_batch(
+    values: Float[Array, " flat"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch"]:
+    if not batch_shape:
+        return values[0]
+    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
+
+
+def _reshape_samples(
+    values: Float[Array, "flat N"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch N"]:
+    if not batch_shape:
+        return values[0]
+    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    return rearrange(
+        values,
+        f"({batch_pattern}) N -> {batch_pattern} N",
+        **axis_lengths,
+    )
 
 
 class MultivariateNormalPrecision(dist.Distribution):
@@ -58,7 +88,7 @@ class MultivariateNormalPrecision(dist.Distribution):
 
     def __init__(
         self,
-        loc: Float[Array, " N"],
+        loc: Float[Array, "*batch N"],
         prec_operator: lx.AbstractLinearOperator,
         solver: AbstractSolverStrategy | None = None,
         *,
@@ -84,18 +114,18 @@ class MultivariateNormalPrecision(dist.Distribution):
         return -0.5 * (n * jnp.log(2.0 * jnp.pi) - ld + quad)
 
     @validate_sample
-    def log_prob(self, value: Float[Array, ...]) -> Float[Array, ...]:
+    def log_prob(self, value: Float[Array, "*batch N"]) -> Float[Array, "*batch"]:
         residual = value - self.loc
         leading_shape = residual.shape[:-1]
         residual_flat = rearrange(residual, "... D -> (...) D")
         log_prob_flat = jax.vmap(self._log_prob_single)(residual_flat)
-        return log_prob_flat.reshape(leading_shape)
+        return _reshape_batch(log_prob_flat, leading_shape)
 
     def sample(
         self,
         key: jax.dtypes.prng_key | None,
         sample_shape: tuple[int, ...] = (),
-    ) -> jax.typing.ArrayLike:
+    ) -> Float[Array, "*batch N"]:
         if key is None:
             raise ValueError(
                 "PRNG key must be provided to sample from MultivariateNormalPrecision."
@@ -109,14 +139,14 @@ class MultivariateNormalPrecision(dist.Distribution):
 
         eps_flat = rearrange(eps, "... D -> (...) D")
         samples_flat = jax.vmap(_solve_one)(eps_flat)
-        return self.loc + samples_flat.reshape(shape)
+        return self.loc + _reshape_samples(samples_flat, shape[:-1])
 
     @lazy_property
-    def mean(self) -> Float[Array, " N"]:
+    def mean(self) -> Float[Array, "*batch N"]:
         return self.loc
 
     @lazy_property
-    def variance(self) -> Float[Array, " N"]:
+    def variance(self) -> Float[Array, "*batch N"]:
         return jnp.broadcast_to(
             _diag(_inv(self.prec_operator)), self.batch_shape + self.event_shape
         )

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -20,7 +20,19 @@ from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
-_BATCH_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+def _axis_names(count: int) -> tuple[str, ...]:
+    names = []
+    for index in range(count):
+        value = index
+        chars = []
+        while True:
+            value, remainder = divmod(value, 26)
+            chars.append(chr(ord("a") + remainder))
+            if value == 0:
+                break
+            value -= 1
+        names.append("".join(reversed(chars)))
+    return tuple(names)
 
 
 def _reshape_batch(
@@ -29,7 +41,7 @@ def _reshape_batch(
 ) -> Float[Array, "*batch"]:
     if not batch_shape:
         return values[0]
-    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    batch_axes = _axis_names(len(batch_shape))
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
     return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
@@ -41,7 +53,7 @@ def _reshape_samples(
 ) -> Float[Array, "*batch N"]:
     if not batch_shape:
         return values[0]
-    batch_axes = _BATCH_AXIS_NAMES[: len(batch_shape)]
+    batch_axes = _axis_names(len(batch_shape))
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
     return rearrange(

--- a/src/gaussx/_distributions/_project.py
+++ b/src/gaussx/_distributions/_project.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 
 def project(
-    K_XZ: jnp.ndarray,
+    K_XZ: Float[Array, "B M"],
     L_Z: lx.AbstractLinearOperator,
-) -> jnp.ndarray:
+) -> Float[Array, "B M"]:
     """Compute A_X = K_XZ @ K_ZZ^{-1} via Cholesky solve.
 
     Solves ``L_Z @ L_Z^T @ A_X^T = K_XZ^T`` using forward/backward

--- a/src/gaussx/_expfam/_gaussian.py
+++ b/src/gaussx/_expfam/_gaussian.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import lineax as lx
 from einops import einsum
+from jaxtyping import Array, Float
 
 from gaussx._expfam._natural import mean_cov_to_natural, natural_to_mean_cov
 from gaussx._primitives._logdet import logdet
@@ -32,12 +33,12 @@ class GaussianExpFam(eqx.Module):
             Represents ``-0.5 * Lambda`` where Lambda is the precision.
     """
 
-    eta1: jnp.ndarray
+    eta1: Float[Array, " N"]
     eta2: lx.AbstractLinearOperator
 
     @staticmethod
     def from_mean_cov(
-        mu: jnp.ndarray,
+        mu: Float[Array, " N"],
         Sigma: lx.AbstractLinearOperator,
     ) -> GaussianExpFam:
         """Construct from mean and covariance.
@@ -54,7 +55,7 @@ class GaussianExpFam(eqx.Module):
 
     @staticmethod
     def from_mean_prec(
-        mu: jnp.ndarray,
+        mu: Float[Array, " N"],
         Lambda: lx.AbstractLinearOperator,
     ) -> GaussianExpFam:
         """Construct from mean and precision.
@@ -73,7 +74,7 @@ class GaussianExpFam(eqx.Module):
 
 def to_expectation(
     expfam: GaussianExpFam,
-) -> tuple[jnp.ndarray, lx.AbstractLinearOperator]:
+) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Convert natural to expectation parameters.
 
     Args:
@@ -86,9 +87,9 @@ def to_expectation(
 
 
 def to_natural(
-    mu: jnp.ndarray,
+    mu: Float[Array, " N"],
     Sigma: lx.AbstractLinearOperator,
-) -> tuple[jnp.ndarray, lx.AbstractLinearOperator]:
+) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Convert expectation to natural parameters.
 
     Args:
@@ -101,7 +102,7 @@ def to_natural(
     return mean_cov_to_natural(mu, Sigma)
 
 
-def log_partition(expfam: GaussianExpFam) -> jnp.ndarray:
+def log_partition(expfam: GaussianExpFam) -> Float[Array, ""]:
     r"""Log-partition function ``A(eta)``.
 
     .. math::
@@ -150,7 +151,9 @@ def fisher_info(
     return -2.0 * expfam.eta2
 
 
-def sufficient_stats(x: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
+def sufficient_stats(
+    x: Float[Array, "*batch N"],
+) -> tuple[Float[Array, "*batch N"], Float[Array, "*batch N N"]]:
     """Compute sufficient statistics ``T(x) = [x, x x^T]``.
 
     Args:
@@ -169,7 +172,7 @@ def sufficient_stats(x: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
 def kl_divergence(
     q: GaussianExpFam,
     p: GaussianExpFam,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """KL divergence ``KL(q || p)`` via Bregman divergence.
 
     .. math::

--- a/src/gaussx/_expfam/_natural.py
+++ b/src/gaussx/_expfam/_natural.py
@@ -8,8 +8,8 @@ operator. For moment-based expectation parameters ``(m1, m2)`` see
 
 from __future__ import annotations
 
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._primitives._inv import inv
 from gaussx._strategies._base import AbstractSolverStrategy
@@ -17,11 +17,11 @@ from gaussx._strategies._dispatch import dispatch_solve
 
 
 def natural_to_mean_cov(
-    eta1: jnp.ndarray,
+    eta1: Float[Array, " N"],
     eta2: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> tuple[jnp.ndarray, lx.AbstractLinearOperator]:
+) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Convert natural parameters to mean/covariance.
 
     Given natural parameters ``(eta1, eta2)`` where
@@ -47,11 +47,11 @@ def natural_to_mean_cov(
 
 
 def mean_cov_to_natural(
-    mu: jnp.ndarray,
+    mu: Float[Array, " N"],
     Sigma: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> tuple[jnp.ndarray, lx.AbstractLinearOperator]:
+) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Convert mean/covariance to natural parameters.
 
     Given mean ``mu`` and covariance ``Sigma``:

--- a/src/gaussx/_gp/_elbo.py
+++ b/src/gaussx/_gp/_elbo.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 
 
 def variational_elbo_gaussian(
-    y: jnp.ndarray,
-    f_loc: jnp.ndarray,
-    f_var: jnp.ndarray,
+    y: Float[Array, " N"],
+    f_loc: Float[Array, " N"],
+    f_var: Float[Array, " N"],
     noise_var: float,
-    kl: jnp.ndarray,
-) -> jnp.ndarray:
+    kl: Float[Array, ""],
+) -> Float[Array, ""]:
     """Titsias collapsed ELBO for Gaussian likelihoods.
 
     Computes::
@@ -46,10 +47,10 @@ def variational_elbo_gaussian(
 
 
 def variational_elbo_mc(
-    log_likelihood_fn: Callable[[jnp.ndarray], jnp.ndarray],
-    f_samples: jnp.ndarray,
-    kl: jnp.ndarray,
-) -> jnp.ndarray:
+    log_likelihood_fn: Callable[[Float[Array, " N"]], Float[Array, ""]],
+    f_samples: Float[Array, "S N"],
+    kl: Float[Array, ""],
+) -> Float[Array, ""]:
     """Monte Carlo ELBO for non-conjugate likelihoods.
 
     Computes::

--- a/src/gaussx/_gp/_kronecker_gp.py
+++ b/src/gaussx/_gp/_kronecker_gp.py
@@ -12,21 +12,42 @@ from jaxtyping import Array, Float
 from gaussx._primitives._eig import eig
 
 
-_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+def _axis_names(count: int) -> tuple[str, ...]:
+    names = []
+    for index in range(count):
+        value = index
+        chars = []
+        while True:
+            value, remainder = divmod(value, 26)
+            chars.append(chr(ord("a") + remainder))
+            if value == 0:
+                break
+            value -= 1
+        names.append("".join(reversed(chars)))
+    return tuple(names)
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    normalized = axis % ndim
+    if normalized < 0 or normalized >= ndim:
+        msg = f"axis {axis} is out of bounds for array with ndim {ndim}"
+        raise ValueError(msg)
+    return normalized
 
 
 def _reshape_flat_to_grid(
     values: Float[Array, " N"],
     grid_shape: tuple[int, ...],
 ) -> Array:
-    axes = _AXIS_NAMES[: len(grid_shape)]
+    axes = _axis_names(len(grid_shape))
     axis_lengths = dict(zip(axes, grid_shape, strict=True))
     grid_pattern = " ".join(axes)
     return rearrange(values, f"({grid_pattern}) -> {grid_pattern}", **axis_lengths)
 
 
 def _move_axis_to_last(values: Array, axis: int) -> Array:
-    axes = list(_AXIS_NAMES[: values.ndim])
+    axis = _normalize_axis(axis, values.ndim)
+    axes = list(_axis_names(values.ndim))
     source_pattern = " ".join(axes)
     target_axes = [name for i, name in enumerate(axes) if i != axis] + [axes[axis]]
     target_pattern = " ".join(target_axes)
@@ -34,7 +55,8 @@ def _move_axis_to_last(values: Array, axis: int) -> Array:
 
 
 def _move_last_axis_to(values: Array, axis: int) -> Array:
-    axes = list(_AXIS_NAMES[: values.ndim])
+    axis = _normalize_axis(axis, values.ndim)
+    axes = list(_axis_names(values.ndim))
     source_axes = [name for i, name in enumerate(axes) if i != axis] + [axes[axis]]
     source_pattern = " ".join(source_axes)
     target_pattern = " ".join(axes)

--- a/src/gaussx/_gp/_kronecker_gp.py
+++ b/src/gaussx/_gp/_kronecker_gp.py
@@ -12,6 +12,35 @@ from jaxtyping import Array, Float
 from gaussx._primitives._eig import eig
 
 
+_AXIS_NAMES = tuple("abcdefghijklmnopqrstuvwxyz")
+
+
+def _reshape_flat_to_grid(
+    values: Float[Array, " N"],
+    grid_shape: tuple[int, ...],
+) -> Array:
+    axes = _AXIS_NAMES[: len(grid_shape)]
+    axis_lengths = dict(zip(axes, grid_shape, strict=True))
+    grid_pattern = " ".join(axes)
+    return rearrange(values, f"({grid_pattern}) -> {grid_pattern}", **axis_lengths)
+
+
+def _move_axis_to_last(values: Array, axis: int) -> Array:
+    axes = list(_AXIS_NAMES[: values.ndim])
+    source_pattern = " ".join(axes)
+    target_axes = [name for i, name in enumerate(axes) if i != axis] + [axes[axis]]
+    target_pattern = " ".join(target_axes)
+    return rearrange(values, f"{source_pattern} -> {target_pattern}")
+
+
+def _move_last_axis_to(values: Array, axis: int) -> Array:
+    axes = list(_AXIS_NAMES[: values.ndim])
+    source_axes = [name for i, name in enumerate(axes) if i != axis] + [axes[axis]]
+    source_pattern = " ".join(source_axes)
+    target_pattern = " ".join(axes)
+    return rearrange(values, f"{source_pattern} -> {target_pattern}")
+
+
 def kronecker_mll(
     K_factors: list[lx.AbstractLinearOperator],
     y: Float[Array, " N"],
@@ -155,14 +184,13 @@ def _kron_rotate(
     Reshapes y to the grid, applies each ``Q_i^T`` along its axis,
     then flattens back.
     """
-    x = rearrange(y, "(total) -> total", total=y.shape[0])
-    x = x.reshape(grid_shape)
+    x = _reshape_flat_to_grid(y, grid_shape)
 
     for i, Q_i in enumerate(vecs_list):
         # Move axis i to last position, apply Qᵢᵀ, move back
-        x = jnp.moveaxis(x, i, -1)
+        x = _move_axis_to_last(x, i)
         x = x @ Q_i  # (..., n_i) @ (n_i, n_i) -> (..., n_i)
-        x = jnp.moveaxis(x, -1, i)
+        x = _move_last_axis_to(x, i)
 
     return rearrange(x, "... -> (...)")
 
@@ -176,13 +204,13 @@ def _kron_matvec(
 
     Similar to the Roth column lemma approach.
     """
-    x = v.reshape(grid_shape)
+    x = _reshape_flat_to_grid(v, grid_shape)
 
     out_shape = []
     for i, A_i in enumerate(A_factors):
-        x = jnp.moveaxis(x, i, -1)
+        x = _move_axis_to_last(x, i)
         x = x @ A_i.T  # (..., n_i) @ (n_i, m_i) -> (..., m_i)
         out_shape.append(A_i.shape[0])
-        x = jnp.moveaxis(x, -1, i)
+        x = _move_last_axis_to(x, i)
 
     return rearrange(x, "... -> (...)")

--- a/src/gaussx/_gp/_loo.py
+++ b/src/gaussx/_gp/_loo.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._linalg._diag_inv import diag_inv
 from gaussx._strategies._base import AbstractSolveStrategy
@@ -20,19 +22,19 @@ class LOOResult(eqx.Module):
         loo_variances: Per-point LOO predictive variances, shape ``(N,)``.
     """
 
-    loo_log_likelihood: jnp.ndarray
-    loo_means: jnp.ndarray
-    loo_variances: jnp.ndarray
+    loo_log_likelihood: Float[Array, ""]
+    loo_means: Float[Array, " N"]
+    loo_variances: Float[Array, " N"]
 
 
 def leave_one_out_cv(
     operator: lx.AbstractLinearOperator,
-    y: jnp.ndarray,
+    y: Float[Array, " N"],
     *,
     solver: AbstractSolveStrategy | None = None,
     diag_inv_method: str = "solve",
     diag_inv_num_probes: int = 30,
-    diag_inv_key: jnp.ndarray | None = None,
+    diag_inv_key: jax.Array | None = None,
 ) -> LOOResult:
     """LOO-CV via the bordered-system identity.
 

--- a/src/gaussx/_gp/_love.py
+++ b/src/gaussx/_gp/_love.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import lineax as lx
 from jaxtyping import Array, Float
@@ -28,7 +29,7 @@ class LOVECache(eqx.Module):
 def love_cache(
     K_op: lx.AbstractLinearOperator,
     lanczos_order: int = 50,
-    key: jnp.ndarray | None = None,
+    key: jax.Array | None = None,
 ) -> LOVECache:
     r"""Precompute Lanczos factorization of ``K^{-1}`` for fast variance.
 

--- a/src/gaussx/_gp/_prediction_cache.py
+++ b/src/gaussx/_gp/_prediction_cache.py
@@ -7,9 +7,9 @@ multiple test sets reuse the same expensive linear solve.
 from __future__ import annotations
 
 import equinox as eqx
-import jax.numpy as jnp
 import lineax as lx
 from einops import reduce
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolveStrategy
 from gaussx._strategies._dispatch import dispatch_solve
@@ -25,12 +25,12 @@ class PredictionCache(eqx.Module):
         alpha: Solved weights ``K_y^{-1} y``, shape ``(N,)``.
     """
 
-    alpha: jnp.ndarray
+    alpha: Float[Array, " N"]
 
 
 def build_prediction_cache(
     operator: lx.AbstractLinearOperator,
-    y: jnp.ndarray,
+    y: Float[Array, " N"],
     *,
     solver: AbstractSolveStrategy | None = None,
 ) -> PredictionCache:
@@ -51,8 +51,8 @@ def build_prediction_cache(
 
 def predict_mean(
     cache: PredictionCache,
-    K_cross: jnp.ndarray,
-) -> jnp.ndarray:
+    K_cross: Float[Array, "Nt N"],
+) -> Float[Array, " Nt"]:
     """Predictive mean: ``mu* = K_*f @ alpha``.
 
     Args:
@@ -66,12 +66,12 @@ def predict_mean(
 
 
 def predict_variance(
-    K_cross: jnp.ndarray,
-    K_test_diag: jnp.ndarray,
+    K_cross: Float[Array, "Nt N"],
+    K_test_diag: Float[Array, " Nt"],
     operator: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolveStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, " Nt"]:
     """Predictive variance: ``sigma^2* = k_** - diag(K_*f K_y^{-1} K_f*)``.
 
     For each test point *i*, solves ``K_y v_i = K_cross[i, :]`` and

--- a/src/gaussx/_gp/_svgp.py
+++ b/src/gaussx/_gp/_svgp.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 import jax.numpy as jnp
 import lineax as lx
 from einops import reduce
+from jaxtyping import Array, Float
 
 from gaussx._primitives._cholesky import cholesky
 
 
 def whitened_svgp_predict(
     K_zz_op: lx.AbstractLinearOperator,
-    K_xz: jnp.ndarray,
-    u_mean: jnp.ndarray,
-    u_chol: jnp.ndarray,
-    K_xx_diag: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    K_xz: Float[Array, "N M"],
+    u_mean: Float[Array, " M"],
+    u_chol: Float[Array, "M M"],
+    K_xx_diag: Float[Array, " N"],
+) -> tuple[Float[Array, " N"], Float[Array, " N"]]:
     r"""Whitened SVGP prediction: mean and variance at test points.
 
     Computes the predictive mean and variance for a sparse variational

--- a/src/gaussx/_gp/_unwhiten.py
+++ b/src/gaussx/_gp/_unwhiten.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._linalg._linalg import cov_transform
 
 
 def unwhiten(
-    m_tilde: jnp.ndarray,
+    m_tilde: Float[Array, " M"],
     L: lx.AbstractLinearOperator,
-) -> jnp.ndarray:
+) -> Float[Array, " M"]:
     """Unwhiten variational mean: ``m = L @ m_tilde``.
 
     Args:

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._operators._low_rank_update import LowRankUpdate
 
 
 def ensemble_covariance(
-    particles: jnp.ndarray,
+    particles: Float[Array, "J N"],
 ) -> LowRankUpdate:
     """Empirical covariance from an ensemble as a low-rank operator.
 
@@ -38,9 +39,9 @@ def ensemble_covariance(
 
 
 def ensemble_cross_covariance(
-    particles_theta: jnp.ndarray,
-    particles_G: jnp.ndarray,
-) -> jnp.ndarray:
+    particles_theta: Float[Array, "J N"],
+    particles_G: Float[Array, "J M"],
+) -> Float[Array, "N M"]:
     """Cross-covariance between two ensemble sets.
 
     Computes ``C^{theta,G} = (1/J) sum_j (theta_j - bar)(G_j - bar)^T``.

--- a/src/gaussx/_inference/_inference.py
+++ b/src/gaussx/_inference/_inference.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._primitives._inv import inv
@@ -13,12 +14,12 @@ from gaussx._strategies._dispatch import dispatch_logdet, dispatch_solve
 
 
 def log_marginal_likelihood(
-    loc: jnp.ndarray,
+    loc: Float[Array, " N"],
     cov_operator: lx.AbstractLinearOperator,
-    y: jnp.ndarray,
+    y: Float[Array, " N"],
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """GP log marginal likelihood.
 
     Computes::
@@ -46,13 +47,13 @@ def log_marginal_likelihood(
 
 
 def gaussian_expected_log_lik(
-    y: jnp.ndarray,
-    q_mu: jnp.ndarray,
+    y: Float[Array, " N"],
+    q_mu: Float[Array, " N"],
     q_cov: lx.AbstractLinearOperator,
     noise: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     r"""Expected log-likelihood ``E_q[log N(y | f, R)]``.
 
     Computes::
@@ -89,11 +90,11 @@ def gaussian_expected_log_lik(
 
 def trace_correction(
     K_xx: lx.AbstractLinearOperator,
-    K_xz: jnp.ndarray,
+    K_xz: Float[Array, "N M"],
     K_zz: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolveStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Trace term in Titsias collapsed ELBO.
 
     Computes::
@@ -127,12 +128,12 @@ def trace_correction(
 
 
 def cavity_distribution(
-    post_mean: jnp.ndarray,
+    post_mean: Float[Array, " N"],
     post_cov: lx.AbstractLinearOperator,
-    site_nat1: jnp.ndarray,
+    site_nat1: Float[Array, " N"],
     site_nat2: lx.AbstractLinearOperator,
     power: float = 1.0,
-) -> tuple[jnp.ndarray, lx.AbstractLinearOperator]:
+) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Compute EP cavity distribution by removing a site.
 
     Computes::
@@ -163,10 +164,10 @@ def cavity_distribution(
 
 
 def newton_update(
-    mean: jnp.ndarray,
-    jacobian: jnp.ndarray,
-    hessian: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    mean: Float[Array, " N"],
+    jacobian: Float[Array, " N"],
+    hessian: Float[Array, "N N"],
+) -> tuple[Float[Array, " N"], Float[Array, "N N"]]:
     """Convert a Newton step to natural pseudo-likelihood parameters.
 
     Computes::
@@ -191,9 +192,9 @@ def newton_update(
 
 
 def process_noise_covariance(
-    A: jnp.ndarray,
-    Pinf: jnp.ndarray,
-) -> jnp.ndarray:
+    A: Float[Array, "N N"],
+    Pinf: Float[Array, "N N"],
+) -> Float[Array, "N N"]:
     """Compute process noise from stationary covariance.
 
     Computes::

--- a/src/gaussx/_inference/_natural_gradient.py
+++ b/src/gaussx/_inference/_natural_gradient.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import lineax as lx
 from jaxtyping import Array, Float
@@ -12,11 +13,11 @@ from gaussx._operators._low_rank_update import LowRankUpdate
 
 def damped_natural_update(
     nat1_old: Float[Array, " d"],
-    nat2_old: lx.AbstractLinearOperator | Float[Array, ...],
+    nat2_old: lx.AbstractLinearOperator | Float[Array, "d d"],
     nat1_target: Float[Array, " d"],
-    nat2_target: lx.AbstractLinearOperator | Float[Array, ...],
+    nat2_target: lx.AbstractLinearOperator | Float[Array, "d d"],
     lr: float = 1.0,
-) -> tuple[Float[Array, " d"], lx.AbstractLinearOperator | Float[Array, ...]]:
+) -> tuple[Float[Array, " d"], lx.AbstractLinearOperator | Float[Array, "d d"]]:
     r"""Damped update in natural parameter space.
 
     The universal primitive for iterative approximate inference
@@ -40,8 +41,8 @@ def damped_natural_update(
     """
     nat1_new = (1.0 - lr) * nat1_old + lr * nat1_target
 
-    if isinstance(nat2_old, jnp.ndarray) and isinstance(nat2_target, jnp.ndarray):
-        nat2_new: lx.AbstractLinearOperator | jnp.ndarray = (
+    if isinstance(nat2_old, jax.Array) and isinstance(nat2_target, jax.Array):
+        nat2_new: lx.AbstractLinearOperator | Float[Array, "d d"] = (
             1.0 - lr
         ) * nat2_old + lr * nat2_target
     elif isinstance(nat2_old, BlockTriDiag) and isinstance(nat2_target, BlockTriDiag):

--- a/src/gaussx/_kernels/_grid.py
+++ b/src/gaussx/_kernels/_grid.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 from einops import rearrange
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, Int
 
 
 def create_grid(
     grid_sizes: list[int] | tuple[int, ...],
     grid_bounds: list[tuple[float, float]] | tuple[tuple[float, float], ...],
-) -> list[jnp.ndarray]:
+) -> list[Float[Array, " n"]]:
     """Create a regular grid from per-dimension sizes and bounds.
 
     Args:
@@ -26,7 +26,7 @@ def create_grid(
     ]
 
 
-def grid_data(grid: list[jnp.ndarray]) -> Float[Array, "G D"]:
+def grid_data(grid: list[Float[Array, " n"]]) -> Float[Array, "G D"]:
     """Expand a grid to the full Cartesian product of grid points.
 
     Args:
@@ -67,8 +67,8 @@ def _cubic_weights_1d(t: Float[Array, " B"]) -> Float[Array, "B four"]:
 
 def cubic_interpolation_weights(
     x_target: Float[Array, "B D"],
-    grid: list[jnp.ndarray],
-) -> tuple[jnp.ndarray, Float[Array, "B K"]]:
+    grid: list[Float[Array, " n"]],
+) -> tuple[Int[Array, "B K"], Float[Array, "B K"]]:
     """Compute cubic interpolation indices and weights for SKI.
 
     For each target point, finds the 4ᴰ nearest grid neighbors and

--- a/src/gaussx/_linalg/_diag_inv.py
+++ b/src/gaussx/_linalg/_diag_inv.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 from einops import reduce
+from jaxtyping import Array, Float
 
 from gaussx._linalg._safe_cholesky import safe_cholesky
 from gaussx._strategies._base import AbstractSolveStrategy
@@ -17,9 +18,9 @@ def diag_inv(
     *,
     method: str = "auto",
     num_probes: int = 30,
-    key: jnp.ndarray | None = None,
+    key: jax.Array | None = None,
     solver: AbstractSolveStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, " N"]:
     """Compute the diagonal of the inverse of a linear operator.
 
     Returns ``diag(A⁻¹)`` without forming the full inverse matrix.
@@ -61,7 +62,7 @@ def diag_inv(
     raise ValueError(msg)
 
 
-def _diag_inv_cholesky(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
+def _diag_inv_cholesky(operator: lx.AbstractLinearOperator) -> Float[Array, " N"]:
     """Exact diagonal of A⁻¹ via Cholesky factorisation.
 
     Uses :func:`safe_cholesky` for robustness on ill-conditioned
@@ -79,13 +80,13 @@ def _diag_inv_solve(
     operator: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolveStrategy | None,
-) -> jnp.ndarray:
+) -> Float[Array, " N"]:
     """Exact diagonal of A⁻¹ via repeated solves against basis vectors."""
     n = operator.in_size()
     dtype = operator.out_structure().dtype
     I = jnp.eye(n, dtype=dtype)
 
-    def _single_basis(e_i: jnp.ndarray) -> jnp.ndarray:
+    def _single_basis(e_i: Float[Array, " N"]) -> Float[Array, ""]:
         Ainv_ei = dispatch_solve(operator, e_i, solver)
         return jnp.sum(e_i * Ainv_ei)
 
@@ -96,9 +97,9 @@ def _diag_inv_hutchinson(
     operator: lx.AbstractLinearOperator,
     *,
     num_probes: int,
-    key: jnp.ndarray | None,
+    key: jax.Array | None,
     solver: AbstractSolveStrategy | None,
-) -> jnp.ndarray:
+) -> Float[Array, " N"]:
     """Stochastic diagonal estimator via Hutchinson's trick.
 
     Generates Rademacher probe vectors z, solves A⁻¹ z, and
@@ -111,7 +112,7 @@ def _diag_inv_hutchinson(
     dtype = operator.out_structure().dtype
     keys = jax.random.split(key, num_probes)
 
-    def _single_probe(k: jnp.ndarray) -> jnp.ndarray:
+    def _single_probe(k: jax.Array) -> Float[Array, " N"]:
         z = 2.0 * jax.random.bernoulli(k, shape=(n,)).astype(dtype) - 1.0
         Ainv_z = dispatch_solve(operator, z, solver)
         return z * Ainv_z

--- a/src/gaussx/_linalg/_linalg.py
+++ b/src/gaussx/_linalg/_linalg.py
@@ -14,7 +14,7 @@ from gaussx._strategies._dispatch import dispatch_solve
 
 
 def cov_transform(
-    J: jnp.ndarray,
+    J: Float[Array, "M N"],
     cov_operator: lx.AbstractLinearOperator,
 ) -> lx.MatrixLinearOperator:
     """Covariance propagation through a linear map: ``J @ Sigma @ J^T``.
@@ -40,7 +40,7 @@ def cov_transform(
 def trace_product(
     A: lx.AbstractLinearOperator,
     B: lx.AbstractLinearOperator,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Trace of a matrix product: ``tr(A @ B)`` without forming the product.
 
     Uses the identity ``tr(AB) = sum(A * B^T)`` element-wise.
@@ -58,10 +58,10 @@ def trace_product(
 
 
 def diag_conditional_variance(
-    K_XX_diag: jnp.ndarray,
-    K_XZ: jnp.ndarray,
-    A_X: jnp.ndarray,
-) -> jnp.ndarray:
+    K_XX_diag: Float[Array, " N"],
+    K_XZ: Float[Array, "N M"],
+    A_X: Float[Array, "N M"],
+) -> Float[Array, " N"]:
     """Base conditional variance without variational covariance.
 
     Computes::

--- a/src/gaussx/_linalg/_safe_cholesky.py
+++ b/src/gaussx/_linalg/_safe_cholesky.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._primitives._cholesky import cholesky
 
 
-def _chol_matrix(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
+def _chol_matrix(operator: lx.AbstractLinearOperator) -> Float[Array, "N N"]:
     """Route through the structured primitive and materialise the factor."""
     return cholesky(operator).as_matrix()
 
@@ -21,7 +22,7 @@ def safe_cholesky(
     max_jitter: float = 1e-2,
     max_retries: int = 5,
     growth_factor: float = 10.0,
-) -> jnp.ndarray:
+) -> Float[Array, "N N"]:
     """Cholesky decomposition with adaptive jitter for near-singular matrices.
 
     The first attempt routes through :func:`gaussx._primitives.cholesky`, so
@@ -46,7 +47,7 @@ def safe_cholesky(
         growth_factor: Multiplicative factor applied to jitter each retry.
 
     Returns:
-        Lower-triangular Cholesky factor as a dense ``jnp.ndarray``.
+        Lower-triangular Cholesky factor as a dense array.
         If all attempts fail the result will contain NaNs — this is
         intentional: JAX cannot raise exceptions inside ``jit``-traced
         code, so callers should check for NaNs when robustness matters.

--- a/src/gaussx/_linalg/_schur.py
+++ b/src/gaussx/_linalg/_schur.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._operators._low_rank_update import LowRankUpdate
 
 
 def schur_complement(
     K_XX: lx.AbstractLinearOperator,
-    K_XZ: jnp.ndarray,
+    K_XZ: Float[Array, "N M"],
     K_ZZ: lx.AbstractLinearOperator,
 ) -> LowRankUpdate:
     """Schur complement: ``K_XX - K_XZ @ K_ZZ^{-1} @ K_ZX``.
@@ -48,10 +49,10 @@ def schur_complement(
 
 
 def conditional_variance(
-    K_XX_diag: jnp.ndarray,
-    A_X: jnp.ndarray,
+    K_XX_diag: Float[Array, " N"],
+    A_X: Float[Array, "N M"],
     S_u: lx.AbstractLinearOperator,
-) -> jnp.ndarray:
+) -> Float[Array, " N"]:
     """Predictive variance for GP conditionals.
 
     Computes::

--- a/src/gaussx/_linalg/_woodbury.py
+++ b/src/gaussx/_linalg/_woodbury.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._primitives._solve import solve
 
 
 def woodbury_solve(
     base: lx.AbstractLinearOperator,
-    U: jnp.ndarray,
-    D: jnp.ndarray,
-    b: jnp.ndarray,
-) -> jnp.ndarray:
+    U: Float[Array, "N k"],
+    D: Float[Array, " k"],
+    b: Float[Array, " N"],
+) -> Float[Array, " N"]:
     """Standalone Woodbury identity solve: ``(L + U diag(D) U^T)^{-1} b``.
 
     Convenience function for cases where the user has the components

--- a/src/gaussx/_operators/_block_tridiag.py
+++ b/src/gaussx/_operators/_block_tridiag.py
@@ -114,7 +114,7 @@ class BlockTriDiag(lx.AbstractLinearOperator):
         # Transposing: new (k+1,k) = old (k,k+1).T = sub[k].
         # So new sub_diagonal = self.sub_diagonal (unchanged).
         return BlockTriDiag(
-            jax.vmap(jnp.transpose)(self.diagonal),
+            rearrange(self.diagonal, "N i j -> N j i"),
             self.sub_diagonal,
             tags=lx.transpose_tags(self.tags),
         )
@@ -232,8 +232,8 @@ class LowerBlockTriDiag(lx.AbstractLinearOperator):
     def transpose(self) -> UpperBlockTriDiag:
         """Transpose gives upper block-bidiagonal."""
         return UpperBlockTriDiag(
-            jax.vmap(jnp.transpose)(self.diagonal),
-            jax.vmap(jnp.transpose)(self.sub_diagonal),
+            rearrange(self.diagonal, "N i j -> N j i"),
+            rearrange(self.sub_diagonal, "N i j -> N j i"),
         )
 
     def in_structure(self) -> jax.ShapeDtypeStruct:
@@ -308,8 +308,8 @@ class UpperBlockTriDiag(lx.AbstractLinearOperator):
 
     def transpose(self) -> LowerBlockTriDiag:
         return LowerBlockTriDiag(
-            jax.vmap(jnp.transpose)(self.diagonal),
-            jax.vmap(jnp.transpose)(self.super_diagonal),
+            rearrange(self.diagonal, "N i j -> N j i"),
+            rearrange(self.super_diagonal, "N i j -> N j i"),
         )
 
     def in_structure(self) -> jax.ShapeDtypeStruct:

--- a/src/gaussx/_operators/_lazy_algebra.py
+++ b/src/gaussx/_operators/_lazy_algebra.py
@@ -98,7 +98,7 @@ class ScaledOperator(lx.AbstractLinearOperator):
         tags: object | frozenset[object] = frozenset(),
     ) -> None:
         self.operator = operator
-        self.scalar = jnp.asarray(scalar).reshape(())
+        self.scalar = jnp.asarray(scalar)
         self._in_size = operator.in_size()
         self._out_size = operator.out_size()
         self._dtype = jnp.result_type(

--- a/src/gaussx/_operators/_lazy_algebra.py
+++ b/src/gaussx/_operators/_lazy_algebra.py
@@ -98,7 +98,14 @@ class ScaledOperator(lx.AbstractLinearOperator):
         tags: object | frozenset[object] = frozenset(),
     ) -> None:
         self.operator = operator
-        self.scalar = jnp.asarray(scalar)
+        scalar_array = jnp.asarray(scalar)
+        if scalar_array.ndim != 0:
+            msg = (
+                "ScaledOperator scalar must be a rank-0 scalar, got "
+                f"shape {scalar_array.shape}."
+            )
+            raise ValueError(msg)
+        self.scalar = scalar_array
         self._in_size = operator.in_size()
         self._out_size = operator.out_size()
         self._dtype = jnp.result_type(

--- a/src/gaussx/_operators/_low_rank_update.py
+++ b/src/gaussx/_operators/_low_rank_update.py
@@ -204,7 +204,7 @@ def _infer_tags(
     return frozenset(inferred)
 
 
-def _arrays_match(x: jnp.ndarray, y: jnp.ndarray) -> bool:
+def _arrays_match(x: Array, y: Array) -> bool:
     """Best-effort equality check that stays safe under tracing."""
     if x is y:
         return True
@@ -216,7 +216,7 @@ def _arrays_match(x: jnp.ndarray, y: jnp.ndarray) -> bool:
         return False
 
 
-def _is_nonnegative(x: jnp.ndarray) -> bool:
+def _is_nonnegative(x: Array) -> bool:
     """Return True only when non-negativity is known concretely."""
     try:
         return bool(jnp.all(x >= 0))

--- a/src/gaussx/_primitives/_diag.py
+++ b/src/gaussx/_primitives/_diag.py
@@ -8,6 +8,7 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 import matfree.stochtrace
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._block_tridiag import BlockTriDiag
@@ -19,8 +20,8 @@ def diag(
     *,
     stochastic: bool = False,
     num_probes: int = 20,
-    key: jnp.ndarray | None = None,
-) -> jnp.ndarray:
+    key: jax.Array | None = None,
+) -> Float[Array, " n"]:
     """Extract the diagonal of an operator as a 1D array.
 
     When ``stochastic=True``, uses Hutchinson's diagonal estimator
@@ -48,16 +49,16 @@ def diag(
     return jnp.diag(operator.as_matrix())
 
 
-def _diag_block_diag(operator: BlockDiag) -> jnp.ndarray:
+def _diag_block_diag(operator: BlockDiag) -> Float[Array, " n"]:
     return jnp.concatenate([diag(op) for op in operator.operators])
 
 
-def _diag_kronecker(operator: Kronecker) -> jnp.ndarray:
+def _diag_kronecker(operator: Kronecker) -> Float[Array, " n"]:
     """diag(A kron B) = kron(diag(A), diag(B))."""
     return ft.reduce(jnp.kron, (diag(op) for op in operator.operators))
 
 
-def _diag_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
+def _diag_block_tridiag(operator: BlockTriDiag) -> Float[Array, " n"]:
     """Extract block-diagonal entries of a block-tridiagonal operator."""
     from einops import rearrange
 
@@ -69,8 +70,8 @@ def _diag_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
 def _diag_stochastic(
     operator: lx.AbstractLinearOperator,
     num_probes: int,
-    key: jnp.ndarray | None,
-) -> jnp.ndarray:
+    key: jax.Array | None,
+) -> Float[Array, " n"]:
     """Hutchinson diagonal estimator via matfree."""
     if key is None:
         key = jax.random.PRNGKey(0)

--- a/src/gaussx/_primitives/_eig.py
+++ b/src/gaussx/_primitives/_eig.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import functools as ft
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 import matfree.decomp
 import matfree.eig
 from jax.scipy.linalg import block_diag as _block_diag
+from jaxtyping import Array
 
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._kronecker import Kronecker
@@ -19,8 +21,8 @@ def eig(
     operator: lx.AbstractLinearOperator,
     *,
     rank: int | None = None,
-    key: jnp.ndarray | None = None,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    key: jax.Array | None = None,
+) -> tuple[Array, Array]:
     """Compute eigenvalues and eigenvectors.
 
     For symmetric operators returns real eigenvalues via ``eigh``.
@@ -53,8 +55,8 @@ def eigvals(
     operator: lx.AbstractLinearOperator,
     *,
     rank: int | None = None,
-    key: jnp.ndarray | None = None,
-) -> jnp.ndarray:
+    key: jax.Array | None = None,
+) -> Array:
     """Compute eigenvalues only.
 
     When ``rank`` is given, returns the top-k eigenvalues via
@@ -82,7 +84,7 @@ def eigvals(
 
 def _eig_diagonal(
     operator: lx.DiagonalLinearOperator,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Array, Array]:
     d = lx.diagonal(operator)
     n = d.shape[0]
     return d, jnp.eye(n, dtype=d.dtype)
@@ -90,7 +92,7 @@ def _eig_diagonal(
 
 def _eig_block_diag(
     operator: BlockDiag,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Array, Array]:
     vals_list = []
     vecs_list = []
     for op in operator.operators:
@@ -104,7 +106,7 @@ def _eig_block_diag(
 
 def _eig_kronecker(
     operator: Kronecker,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Array, Array]:
     """eig(A kron B) = (kron(eigvals), kron(eigvecs))."""
     factor_eigs = [eig(op) for op in operator.operators]
     vals = ft.reduce(jnp.kron, (v for v, _ in factor_eigs))
@@ -112,7 +114,7 @@ def _eig_kronecker(
     return vals, vecs
 
 
-def _eigvals_kronecker(operator: Kronecker) -> jnp.ndarray:
+def _eigvals_kronecker(operator: Kronecker) -> Array:
     """eigvals(A kron B) = kron(eigvals(A), eigvals(B))."""
     return ft.reduce(jnp.kron, (eigvals(op) for op in operator.operators))
 
@@ -120,8 +122,8 @@ def _eigvals_kronecker(operator: Kronecker) -> jnp.ndarray:
 def _eig_partial(
     operator: lx.AbstractLinearOperator,
     rank: int,
-    key: jnp.ndarray | None,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    key: jax.Array | None,
+) -> tuple[Array, Array]:
     """Partial eigendecomposition via matfree Lanczos."""
     if key is None:
         key = jr.PRNGKey(0)
@@ -140,14 +142,14 @@ def _eig_partial(
 
 def _eig_dense(
     operator: lx.AbstractLinearOperator,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Array, Array]:
     mat = operator.as_matrix()
     if lx.is_symmetric(operator):
         return jnp.linalg.eigh(mat)
     return jnp.linalg.eig(mat)
 
 
-def _eigvals_dense(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
+def _eigvals_dense(operator: lx.AbstractLinearOperator) -> Array:
     mat = operator.as_matrix()
     if lx.is_symmetric(operator):
         return jnp.linalg.eigvalsh(mat)

--- a/src/gaussx/_primitives/_logdet.py
+++ b/src/gaussx/_primitives/_logdet.py
@@ -7,6 +7,7 @@ import functools as ft
 import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._block_tridiag import BlockTriDiag, LowerBlockTriDiag
@@ -16,7 +17,7 @@ from gaussx._operators._low_rank_update import LowRankUpdate
 from gaussx._operators._svd_low_rank_update import SVDLowRankUpdate
 
 
-def cholesky_logdet(L: jnp.ndarray) -> jnp.ndarray:
+def cholesky_logdet(L: Float[Array, "N N"]) -> Float[Array, ""]:
     """Compute log|A| from Cholesky factor L where A = L Lᵀ.
 
     Args:
@@ -28,7 +29,7 @@ def cholesky_logdet(L: jnp.ndarray) -> jnp.ndarray:
     return 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
 
 
-def logdet(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
+def logdet(operator: lx.AbstractLinearOperator) -> Float[Array, ""]:
     """Compute log |det(A)| with structural dispatch.
 
     Args:
@@ -56,16 +57,16 @@ def logdet(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
     return _logdet_dense(operator)
 
 
-def _logdet_diagonal(operator: lx.DiagonalLinearOperator) -> jnp.ndarray:
+def _logdet_diagonal(operator: lx.DiagonalLinearOperator) -> Float[Array, ""]:
     diag = lx.diagonal(operator)
     return jnp.sum(jnp.log(jnp.abs(diag)))
 
 
-def _logdet_block_diag(operator: BlockDiag) -> jnp.ndarray:
+def _logdet_block_diag(operator: BlockDiag) -> Float[Array, ""]:
     return ft.reduce(jnp.add, (logdet(op) for op in operator.operators))
 
 
-def _logdet_kronecker(operator: Kronecker) -> jnp.ndarray:
+def _logdet_kronecker(operator: Kronecker) -> Float[Array, ""]:
     """logdet(A1 kron A2 kron ... kron Ak).
 
     For two factors: logdet(A kron B) = n_B * logdet(A) + n_A * logdet(B).
@@ -80,7 +81,7 @@ def _logdet_kronecker(operator: Kronecker) -> jnp.ndarray:
     return result
 
 
-def _logdet_low_rank(operator: LowRankUpdate) -> jnp.ndarray:
+def _logdet_low_rank(operator: LowRankUpdate) -> Float[Array, ""]:
     """Matrix determinant lemma: det(L + U D V^T) = det(C) det(D) det(L).
 
     where C = D^{-1} + V^T L^{-1} U is the k x k capacitance matrix.
@@ -110,7 +111,7 @@ def _logdet_low_rank(operator: LowRankUpdate) -> jnp.ndarray:
     return ld_base + ld_C + ld_d
 
 
-def _logdet_svd_low_rank(operator: SVDLowRankUpdate) -> jnp.ndarray:
+def _logdet_svd_low_rank(operator: SVDLowRankUpdate) -> Float[Array, ""]:
     """Matrix determinant lemma for SVDLowRankUpdate: det(L + U S V^T).
 
     logdet = logdet(L) + logdet(C) + sum(log|S_i|)
@@ -140,7 +141,7 @@ def _logdet_svd_low_rank(operator: SVDLowRankUpdate) -> jnp.ndarray:
     return ld_base + ld_C + ld_S
 
 
-def _logdet_kronecker_sum(operator: KroneckerSum) -> jnp.ndarray:
+def _logdet_kronecker_sum(operator: KroneckerSum) -> Float[Array, ""]:
     """logdet(A (+) B) = sum(log(lambda_A_i + lambda_B_j)) for all i,j."""
 
     evals_a = jnp.linalg.eigvalsh(operator.A.as_matrix())
@@ -149,7 +150,7 @@ def _logdet_kronecker_sum(operator: KroneckerSum) -> jnp.ndarray:
     return jnp.sum(jnp.log(jnp.abs(eig_mat)))
 
 
-def _logdet_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
+def _logdet_block_tridiag(operator: BlockTriDiag) -> Float[Array, ""]:
     """logdet via banded Cholesky: logdet(A) = 2 * logdet(L)."""
     from gaussx._primitives._cholesky import cholesky
 
@@ -157,14 +158,16 @@ def _logdet_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
     return 2.0 * logdet(L)
 
 
-def _logdet_lower_block_tridiag(operator: LowerBlockTriDiag) -> jnp.ndarray:
+def _logdet_lower_block_tridiag(
+    operator: LowerBlockTriDiag,
+) -> Float[Array, ""]:
     """logdet of lower block-bidiagonal = sum of logdet of diagonal blocks."""
     return jnp.sum(
         jax.vmap(lambda L: jnp.sum(jnp.log(jnp.abs(jnp.diag(L)))))(operator.diagonal)
     )
 
 
-def _logdet_dense(operator: lx.AbstractLinearOperator) -> jnp.ndarray:
+def _logdet_dense(operator: lx.AbstractLinearOperator) -> Float[Array, ""]:
     mat = operator.as_matrix()
     _, ld = jnp.linalg.slogdet(mat)
     return ld

--- a/src/gaussx/_primitives/_solve.py
+++ b/src/gaussx/_primitives/_solve.py
@@ -7,6 +7,7 @@ import functools as ft
 import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._block_tridiag import (
@@ -22,10 +23,10 @@ from gaussx._operators._svd_low_rank_update import SVDLowRankUpdate
 
 def solve(
     operator: lx.AbstractLinearOperator,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     *,
     solver: lx.AbstractLinearSolver | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     """Solve ``A x = b`` with structural dispatch.
 
     Args:
@@ -58,17 +59,18 @@ def solve(
 
 
 def _solve_diagonal(
-    operator: lx.DiagonalLinearOperator, vector: jnp.ndarray
-) -> jnp.ndarray:
+    operator: lx.DiagonalLinearOperator,
+    vector: Float[Array, " n"],
+) -> Float[Array, " n"]:
     diag = lx.diagonal(operator)
     return vector / diag
 
 
 def _solve_block_diag(
     operator: BlockDiag,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: lx.AbstractLinearSolver | None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     results = []
     offset = 0
     for op in operator.operators:
@@ -81,9 +83,9 @@ def _solve_block_diag(
 
 def _solve_kronecker(
     operator: Kronecker,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: lx.AbstractLinearSolver | None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     """Solve (A1 kron A2 kron ... kron Ak) x = b.
 
     Uses the same reshape trick as Kronecker.mv but with
@@ -104,9 +106,9 @@ def _solve_kronecker(
 
 def _solve_low_rank(
     operator: LowRankUpdate,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: lx.AbstractLinearSolver | None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     """Woodbury identity: (L + U D V^T)^{-1} b.
 
     (L + U D V^T)^{-1} = L^{-1} - L^{-1} U C^{-1} V^T L^{-1}
@@ -137,9 +139,9 @@ def _solve_low_rank(
 
 def _solve_svd_low_rank(
     operator: SVDLowRankUpdate,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: lx.AbstractLinearSolver | None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     """Woodbury identity for SVDLowRankUpdate: (L + U S V^T)^{-1} b.
 
     Same as _solve_low_rank but uses S (singular values) instead of d.
@@ -169,8 +171,8 @@ def _solve_svd_low_rank(
 
 def _solve_kronecker_sum(
     operator: KroneckerSum,
-    vector: jnp.ndarray,
-) -> jnp.ndarray:
+    vector: Float[Array, " n"],
+) -> Float[Array, " n"]:
     """Solve (A (+) B) x = b via eigendecomposition.
 
     (A (+) B) = (Q_A (x) Q_B) diag(lambda_A_i + lambda_B_j) (Q_A (x) Q_B)^T.
@@ -193,8 +195,8 @@ def _solve_kronecker_sum(
 
 def _solve_block_tridiag(
     operator: BlockTriDiag,
-    vector: jnp.ndarray,
-) -> jnp.ndarray:
+    vector: Float[Array, " n"],
+) -> Float[Array, " n"]:
     """Solve via block-banded Cholesky then forward/backward substitution."""
     from gaussx._primitives._cholesky import cholesky
 
@@ -207,8 +209,8 @@ def _solve_block_tridiag(
 
 def _solve_lower_block_tridiag(
     operator: LowerBlockTriDiag,
-    vector: jnp.ndarray,
-) -> jnp.ndarray:
+    vector: Float[Array, " n"],
+) -> Float[Array, " n"]:
     """Forward substitution for lower block-bidiagonal system."""
     N = operator._num_blocks
     d = operator._block_size
@@ -232,8 +234,8 @@ def _solve_lower_block_tridiag(
 
 def _solve_upper_block_tridiag(
     operator: UpperBlockTriDiag,
-    vector: jnp.ndarray,
-) -> jnp.ndarray:
+    vector: Float[Array, " n"],
+) -> Float[Array, " n"]:
     """Backward substitution for upper block-bidiagonal system."""
     N = operator._num_blocks
     d = operator._block_size
@@ -260,9 +262,9 @@ def _solve_upper_block_tridiag(
 
 def _solve_fallback(
     operator: lx.AbstractLinearOperator,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: lx.AbstractLinearSolver | None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     if solver is None:
         solver = lx.AutoLinearSolver(well_posed=True)
     return lx.linear_solve(operator, vector, solver).value

--- a/src/gaussx/_primitives/_svd.py
+++ b/src/gaussx/_primitives/_svd.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 import matfree.decomp
 import matfree.eig
+from jaxtyping import Array, Float
 
 
 def svd(
     operator: lx.AbstractLinearOperator,
     *,
     rank: int | None = None,
-    key: jnp.ndarray | None = None,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    key: jax.Array | None = None,
+) -> tuple[Float[Array, "m k"], Float[Array, " k"], Float[Array, "k n"]]:
     """Compute the singular value decomposition ``A = U diag(s) V^T``.
 
     When ``rank`` is given, computes a partial (truncated) SVD via
@@ -40,7 +42,7 @@ def svd(
 
 def _svd_diagonal(
     operator: lx.DiagonalLinearOperator,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> tuple[Float[Array, "n n"], Float[Array, " n"], Float[Array, "n n"]]:
     d = lx.diagonal(operator)
     n = d.shape[0]
     s = jnp.abs(d)
@@ -53,8 +55,8 @@ def _svd_diagonal(
 def _svd_partial(
     operator: lx.AbstractLinearOperator,
     rank: int,
-    key: jnp.ndarray | None,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    key: jax.Array | None,
+) -> tuple[Float[Array, "m k"], Float[Array, " k"], Float[Array, "k n"]]:
     """Partial SVD via matfree bidiagonalization."""
     if key is None:
         key = jr.PRNGKey(0)
@@ -73,7 +75,7 @@ def _svd_partial(
 
 def _svd_dense(
     operator: lx.AbstractLinearOperator,
-) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+) -> tuple[Float[Array, "m k"], Float[Array, " k"], Float[Array, "k n"]]:
     mat = operator.as_matrix()
     U, s, Vt = jnp.linalg.svd(mat, full_matrices=False)  # type: ignore[arg-type]
     return U, s, Vt

--- a/src/gaussx/_primitives/_trace.py
+++ b/src/gaussx/_primitives/_trace.py
@@ -8,6 +8,7 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 import matfree.stochtrace
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._block_tridiag import BlockTriDiag
@@ -19,8 +20,8 @@ def trace(
     *,
     stochastic: bool = False,
     num_probes: int = 20,
-    key: jnp.ndarray | None = None,
-) -> jnp.ndarray:
+    key: jax.Array | None = None,
+) -> Float[Array, ""]:
     """Compute the trace of an operator.
 
     When ``stochastic=True``, uses Hutchinson's estimator via
@@ -48,16 +49,16 @@ def trace(
     return jnp.trace(operator.as_matrix())
 
 
-def _trace_block_diag(operator: BlockDiag) -> jnp.ndarray:
+def _trace_block_diag(operator: BlockDiag) -> Float[Array, ""]:
     return ft.reduce(jnp.add, (trace(op) for op in operator.operators))
 
 
-def _trace_kronecker(operator: Kronecker) -> jnp.ndarray:
+def _trace_kronecker(operator: Kronecker) -> Float[Array, ""]:
     """trace(A kron B) = trace(A) * trace(B)."""
     return ft.reduce(jnp.multiply, (trace(op) for op in operator.operators))
 
 
-def _trace_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
+def _trace_block_tridiag(operator: BlockTriDiag) -> Float[Array, ""]:
     """trace of block-tridiagonal = sum of traces of diagonal blocks."""
     return jnp.sum(jax.vmap(jnp.trace)(operator.diagonal))
 
@@ -65,8 +66,8 @@ def _trace_block_tridiag(operator: BlockTriDiag) -> jnp.ndarray:
 def _trace_stochastic(
     operator: lx.AbstractLinearOperator,
     num_probes: int,
-    key: jnp.ndarray | None,
-) -> jnp.ndarray:
+    key: jax.Array | None,
+) -> Float[Array, ""]:
     """Hutchinson trace estimator via matfree."""
     if key is None:
         key = jax.random.PRNGKey(0)

--- a/src/gaussx/_quadrature/_psi_statistics.py
+++ b/src/gaussx/_quadrature/_psi_statistics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+import jax
 import jax.numpy as jnp
 from einops import rearrange
 from jaxtyping import Array, Float
@@ -21,23 +22,23 @@ class AnalyticalPsiStatistics(Protocol):
     analytical formulae instead of requiring numerical integration.
     """
 
-    def psi0(self, state: GaussianState) -> jnp.ndarray:
+    def psi0(self, state: GaussianState) -> Float[Array, ""]:
         """Compute Ψ₀ = E[k(x, x)] (scalar)."""
         ...
 
     def psi1(
         self,
         state: GaussianState,
-        X_train: jnp.ndarray,
-    ) -> jnp.ndarray:
+        X_train: Float[Array, "M D"],
+    ) -> Float[Array, " M"]:
         """Compute Ψ₁ᵢ = E[k(x, xᵢ)], shape ``(M,)``."""
         ...
 
     def psi2(
         self,
         state: GaussianState,
-        X_train: jnp.ndarray,
-    ) -> jnp.ndarray:
+        X_train: Float[Array, "M D"],
+    ) -> Float[Array, "M M"]:
         """Compute Ψ₂ᵢⱼ = E[k(x, xᵢ) k(x, xⱼ)], shape ``(M, M)``."""
         ...
 
@@ -88,19 +89,17 @@ def compute_psi_statistics(
         )
         raise ValueError(msg)
 
-    import jax
-
     # ── Numerical fallback ────────────────────────────────────────
 
     # Ψ₀ = E[k(x, x)]
-    def _k_self(x: jnp.ndarray) -> jnp.ndarray:
+    def _k_self(x: Float[Array, " D"]) -> Float[Array, " 1"]:
         return jnp.atleast_1d(kernel(x, x))  # type: ignore[operator]
 
     psi0_result = integrator.integrate(_k_self, state)
     psi0 = psi0_result.state.mean[0]  # scalar
 
     # Ψ₁ᵢ = E[k(x, xᵢ)]
-    def _k_cross(x: jnp.ndarray) -> jnp.ndarray:
+    def _k_cross(x: Float[Array, " D"]) -> Float[Array, " M"]:
         return jax.vmap(lambda xj: kernel(x, xj))(X_train)  # type: ignore[operator]
 
     psi1_result = integrator.integrate(_k_cross, state)
@@ -109,7 +108,7 @@ def compute_psi_statistics(
     # Ψ₂ᵢⱼ = E[k(x, xᵢ) k(x, xⱼ)]
     M = X_train.shape[0]
 
-    def _k_outer(x: jnp.ndarray) -> jnp.ndarray:
+    def _k_outer(x: Float[Array, " D"]) -> Float[Array, " flat"]:
         kx = jax.vmap(lambda xj: kernel(x, xj))(X_train)  # type: ignore[operator]
         return rearrange(jnp.outer(kx, kx), "i j -> (i j)")  # (M²,)
 

--- a/src/gaussx/_ssm/_dare.py
+++ b/src/gaussx/_ssm/_dare.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array, Bool, Float
 
 
 class DAREResult(eqx.Module):
@@ -16,18 +17,18 @@ class DAREResult(eqx.Module):
         converged: Scalar boolean indicating convergence.
     """
 
-    P_inf: jnp.ndarray
-    K_inf: jnp.ndarray
-    converged: jnp.ndarray
+    P_inf: Float[Array, "D D"]
+    K_inf: Float[Array, "D M"]
+    converged: Bool[Array, ""]
 
 
 def dare(
-    A: jnp.ndarray,
-    H: jnp.ndarray,
-    Q: jnp.ndarray,
-    R: jnp.ndarray,
+    A: Float[Array, "D D"],
+    H: Float[Array, "M D"],
+    Q: Float[Array, "D D"],
+    R: Float[Array, "M M"],
     *,
-    P_init: jnp.ndarray | None = None,
+    P_init: Float[Array, "D D"] | None = None,
     max_iter: int = 100,
     tol: float = 1e-8,
 ) -> DAREResult:
@@ -61,7 +62,9 @@ def dare(
     D = A.shape[0]
     I_D = jnp.eye(D)
 
-    def _step(P: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
+    def _step(
+        P: Float[Array, "D D"],
+    ) -> tuple[Float[Array, "D D"], Float[Array, "D M"]]:
         """One predict-update step. Returns ``(P_new, K)``."""
         P_pred = A @ P @ A.T + Q
         S = H @ P_pred @ H.T + R
@@ -70,13 +73,15 @@ def dare(
         P_new = (I_D - K @ H) @ P_pred
         return P_new, K
 
-    def _cond(state: tuple[jnp.ndarray, int, jnp.ndarray]) -> jnp.ndarray:
+    def _cond(
+        state: tuple[Float[Array, "D D"], int, Bool[Array, ""]],
+    ) -> Bool[Array, ""]:
         _, i, converged = state
         return (i < max_iter) & (~converged)
 
     def _body(
-        state: tuple[jnp.ndarray, int, jnp.ndarray],
-    ) -> tuple[jnp.ndarray, int, jnp.ndarray]:
+        state: tuple[Float[Array, "D D"], int, Bool[Array, ""]],
+    ) -> tuple[Float[Array, "D D"], int, Bool[Array, ""]]:
         P_old, i, _ = state
         P_new, _ = _step(P_old)
         converged = jnp.max(jnp.abs(P_new - P_old)) < tol

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._linalg._linalg import solve_rows
 from gaussx._strategies._base import AbstractSolverStrategy
@@ -23,21 +24,21 @@ class FilterState(eqx.Module):
         log_likelihood: Scalar — total log-likelihood.
     """
 
-    filtered_means: jnp.ndarray
-    filtered_covs: jnp.ndarray
-    predicted_means: jnp.ndarray
-    predicted_covs: jnp.ndarray
-    log_likelihood: jnp.ndarray
+    filtered_means: Float[Array, "T N"]
+    filtered_covs: Float[Array, "T N N"]
+    predicted_means: Float[Array, "T N"]
+    predicted_covs: Float[Array, "T N N"]
+    log_likelihood: Float[Array, ""]
 
 
 def kalman_filter(
-    transition: jnp.ndarray,
-    obs_model: jnp.ndarray,
-    process_noise: jnp.ndarray,
-    obs_noise: jnp.ndarray,
-    observations: jnp.ndarray,
-    init_mean: jnp.ndarray,
-    init_cov: jnp.ndarray,
+    transition: Float[Array, "N N"],
+    obs_model: Float[Array, "M N"],
+    process_noise: Float[Array, "N N"],
+    obs_noise: Float[Array, "M M"],
+    observations: Float[Array, "T M"],
+    init_mean: Float[Array, " N"],
+    init_cov: Float[Array, "N N"],
     *,
     solver: AbstractSolverStrategy | None = None,
 ) -> FilterState:
@@ -111,11 +112,11 @@ def kalman_filter(
 
 def rts_smoother(
     filter_state: FilterState,
-    transition: jnp.ndarray,
-    process_noise: jnp.ndarray,
+    transition: Float[Array, "N N"],
+    process_noise: Float[Array, "N N"],
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
     """Rauch-Tung-Striebel backward smoother.
 
     Args:
@@ -177,7 +178,7 @@ def kalman_gain(
     R: lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, "N M"]:
     """Compute Kalman gain ``K = P @ H^T @ (H @ P @ H^T + R)^{-1}``.
 
     Args:

--- a/src/gaussx/_ssm/_pairwise_marginals.py
+++ b/src/gaussx/_ssm/_pairwise_marginals.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 
 
 def pairwise_marginals(
-    means: jnp.ndarray,
-    covariances: jnp.ndarray,
-    cross_covariances: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    means: Float[Array, "T d"],
+    covariances: Float[Array, "T d d"],
+    cross_covariances: Float[Array, "Tm1 d d"],
+) -> tuple[Float[Array, "Tm1 two_d"], Float[Array, "Tm1 two_d two_d"]]:
     r"""Joint p(x_k, x_{k+1}) for each consecutive pair.
 
     For each pair ``(k, k+1)``, the joint distribution is::
@@ -35,12 +36,12 @@ def pairwise_marginals(
     """
 
     def _single_pair(
-        m_k: jnp.ndarray,
-        m_kp1: jnp.ndarray,
-        P_k: jnp.ndarray,
-        P_kp1: jnp.ndarray,
-        C_k: jnp.ndarray,
-    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        m_k: Float[Array, " d"],
+        m_kp1: Float[Array, " d"],
+        P_k: Float[Array, "d d"],
+        P_kp1: Float[Array, "d d"],
+        C_k: Float[Array, "d d"],
+    ) -> tuple[Float[Array, " two_d"], Float[Array, "two_d two_d"]]:
         joint_mean = jnp.concatenate([m_k, m_kp1])
         joint_cov = jnp.block(
             [

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 
 from gaussx._ssm._kalman import FilterState
 
 
 def parallel_kalman_filter(
-    transition: jnp.ndarray,
-    obs_model: jnp.ndarray,
-    process_noise: jnp.ndarray,
-    obs_noise: jnp.ndarray,
-    observations: jnp.ndarray,
-    init_mean: jnp.ndarray,
-    init_cov: jnp.ndarray,
+    transition: Float[Array, "N N"],
+    obs_model: Float[Array, "M N"],
+    process_noise: Float[Array, "N N"],
+    obs_noise: Float[Array, "M M"],
+    observations: Float[Array, "T M"],
+    init_mean: Float[Array, " N"],
+    init_cov: Float[Array, "N N"],
 ) -> FilterState:
     """Kalman filter with dense array operations via ``jax.lax.scan``.
 
@@ -68,9 +69,9 @@ def parallel_kalman_filter(
 
 def parallel_rts_smoother(
     filter_state: FilterState,
-    transition: jnp.ndarray,
-    process_noise: jnp.ndarray,
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    transition: Float[Array, "N N"],
+    process_noise: Float[Array, "N N"],
+) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
     """Dense RTS smoother for outputs produced by ``parallel_kalman_filter``.
 
     The previous associative-scan formulation was not algebraically

--- a/src/gaussx/_ssm/_spingp.py
+++ b/src/gaussx/_ssm/_spingp.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 from einops import einsum, rearrange, repeat
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_tridiag import BlockTriDiag
 from gaussx._primitives._inv import inv
@@ -15,7 +16,7 @@ from gaussx._strategies._dispatch import dispatch_logdet, dispatch_solve
 
 
 def _build_likelihood_precision(
-    emission_model: jnp.ndarray,
+    emission_model: Array,
     obs_noise: lx.AbstractLinearOperator,
     N: int,
     d: int,
@@ -61,10 +62,10 @@ def _build_likelihood_precision(
 
 
 def _build_data_vector(
-    emission_model: jnp.ndarray,
+    emission_model: Array,
     obs_noise: lx.AbstractLinearOperator,
-    observations: jnp.ndarray,
-) -> jnp.ndarray:
+    observations: Float[Array, "N d_obs"],
+) -> Float[Array, " Nd"]:
     """Build the data contribution to the posterior mean equation.
 
     Computes ``H^T R^{-1} y`` for each time step.  The observation
@@ -96,12 +97,12 @@ def _build_data_vector(
 
 def spingp_log_likelihood(
     prior_precision: BlockTriDiag,
-    emission_model: jnp.ndarray,
+    emission_model: Array,
     obs_noise: lx.AbstractLinearOperator,
-    observations: jnp.ndarray,
+    observations: Float[Array, "N d_obs"],
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     r"""Log marginal likelihood via sparse inverse GP formulation.
 
     Computes the log marginal likelihood using the precision-form
@@ -175,12 +176,12 @@ def spingp_log_likelihood(
 
 def spingp_posterior(
     prior_precision: BlockTriDiag,
-    emission_model: jnp.ndarray,
+    emission_model: Array,
     obs_noise: lx.AbstractLinearOperator,
-    observations: jnp.ndarray,
+    observations: Float[Array, "N d_obs"],
     *,
     solver: AbstractSolverStrategy | None = None,
-) -> tuple[jnp.ndarray, BlockTriDiag]:
+) -> tuple[Float[Array, " Nd"], BlockTriDiag]:
     r"""Posterior mean and precision via SpInGP.
 
     Computes the posterior by adding likelihood precision sites to the

--- a/src/gaussx/_strategies/_auto.py
+++ b/src/gaussx/_strategies/_auto.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 
@@ -30,8 +30,8 @@ class AutoSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b with automatically selected algorithm.
 
         Args:
@@ -48,7 +48,7 @@ class AutoSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Compute log |det(A)| with automatically selected algorithm.
 
         Args:

--- a/src/gaussx/_strategies/_base.py
+++ b/src/gaussx/_strategies/_base.py
@@ -6,8 +6,8 @@ import abc
 
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 
 class AbstractSolveStrategy(eqx.Module):
@@ -22,8 +22,8 @@ class AbstractSolveStrategy(eqx.Module):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b."""
         ...
 
@@ -45,7 +45,7 @@ class AbstractLogdetStrategy(eqx.Module):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Compute log |det(A)|.
 
         Args:

--- a/src/gaussx/_strategies/_bbmm.py
+++ b/src/gaussx/_strategies/_bbmm.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import SLQLogdet
@@ -44,8 +44,8 @@ class BBMMSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b via CG.
 
         Args:
@@ -67,7 +67,7 @@ class BBMMSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic log-determinant via Lanczos quadrature.
 
         Probe vectors are generated deterministically from ``self.seed``.
@@ -87,8 +87,8 @@ class BBMMSolver(AbstractSolverStrategy):
     def solve_and_logdet(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        vector: Float[Array, " n"],
+    ) -> tuple[Float[Array, " n"], Float[Array, ""]]:
         """Joint solve + logdet.
 
         Computes both solve(A, b) and logdet(A) sharing the

--- a/src/gaussx/_strategies/_cg.py
+++ b/src/gaussx/_strategies/_cg.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import SLQLogdet
@@ -35,8 +35,8 @@ class CGSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         solver = lx.CG(rtol=self.rtol, atol=self.atol, max_steps=self.max_steps)
         return lx.linear_solve(operator, vector, solver).value
 
@@ -45,7 +45,7 @@ class CGSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic log-determinant via Lanczos quadrature.
 
         Args:

--- a/src/gaussx/_strategies/_composed.py
+++ b/src/gaussx/_strategies/_composed.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import (
     AbstractLogdetStrategy,
@@ -41,8 +41,8 @@ class ComposedSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b using the solve strategy."""
         return self.solve_strategy.solve(operator, vector)
 
@@ -51,6 +51,6 @@ class ComposedSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Compute log |det(A)| using the logdet strategy."""
         return self.logdet_strategy.logdet(operator, key=key)

--- a/src/gaussx/_strategies/_dense.py
+++ b/src/gaussx/_strategies/_dense.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._primitives._logdet import logdet as _logdet
 from gaussx._primitives._solve import solve as _solve
@@ -23,8 +23,8 @@ class DenseSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         return _solve(operator, vector)
 
     def logdet(
@@ -32,5 +32,5 @@ class DenseSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         return _logdet(operator)

--- a/src/gaussx/_strategies/_dispatch.py
+++ b/src/gaussx/_strategies/_dispatch.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractLogdetStrategy, AbstractSolveStrategy
 
 
 def dispatch_solve(
     operator: lx.AbstractLinearOperator,
-    vector: jnp.ndarray,
+    vector: Float[Array, " n"],
     solver: AbstractSolveStrategy | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, " n"]:
     """Solve ``A x = b`` via *solver* or structural-dispatch primitive.
 
     Args:
@@ -37,7 +37,7 @@ def dispatch_logdet(
     solver: AbstractLogdetStrategy | None = None,
     *,
     key: jax.Array | None = None,
-) -> jnp.ndarray:
+) -> Float[Array, ""]:
     """Compute ``log |det(A)|`` via *solver* or structural-dispatch primitive.
 
     Args:

--- a/src/gaussx/_strategies/_lsmr.py
+++ b/src/gaussx/_strategies/_lsmr.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
 import matfree.lstsq
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import SLQLogdet
@@ -44,8 +44,8 @@ class LSMRSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " m"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b via LSMR.
 
         Args:
@@ -73,7 +73,7 @@ class LSMRSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic log-determinant via Lanczos quadrature.
 
         Args:

--- a/src/gaussx/_strategies/_minres.py
+++ b/src/gaussx/_strategies/_minres.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import IndefiniteSLQLogdet
@@ -12,13 +13,13 @@ from gaussx._strategies._slq_logdet import IndefiniteSLQLogdet
 
 def _minres_solve(
     matvec,
-    b: jnp.ndarray,
+    b: Float[Array, " N"],
     *,
     rtol: float = 1e-5,
     atol: float = 1e-5,
     max_steps: int = 1000,
     shift: float = 0.0,
-) -> jnp.ndarray:
+) -> Float[Array, " N"]:
     r"""Solve ``(A + shift I) x = b`` via MINRES for symmetric ``A``.
 
     Implements the Lanczos-based MINRES algorithm (Paige & Saunders, 1975).
@@ -180,8 +181,8 @@ class MINRESSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         return _minres_solve(
             operator.mv,
             vector,
@@ -196,7 +197,7 @@ class MINRESSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic ``log|det(A + shift I)|`` via Lanczos quadrature.
 
         Args:

--- a/src/gaussx/_strategies/_precond_cg.py
+++ b/src/gaussx/_strategies/_precond_cg.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 import matfree.low_rank
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import SLQLogdet
@@ -46,8 +47,8 @@ class PreconditionedCGSolver(AbstractSolverStrategy):
     def solve(
         self,
         operator: lx.AbstractLinearOperator,
-        vector: jnp.ndarray,
-    ) -> jnp.ndarray:
+        vector: Float[Array, " n"],
+    ) -> Float[Array, " n"]:
         """Solve A x = b via preconditioned CG.
 
         Args:
@@ -93,7 +94,7 @@ class PreconditionedCGSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic log-determinant via Lanczos quadrature.
 
         Args:

--- a/src/gaussx/_strategies/_slq_logdet.py
+++ b/src/gaussx/_strategies/_slq_logdet.py
@@ -8,6 +8,7 @@ import lineax as lx
 import matfree.decomp
 import matfree.funm
 import matfree.stochtrace
+from jaxtyping import Array, Float
 
 from gaussx._strategies._base import AbstractLogdetStrategy
 
@@ -42,7 +43,7 @@ class SLQLogdet(AbstractLogdetStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Stochastic ``log det(A)`` via Lanczos quadrature.
 
         Args:
@@ -95,7 +96,7 @@ class IndefiniteSLQLogdet(AbstractLogdetStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         r"""Stochastic ``log|det(A + shift I)|`` via Lanczos quadrature.
 
         Args:
@@ -140,7 +141,7 @@ class DenseLogdet(AbstractLogdetStrategy):
         operator: lx.AbstractLinearOperator,
         *,
         key: jax.Array | None = None,
-    ) -> jnp.ndarray:
+    ) -> Float[Array, ""]:
         """Compute ``log |det(A)|`` via structural dispatch.
 
         Args:

--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -12,6 +12,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
+from jaxtyping import Array, Bool, Float
 
 from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 
@@ -23,7 +24,7 @@ from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 
 def tree_allclose(
     x, y, *, rtol: float = 1e-5, atol: float = 1e-8
-) -> bool | jnp.ndarray:
+) -> bool | Bool[Array, ""]:
     """PyTree-aware approximate equality check.
 
     Wraps ``eqx.tree_equal`` with tolerance support. Matches the
@@ -37,7 +38,12 @@ def tree_allclose(
 # ---------------------------------------------------------------------------
 
 
-def random_pd_matrix(key: jax.Array, n: int, *, dtype=jnp.float64) -> jnp.ndarray:
+def random_pd_matrix(
+    key: jax.Array,
+    n: int,
+    *,
+    dtype=jnp.float64,
+) -> Float[Array, "n n"]:
     """Generate a random positive-definite n x n matrix."""
     A = jr.normal(key, (n, n), dtype=dtype)
     return A @ A.T + 0.1 * jnp.eye(n, dtype=dtype)
@@ -100,26 +106,29 @@ def random_low_rank_update(
 # ---------------------------------------------------------------------------
 
 
-def dense_solve(op: lx.AbstractLinearOperator, v: jnp.ndarray) -> jnp.ndarray:
+def dense_solve(
+    op: lx.AbstractLinearOperator,
+    v: Float[Array, " n"],
+) -> Float[Array, " n"]:
     """Solve via dense materialization (reference implementation)."""
     return jnp.linalg.solve(op.as_matrix(), v)
 
 
-def dense_logdet(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+def dense_logdet(op: lx.AbstractLinearOperator) -> Float[Array, ""]:
     """Log-determinant via dense materialization."""
     return jnp.linalg.slogdet(op.as_matrix())[1]
 
 
-def dense_inv(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+def dense_inv(op: lx.AbstractLinearOperator) -> Float[Array, "n n"]:
     """Inverse via dense materialization."""
     return jnp.linalg.inv(op.as_matrix())
 
 
-def dense_diag(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+def dense_diag(op: lx.AbstractLinearOperator) -> Float[Array, " n"]:
     """Diagonal via dense materialization."""
     return jnp.diag(op.as_matrix())
 
 
-def dense_trace(op: lx.AbstractLinearOperator) -> jnp.ndarray:
+def dense_trace(op: lx.AbstractLinearOperator) -> Float[Array, ""]:
     """Trace via dense materialization."""
     return jnp.trace(op.as_matrix())


### PR DESCRIPTION
## Summary

This PR standardizes tensor-shape handling across `src/gaussx` by aligning the codebase with the repo's documented conventions around `einops` and `jaxtyping`.

## What changed

- replaced remaining raw reshape/transpose/moveaxis-style tensor manipulation with `einops`-based equivalents where appropriate
- converted remaining raw `jnp.ndarray` and `ArrayLike` annotations in `src/gaussx` to shape-aware `jaxtyping` annotations
- tightened shape contracts across distributions, GP utilities, inference helpers, linalg helpers, primitives, strategies, quadrature utilities, and SSM modules
- kept unrelated worktree changes out of the commit, including `uv.lock` and `.codex`

## Why

The repo already documents a standard of using `einops` for tensor reshaping and `jaxtyping` for array shape tracking, but the implementation had drifted from that guidance in a number of modules. This pass brings the code back into line with the intended style and makes shape expectations more explicit throughout the package.

## Impact

- more consistent tensor manipulation style across the package
- stronger shape documentation at the type level
- no intended behavioral changes

## Validation

- `uv run --group lint ruff check .`
- `uv run --group lint ruff format --check .`
- `uv run --group typecheck ty check src/gaussx`
- `uv run pytest -q`

Pytest result: `981 passed, 1 warning`
