### PR TITLE
chore(deps): loosen jaxlib floor back to >=0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "jax>=0.4",
-    "jaxlib>=0.9.2",
+    "jaxlib>=0.4",
     "equinox>=0.11",
     "lineax>=0.1.0",
     "matfree>=0.3",


### PR DESCRIPTION
## Summary

Reverts the `jaxlib` floor from `>=0.9.2` (raised in #109 by dependabot) back to `>=0.4`, matching the existing `jax>=0.4` pin.

## Why

The #109 bump was pyproject-only — no code in gaussx calls jaxlib APIs that shipped after 0.4, so the floor-raise purely narrowed the compatible install range with no functional benefit.

That narrower range now blocks downstream integrators. Concretely:

- pyrox@main pulls \`gaussx @ git+...gaussx.git@main\` transitively
- numpyro 0.20.1 (latest on PyPI) still imports \`xla_pmap_p\` from \`jax.extend.core.primitives\` — a symbol JAX removed at the 0.9 line
- With \`jaxlib>=0.9.2\` forced by gaussx, the resolver can't pick a numpyro-compatible jaxlib, so \`pip install pyrox\` → \`import numpyro\` fails at import time

Loosening gaussx's pin lets downstream envs pick a jax version compatible with whatever their other deps need, without changing what gaussx itself can do.

## Test plan

- [x] \`uv run pytest -v -x\` — **981/981 pass** locally on current jax 0.9.2 (range widening; current-tip unchanged)
- [ ] CI on PR — same suite
- [ ] Downstream smoke: \`pixi install -e pyrox\` + \`pixi run -e pyrox execute-pyrox\` in jejjohnson/research_notebook works after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)