### PR TITLE
feat: sumKronecker per-factor eig + ProductSDE Kronecker expm

### DIFF
--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -112,8 +112,15 @@ class SumKronecker(lx.AbstractLinearOperator):
             ``self == Q @ diag(eigenvalues) @ Q^T``.
         """
         A2_op, B2_op = self.kron2.operators
+        A1_op, B1_op = self.kron1.operators
+        # The final ``eigh(transformed)`` call requires ``transformed`` to
+        # be symmetric, which in turn requires *both* kron pairs to have
+        # symmetric factors (so that ``A1_tilde`` and ``B1_tilde`` stay
+        # symmetric under the ``Q^T A Q`` rotation).
         if not lx.is_symmetric(A2_op) or not lx.is_symmetric(B2_op):
             raise ValueError("eigendecompose requires kron2 factors to be symmetric.")
+        if not lx.is_symmetric(A1_op) or not lx.is_symmetric(B1_op):
+            raise ValueError("eigendecompose requires kron1 factors to be symmetric.")
 
         from gaussx._primitives._eig import eig
 

--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -115,11 +115,15 @@ class SumKronecker(lx.AbstractLinearOperator):
         if not lx.is_symmetric(A2_op) or not lx.is_symmetric(B2_op):
             raise ValueError("eigendecompose requires kron2 factors to be symmetric.")
 
-        A1, B1 = (op.as_matrix() for op in self.kron1.operators)
-        A2, B2 = A2_op.as_matrix(), B2_op.as_matrix()
+        from gaussx._primitives._eig import eig
 
-        evals_c, Q_C = jnp.linalg.eigh(A2)
-        evals_d, Q_D = jnp.linalg.eigh(B2)
+        A1, B1 = (op.as_matrix() for op in self.kron1.operators)
+
+        # Per-factor eigendecomposition routed through the structural
+        # primitive: Diagonal / BlockDiag / nested Kronecker factors of
+        # ``A_2`` or ``B_2`` skip materialization here.
+        evals_c, Q_C = eig(A2_op)
+        evals_d, Q_D = eig(B2_op)
 
         # Transform first pair into eigenbasis of second pair
         A1_tilde = Q_C.T @ A1 @ Q_C

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -130,8 +130,11 @@ class ProductSDE(SDEKernel):
         A2 = jsl.expm(p2.F * dt)
         A = jnp.kron(A1, A2)
 
-        params = self.sde_params()
-        Q = params.P_inf - A @ params.P_inf @ A.T
+        # Use the per-factor stationary covariances directly; building
+        # the full ``F`` via ``self.sde_params()`` would defeat the
+        # whole point of this override.
+        P_inf = jnp.kron(p1.P_inf, p2.P_inf)
+        Q = P_inf - A @ P_inf @ A.T
         Q = 0.5 * (Q + Q.T)
         return A, Q
 

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 import jax.scipy.linalg as jsl
+from jaxtyping import Array, Float
 
 from gaussx._ssm._sde_kernel import SDEKernel, SDEParams
 
@@ -92,6 +93,47 @@ class ProductSDE(SDEKernel):
         P_inf = jnp.kron(p1.P_inf, p2.P_inf)
 
         return SDEParams(F=F, L=L, H=H, Q_c=Q_c, P_inf=P_inf)
+
+    def discretise(
+        self,
+        dt: Float[Array, ""],
+    ) -> tuple[Float[Array, "d d"], Float[Array, "d d"]]:
+        r"""Discretise via the Kronecker matrix-exponential identity.
+
+        For a product kernel ``F = F_1 \oplus F_2 = F_1 \otimes I + I \otimes F_2``,
+        the factors ``F_1 \otimes I`` and ``I \otimes F_2`` commute, so
+
+        .. math::
+
+            \exp(F \, dt) = \exp(F_1 \, dt) \otimes \exp(F_2 \, dt).
+
+        This computes two ``expm`` calls of size ``d_1`` and ``d_2``
+        each, plus one Kronecker product, instead of one ``expm`` of
+        size ``d_1 \cdot d_2``. Numerically equivalent to the dense
+        ``expm`` on ``F`` but cheaper for moderate factor sizes.
+
+        ``Q = P_\infty - A P_\infty A^T`` is computed densely from the
+        resulting ``A``; with ``P_\infty = P_{\infty,1} \otimes
+        P_{\infty,2}`` this could itself be expressed as a Kronecker
+        difference, but is left dense to keep the consumer-facing
+        ``(A, Q)`` interface unchanged.
+
+        Args:
+            dt: Time step (scalar, positive).
+
+        Returns:
+            Tuple ``(A, Q)`` matching :meth:`SDEKernel.discretise`.
+        """
+        p1 = self.kernel1.sde_params()
+        p2 = self.kernel2.sde_params()
+        A1 = jsl.expm(p1.F * dt)
+        A2 = jsl.expm(p2.F * dt)
+        A = jnp.kron(A1, A2)
+
+        params = self.sde_params()
+        Q = params.P_inf - A @ params.P_inf @ A.T
+        Q = 0.5 * (Q + Q.T)
+        return A, Q
 
 
 class QuasiPeriodicSDE(ProductSDE):

--- a/tests/operators/test_sum_kronecker.py
+++ b/tests/operators/test_sum_kronecker.py
@@ -273,13 +273,19 @@ class TestJAX:
         assert jnp.all(jnp.isfinite(g))
 
 
-def test_eigendecompose_with_diagonal_factor_avoids_eigh(getkey):
-    """When kron2's factors are Diagonal, per-factor eig dispatches to the
-    Diagonal path (no jnp.linalg.eigh on a materialized matrix).
+def test_eigendecompose_supports_diagonal_kron2_factors(getkey, monkeypatch):
+    """SumKronecker.eigendecompose accepts Diagonal kron2 factors and
+    routes their per-factor eig through the structural primitive,
+    *not* through ``jnp.linalg.eigh`` on a materialized matrix.
 
-    The joint diagonalization step requires kron1 factors to be symmetric
-    so the ``transformed`` matrix passed to ``eigh`` is symmetric.
+    Asserts both correctness (Q diag(evals) Q^T == SK.as_matrix()) and
+    that the Diagonal-factor path was taken (no fallback to
+    ``jnp.linalg.eigh`` on those factors). The joint diagonalization
+    step still calls ``jnp.linalg.eigh`` on the ``(n_c·n_d, n_c·n_d)``
+    transformed matrix, which is unavoidable.
     """
+    import jax.numpy as _jnp
+
     from gaussx._testing import random_pd_matrix
 
     A1_mat = random_pd_matrix(getkey(), 2)
@@ -293,6 +299,39 @@ def test_eigendecompose_with_diagonal_factor_avoids_eigh(getkey):
     B2 = lx.DiagonalLinearOperator(B2_diag)
     SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
 
+    # Wrap jnp.linalg.eigh so we can count calls and inspect argument
+    # shapes. The Diagonal-factor path should produce *exactly one*
+    # eigh call — on the transformed (n_c·n_d, n_c·n_d) matrix.
+    eigh_calls: list[tuple[int, int]] = []
+    real_eigh = _jnp.linalg.eigh
+
+    def spy_eigh(mat, *args, **kwargs):
+        eigh_calls.append(mat.shape)
+        return real_eigh(mat, *args, **kwargs)
+
+    monkeypatch.setattr(_jnp.linalg, "eigh", spy_eigh)
+
     evals, Q = SK.eigendecompose()
     reconstructed = Q @ jnp.diag(evals) @ Q.T
     assert tree_allclose(reconstructed, SK.as_matrix(), rtol=1e-4, atol=1e-6)
+
+    # No (2, 2) or (3, 3) eigh calls on the Diagonal kron2 factors.
+    assert (2, 2) not in eigh_calls
+    assert (3, 3) not in eigh_calls
+    # The single remaining eigh is on the (6, 6) transformed matrix.
+    assert (6, 6) in eigh_calls
+
+
+def test_eigendecompose_rejects_nonsymmetric_kron1(getkey):
+    """Non-symmetric kron1 factors should raise ValueError, not silently
+    return wrong results from ``eigh`` on a non-symmetric matrix."""
+    A1 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))  # not tagged symmetric
+    B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
+    A2_mat = jr.normal(getkey(), (2, 2))
+    B2_mat = jr.normal(getkey(), (3, 3))
+    A2 = lx.MatrixLinearOperator(A2_mat @ A2_mat.T, lx.symmetric_tag)
+    B2 = lx.MatrixLinearOperator(B2_mat @ B2_mat.T, lx.symmetric_tag)
+    SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+
+    with pytest.raises(ValueError, match="kron1 factors"):
+        SK.eigendecompose()

--- a/tests/operators/test_sum_kronecker.py
+++ b/tests/operators/test_sum_kronecker.py
@@ -271,3 +271,28 @@ class TestJAX:
         g = jax.grad(loss)(A1_mat)
         assert g.shape == (2, 2)
         assert jnp.all(jnp.isfinite(g))
+
+
+def test_eigendecompose_with_diagonal_factor_avoids_eigh(getkey):
+    """When kron2's factors are Diagonal, per-factor eig dispatches to the
+    Diagonal path (no jnp.linalg.eigh on a materialized matrix).
+
+    The joint diagonalization step requires kron1 factors to be symmetric
+    so the ``transformed`` matrix passed to ``eigh`` is symmetric.
+    """
+    from gaussx._testing import random_pd_matrix
+
+    A1_mat = random_pd_matrix(getkey(), 2)
+    B1_mat = random_pd_matrix(getkey(), 3)
+    A2_diag = jnp.abs(jr.normal(getkey(), (2,))) + 1.0
+    B2_diag = jnp.abs(jr.normal(getkey(), (3,))) + 1.0
+
+    A1 = lx.MatrixLinearOperator(A1_mat, lx.symmetric_tag)
+    B1 = lx.MatrixLinearOperator(B1_mat, lx.symmetric_tag)
+    A2 = lx.DiagonalLinearOperator(A2_diag)
+    B2 = lx.DiagonalLinearOperator(B2_diag)
+    SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+
+    evals, Q = SK.eigendecompose()
+    reconstructed = Q @ jnp.diag(evals) @ Q.T
+    assert tree_allclose(reconstructed, SK.as_matrix(), rtol=1e-4, atol=1e-6)

--- a/tests/ssm/test_sde_kernels.py
+++ b/tests/ssm/test_sde_kernels.py
@@ -116,6 +116,40 @@ class TestProductSDE:
         kern = ProductSDE(kernel1=k1, kernel2=k2)
         assert kern.state_dim == 2
 
+    def test_discretise_matches_dense_expm(self):
+        """ProductSDE.discretise via Kronecker expm equals dense expm(F*dt)."""
+        import jax.scipy.linalg as jsl
+
+        k1 = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(2.0), order=1)
+        k2 = CosineSDE(variance=jnp.array(1.0), frequency=jnp.array(0.5))
+        kern = ProductSDE(kernel1=k1, kernel2=k2)
+        dt = jnp.array(0.3)
+
+        A, Q = kern.discretise(dt)
+
+        # Reference: dense expm of the full F.
+        params = kern.sde_params()
+        A_ref = jsl.expm(params.F * dt)
+        Q_ref = params.P_inf - A_ref @ params.P_inf @ A_ref.T
+        Q_ref = 0.5 * (Q_ref + Q_ref.T)
+
+        assert jnp.allclose(A, A_ref, atol=1e-6)
+        assert jnp.allclose(Q, Q_ref, atol=1e-6)
+
+    def test_discretise_kronecker_structure(self):
+        """A = expm(F1*dt) ⊗ expm(F2*dt) is exactly Kronecker-structured."""
+        import jax.scipy.linalg as jsl
+
+        k1 = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(2.0), order=1)
+        k2 = CosineSDE(variance=jnp.array(1.0), frequency=jnp.array(0.5))
+        kern = ProductSDE(kernel1=k1, kernel2=k2)
+        dt = jnp.array(0.25)
+
+        A, _ = kern.discretise(dt)
+        A1 = jsl.expm(k1.sde_params().F * dt)
+        A2 = jsl.expm(k2.sde_params().F * dt)
+        assert jnp.allclose(A, jnp.kron(A1, A2), atol=1e-10)
+
 
 class TestQuasiPeriodicSDE:
     def test_is_product(self):


### PR DESCRIPTION
Stacked on top of #158. Closes the remaining "replace" item from the gaussx linalg audit (#153) and turns the deferred `ProductSDE` Kronecker note into a real perf win.

## `SumKronecker.eigendecompose`

- Per-factor eigendecomposition routed through `gaussx.eig` instead of raw `jnp.linalg.eigh` on materialized factors. `Diagonal` / `BlockDiag` / nested `Kronecker` / `KroneckerSum` factors of `A_2` or `B_2` now skip materialization in this hot path.
- The joint diagonalisation step still forms the `(n_c·n_d) × (n_c·n_d)` intermediate (the algorithm requires it) and is documented as such — this is the audit's "justified" classification.

## `ProductSDE.discretise`

Overrides `SDEKernel.discretise` to use the matrix-exponential identity
$$\exp(F_1 \oplus F_2 \cdot dt) = \exp(F_1\,dt) \otimes \exp(F_2\,dt).$$
Two `expm` calls of sizes `d_1` and `d_2` plus one Kronecker product, instead of a single `expm` over the `(d_1·d_2, d_1·d_2)` drift. The consumer-facing `(A, Q)` interface is unchanged; numerically equivalent to the dense `expm`.

This addresses the deferred item 7 from #158: instead of cascading a refactor through `SDEParams`, we get a contained, opt-in perf win at the discretisation site without changing the public type signature.

## Tests

- `tests/operators/test_sum_kronecker.py` — Diagonal `kron2` factors path reconstructs `SK.as_matrix()` from `(Q, evals)`.
- `tests/ssm/test_sde_kernels.py` — `ProductSDE.discretise` matches the dense `expm` reference and yields exactly Kronecker-structured `A`.

## Test plan

- [x] `uv run pytest tests/ -m "not slow"` — 1038 passed.
- [x] `ruff format .` and `ruff check .` clean.
- [x] `ty check src/gaussx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Fvisjv7vkRwUa2uQfPBrCu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvisjv7vkRwUa2uQfPBrCu)_