### PR TITLE
feat(ssm): operator-typed Kalman family + time-varying generalisation

### DIFF
--- a/src/gaussx/_ssm/_dare.py
+++ b/src/gaussx/_ssm/_dare.py
@@ -9,6 +9,7 @@ import lineax as lx
 from jaxtyping import Array, Bool, Float
 
 from gaussx._linalg._linalg import solve_matrix
+from gaussx._ssm._utils import _materialise
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -27,10 +28,10 @@ class DAREResult(eqx.Module):
 
 
 def dare(
-    A: Float[Array, "D D"],
-    H: Float[Array, "M D"],
-    Q: Float[Array, "D D"],
-    R: Float[Array, "M M"],
+    A: Float[Array, "D D"] | lx.AbstractLinearOperator,
+    H: Float[Array, "M D"] | lx.AbstractLinearOperator,
+    Q: Float[Array, "D D"] | lx.AbstractLinearOperator,
+    R: Float[Array, "M M"] | lx.AbstractLinearOperator,
     *,
     P_init: Float[Array, "D D"] | None = None,
     max_iter: int = 100,
@@ -49,10 +50,10 @@ def dare(
     Convergence is declared when ``max|P_new - P_old| < tol``.
 
     Args:
-        A: Transition matrix, shape ``(D, D)``.
-        H: Observation matrix, shape ``(M, D)``.
-        Q: Process noise covariance, shape ``(D, D)``.
-        R: Observation noise covariance, shape ``(M, M)``.
+        A: Transition matrix or operator, shape ``(D, D)``.
+        H: Observation matrix or operator, shape ``(M, D)``.
+        Q: Process noise covariance or operator, shape ``(D, D)``.
+        R: Observation noise covariance or operator, shape ``(M, M)``.
         P_init: Initial covariance guess, shape ``(D, D)``. Defaults to ``Q``.
         max_iter: Maximum number of iterations.
         tol: Convergence tolerance on the element-wise max absolute change.
@@ -63,23 +64,28 @@ def dare(
         A :class:`DAREResult` containing the steady-state covariance,
         Kalman gain, and convergence flag.
     """
-    if P_init is None:
-        P_init = Q
+    A_dense = _materialise(A)
+    H_dense = _materialise(H)
+    Q_dense = _materialise(Q)
+    R_dense = _materialise(R)
 
-    D = A.shape[0]
+    if P_init is None:
+        P_init = Q_dense
+
+    D = A_dense.shape[0]
     I_D = jnp.eye(D)
 
     def _step(
         P: Float[Array, "D D"],
     ) -> tuple[Float[Array, "D D"], Float[Array, "D M"]]:
         """One predict-update step. Returns ``(P_new, K)``."""
-        P_pred = A @ P @ A.T + Q
-        S = H @ P_pred @ H.T + R
+        P_pred = A_dense @ P @ A_dense.T + Q_dense
+        S = H_dense @ P_pred @ H_dense.T + R_dense
         # K = P_pred @ H.T @ S⁻¹, computed via a single factorization
         # on the matrix RHS for numerical stability and efficiency.
         S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
-        K = solve_matrix(S_op, H @ P_pred, solver=solver).T
-        P_new = (I_D - K @ H) @ P_pred
+        K = solve_matrix(S_op, H_dense @ P_pred, solver=solver).T
+        P_new = (I_D - K @ H_dense) @ P_pred
         return P_new, K
 
     def _cond(

--- a/src/gaussx/_ssm/_infinite_horizon_kalman.py
+++ b/src/gaussx/_ssm/_infinite_horizon_kalman.py
@@ -13,6 +13,7 @@ from gaussx._linalg._linalg import solve_rows
 from gaussx._linalg._lyapunov import discrete_lyapunov_solve
 from gaussx._primitives._cholesky import cholesky
 from gaussx._ssm._dare import DAREResult, dare
+from gaussx._ssm._utils import _materialise, _matvec
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -35,10 +36,10 @@ class InfiniteHorizonState(eqx.Module):
 
 
 def infinite_horizon_filter(
-    transition: Float[Array, "N N"],
-    obs_model: Float[Array, "M N"],
-    process_noise: Float[Array, "N N"],
-    obs_noise: Float[Array, "M M"],
+    transition: Float[Array, "N N"] | lx.AbstractLinearOperator,
+    obs_model: Float[Array, "M N"] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, "N N"] | lx.AbstractLinearOperator,
+    obs_noise: Float[Array, "M M"] | lx.AbstractLinearOperator,
     observations: Float[Array, "T M"],
     init_mean: Float[Array, " N"] | None = None,
     *,
@@ -57,11 +58,16 @@ def infinite_horizon_filter(
         Update:   vₜ  = yₜ − H x⁻ₜ
                   xₜ  = x⁻ₜ + K∞ vₜ
 
+    All four operator/array arguments accept either a raw JAX array or
+    a :class:`lineax.AbstractLinearOperator`. Operator inputs preserve
+    their structural matvec inside the per-step scan; the sandwiches
+    materialise once outside the scan.
+
     Args:
-        transition: State transition matrix A, shape ``(N, N)``.
-        obs_model: Observation matrix H, shape ``(M, N)``.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
-        obs_noise: Observation noise covariance R, shape ``(M, M)``.
+        transition: State transition matrix or operator, shape ``(N, N)``.
+        obs_model: Observation matrix or operator, shape ``(M, N)``.
+        process_noise: Process noise covariance or operator, shape ``(N, N)``.
+        obs_noise: Observation noise covariance or operator, shape ``(M, M)``.
         observations: Observed data y, shape ``(T, M)``.
         init_mean: Initial state mean, shape ``(N,)``. Defaults to zeros.
         dare_result: Precomputed DARE result. If ``None``, calls
@@ -88,15 +94,20 @@ def infinite_horizon_filter(
             solver=solver,
         )
 
+    A_dense = _materialise(transition)
+    H_dense = _materialise(obs_model)
+    Q_dense = _materialise(process_noise)
+    R_dense = _materialise(obs_noise)
+
     P_inf = dare_result.P_inf  # (N, N)
     K_inf = dare_result.K_inf  # (N, M)
     T = observations.shape[0]
-    M = obs_model.shape[0]
-    N = transition.shape[0]
+    M = observations.shape[-1]
+    N = A_dense.shape[0]
 
     # Precompute steady-state quantities
-    P_pred_inf = transition @ P_inf @ transition.T + process_noise  # (N, N)
-    S_inf = obs_model @ P_pred_inf @ obs_model.T + obs_noise  # (M, M)
+    P_pred_inf = A_dense @ P_inf @ A_dense.T + Q_dense  # (N, N)
+    S_inf = H_dense @ P_pred_inf @ H_dense.T + R_dense  # (M, M)
     L_S = cholesky(  # (M, M)
         lx.MatrixLinearOperator(S_inf, lx.positive_semidefinite_tag)
     ).as_matrix()
@@ -107,13 +118,13 @@ def infinite_horizon_filter(
 
     # Steady-state filtered covariance: P_filt = (I − K∞ H) P⁻pred
     I_N = jnp.eye(N)
-    P_filt_inf = (I_N - K_inf @ obs_model) @ P_pred_inf  # (N, N)
+    P_filt_inf = (I_N - K_inf @ H_dense) @ P_pred_inf  # (N, N)
 
     def step(carry, y_t):
         x_filt, ll = carry
 
-        x_pred = transition @ x_filt  # (N,)
-        v = y_t - obs_model @ x_pred  # (M,)  innovation
+        x_pred = _matvec(transition, x_filt)  # (N,)
+        v = y_t - _matvec(obs_model, x_pred)  # (M,)  innovation
         x_filt_new = x_pred + K_inf @ v  # (N,)
 
         # Log-likelihood increment (reuse precomputed Cholesky L_S)
@@ -146,9 +157,9 @@ def infinite_horizon_filter(
 
 def infinite_horizon_smoother(
     filter_state: InfiniteHorizonState,
-    transition: Float[Array, "N N"],
+    transition: Float[Array, "N N"] | lx.AbstractLinearOperator,
     dare_result: DAREResult,
-    process_noise: Float[Array, "N N"],
+    process_noise: Float[Array, "N N"] | lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
 ) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
@@ -162,9 +173,9 @@ def infinite_horizon_smoother(
 
     Args:
         filter_state: Output of ``infinite_horizon_filter``.
-        transition: State transition matrix A, shape ``(N, N)``.
+        transition: State transition matrix or operator, shape ``(N, N)``.
         dare_result: DARE result used in the filter.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
+        process_noise: Process noise covariance or operator, shape ``(N, N)``.
         solver: Optional solver strategy for structured linear algebra.
             When ``None``, falls back to structural dispatch.
 
@@ -172,12 +183,14 @@ def infinite_horizon_smoother(
         Tuple ``(smoothed_means, smoothed_covs)`` with shapes
         ``(T, N)`` and ``(T, N, N)``.
     """
+    A_dense = _materialise(transition)
+    Q_dense = _materialise(process_noise)
     P_inf = dare_result.P_inf  # (N, N)
-    P_pred_inf = transition @ P_inf @ transition.T + process_noise  # (N, N)
+    P_pred_inf = A_dense @ P_inf @ A_dense.T + Q_dense  # (N, N)
 
     # Steady-state smoother gain: G∞ = P∞ Aᵀ P⁻pred⁻¹
     P_pred_inf_op = lx.MatrixLinearOperator(P_pred_inf, lx.positive_semidefinite_tag)
-    G_inf = solve_rows(P_pred_inf_op, P_inf @ transition.T, solver=solver)  # (N, N)
+    G_inf = solve_rows(P_pred_inf_op, P_inf @ A_dense.T, solver=solver)  # (N, N)
 
     # Solve discrete Lyapunov equation:
     # P_smooth = P∞ + G∞ (P_smooth − P⁻pred) G∞ᵀ

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -60,9 +60,11 @@ def kalman_filter(
     **Operator inputs** (lineax ``BlockDiag`` / ``Kronecker`` /
     ``DiagonalLinearOperator`` / ``MaskedOperator`` / etc.) are accepted
     in the **time-invariant** signature only. The structural matvec
-    (``A @ x``, ``H @ x``) runs through the operator's ``mv``; the
-    sandwiches ``A P A^T`` / ``H P H^T`` materialise once outside the
-    scan.
+    (``A @ x``, ``H @ x``) runs through the operator's ``mv``;
+    operator-typed ``Q`` / ``R`` are materialised to dense arrays once
+    outside the scan (the per-step sandwiches ``A P A^T`` / ``H P H^T``
+    themselves run inside the scan because they depend on the evolving
+    ``P_filt``).
 
     Args:
         transition: State transition matrix ``A``. Shape ``(N, N)``,
@@ -117,27 +119,32 @@ def kalman_filter(
         x_pred = A_op.mv(x_filt) if A_op is not None else A_t @ x_filt
         P_pred = A_t @ P_filt @ A_t.T + Q_t
 
-        # --- Update ---
-        v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
-        S = H_t @ P_pred @ H_t.T + R_t  # innovation cov
-        S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
+        # --- Update (gated by mask via lax.cond so the predict-only
+        #             branch evaluates neither the update arithmetic
+        #             nor produces gradients for the dropped path). ---
+        def _do_update(_):
+            v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
+            S = H_t @ P_pred @ H_t.T + R_t
+            S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
 
-        # Kalman gain: K = P_pred Hᵀ S⁻¹
-        PHt = P_pred @ H_t.T  # (N, M)
-        K = solve_rows(S_op, PHt, solver=solver)  # (N, M)
+            PHt = P_pred @ H_t.T  # (N, M)
+            K = solve_rows(S_op, PHt, solver=solver)  # (N, M)
 
-        x_updated = x_pred + K @ v
-        P_updated = P_pred - K @ S @ K.T
+            x_upd = x_pred + K @ v
+            P_upd = P_pred - K @ S @ K.T
 
-        # Log-likelihood increment
-        Sinv_v = dispatch_solve(S_op, v, solver)
-        ld = dispatch_logdet(S_op, solver)
-        ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
+            Sinv_v = dispatch_solve(S_op, v, solver)
+            ld = dispatch_logdet(S_op, solver)
+            ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
+            return x_upd, P_upd, ll_inc
 
-        # Mask: select between (predict-and-update) and (predict-only).
-        x_filt_new = jnp.where(mask_t, x_updated, x_pred)
-        P_filt_new = jnp.where(mask_t, P_updated, P_pred)
-        ll_new = ll + jnp.where(mask_t, ll_inc, jnp.array(0.0))
+        def _skip_update(_):
+            return x_pred, P_pred, jnp.array(0.0)
+
+        x_filt_new, P_filt_new, ll_inc = jax.lax.cond(
+            mask_t, _do_update, _skip_update, operand=None
+        )
+        ll_new = ll + ll_inc
 
         carry_new = (x_filt_new, P_filt_new, ll_new)
         outputs = (x_filt_new, P_filt_new, x_pred, P_pred)

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -6,9 +6,10 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from jaxtyping import Array, Float
+from jaxtyping import Array, Bool, Float
 
 from gaussx._linalg._linalg import solve_rows
+from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._dispatch import dispatch_logdet, dispatch_solve
 
@@ -32,73 +33,119 @@ class FilterState(eqx.Module):
 
 
 def kalman_filter(
-    transition: Float[Array, "N N"],
-    obs_model: Float[Array, "M N"],
-    process_noise: Float[Array, "N N"],
-    obs_noise: Float[Array, "M M"],
+    transition: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    obs_model: Float[Array, "*T M N"] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    obs_noise: Float[Array, "*T M M"] | lx.AbstractLinearOperator,
     observations: Float[Array, "T M"],
     init_mean: Float[Array, " N"],
     init_cov: Float[Array, "N N"],
     *,
+    mask: Bool[Array, " T"] | None = None,
     solver: AbstractSolverStrategy | None = None,
 ) -> FilterState:
-    """Kalman filter forward pass via ``jax.lax.scan``.
+    r"""Kalman filter forward pass via ``jax.lax.scan``.
 
-    Implements the standard predict-update cycle for a linear-Gaussian
-    state-space model::
+    Implements the predict-update cycle for a (possibly time-varying)
+    linear-Gaussian state-space model::
 
-        x_t = A @ x_{t-1} + q_t,   q_t ~ N(0, Q)
-        y_t = H @ x_t + r_t,        r_t ~ N(0, R)
+        x_t = A_t @ x_{t-1} + q_t,   q_t ~ N(0, Q_t)
+        y_t = H_t @ x_t + r_t,        r_t ~ N(0, R_t)
+
+    **Time-invariant inputs** (single ``(N, N)`` / ``(M, N)`` etc.) are
+    automatically broadcast along the time axis. **Time-varying inputs**
+    are passed as ``(T, …)`` stacks (e.g. from
+    :meth:`~gaussx.SDEKernel.discretise_sequence`).
+
+    **Operator inputs** (lineax ``BlockDiag`` / ``Kronecker`` /
+    ``DiagonalLinearOperator`` / ``MaskedOperator`` / etc.) are accepted
+    in the **time-invariant** signature only. The structural matvec
+    (``A @ x``, ``H @ x``) runs through the operator's ``mv``; the
+    sandwiches ``A P A^T`` / ``H P H^T`` materialise once outside the
+    scan.
 
     Args:
-        transition: State transition matrix A, shape ``(N, N)``.
-        obs_model: Observation matrix H, shape ``(M, N)``.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
-        obs_noise: Observation noise covariance R, shape ``(M, M)``.
-        observations: Observed data y, shape ``(T, M)``.
-        init_mean: Initial state mean x0, shape ``(N,)``.
-        init_cov: Initial state covariance P0, shape ``(N, N)``.
+        transition: State transition matrix ``A``. Shape ``(N, N)``,
+            ``(T, N, N)``, or :class:`lineax.AbstractLinearOperator`.
+        obs_model: Observation matrix ``H``. Shape ``(M, N)``,
+            ``(T, M, N)``, or operator.
+        process_noise: Process noise covariance ``Q``. Shape ``(N, N)``,
+            ``(T, N, N)``, or operator.
+        obs_noise: Observation noise covariance ``R``. Shape ``(M, M)``,
+            ``(T, M, M)``, or operator.
+        observations: Observed data, shape ``(T, M)``.
+        init_mean: Initial state mean, shape ``(N,)``.
+        init_cov: Initial state covariance, shape ``(N, N)``.
+        mask: Optional per-step boolean mask, shape ``(T,)``. ``True``
+            (or ``1``) runs the full predict + update step; ``False``
+            (or ``0``) runs the predict step only and skips the
+            log-likelihood contribution. Defaults to all-True. Useful
+            for prediction on merged train/test grids.
         solver: Optional solver strategy. When ``None``, uses
             structural dispatch.
+
+    Raises:
+        TypeError: If operator-typed inputs are mixed with 3D ``(T, …)``
+            arrays. Operator inputs must come from the time-invariant
+            signature (per-step structured stacks are not supported;
+            pass dense ``(T, …)`` arrays for the time-varying path).
 
     Returns:
         A ``FilterState`` with filtered/predicted means, covariances,
         and total log-likelihood.
     """
-    M = obs_model.shape[0]
+    M = observations.shape[-1]
+    T = observations.shape[0]
     log_2pi = jnp.log(2.0 * jnp.pi)
 
-    def step(carry, y_t):
+    A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
+        transition, obs_model, process_noise, obs_noise, T=T, mask=mask
+    )
+
+    # Closure-friendly matvec: when an operator is supplied, prefer its
+    # structural ``mv`` over the dense ``A @ x``. Otherwise the
+    # broadcast 3D array contains ``A_seq[t]`` for each step.
+    A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
+    H_op = obs_model if isinstance(obs_model, lx.AbstractLinearOperator) else None
+
+    def step(carry, inputs):
         x_filt, P_filt, ll = carry
+        A_t, H_t, Q_t, R_t, y_t, mask_t = inputs
 
         # --- Predict ---
-        x_pred = transition @ x_filt
-        P_pred = transition @ P_filt @ transition.T + process_noise
+        # Structural matvec when an operator was supplied; dense matmul otherwise.
+        x_pred = A_op.mv(x_filt) if A_op is not None else A_t @ x_filt
+        P_pred = A_t @ P_filt @ A_t.T + Q_t
 
         # --- Update ---
-        v = y_t - obs_model @ x_pred  # innovation
-        S = obs_model @ P_pred @ obs_model.T + obs_noise  # innovation cov
+        v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
+        S = H_t @ P_pred @ H_t.T + R_t  # innovation cov
         S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
 
         # Kalman gain: K = P_pred Hᵀ S⁻¹
-        PHt = P_pred @ obs_model.T  # (N, M)
+        PHt = P_pred @ H_t.T  # (N, M)
         K = solve_rows(S_op, PHt, solver=solver)  # (N, M)
 
-        x_filt_new = x_pred + K @ v
-        P_filt_new = P_pred - K @ S @ K.T
+        x_updated = x_pred + K @ v
+        P_updated = P_pred - K @ S @ K.T
 
         # Log-likelihood increment
         Sinv_v = dispatch_solve(S_op, v, solver)
         ld = dispatch_logdet(S_op, solver)
         ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
 
-        carry_new = (x_filt_new, P_filt_new, ll + ll_inc)
+        # Mask: select between (predict-and-update) and (predict-only).
+        x_filt_new = jnp.where(mask_t, x_updated, x_pred)
+        P_filt_new = jnp.where(mask_t, P_updated, P_pred)
+        ll_new = ll + jnp.where(mask_t, ll_inc, jnp.array(0.0))
+
+        carry_new = (x_filt_new, P_filt_new, ll_new)
         outputs = (x_filt_new, P_filt_new, x_pred, P_pred)
         return carry_new, outputs
 
     init_carry = (init_mean, init_cov, jnp.array(0.0))
     final_carry, (f_means, f_covs, p_means, p_covs) = jax.lax.scan(
-        step, init_carry, observations
+        step, init_carry, (A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
     )
 
     return FilterState(
@@ -112,32 +159,56 @@ def kalman_filter(
 
 def rts_smoother(
     filter_state: FilterState,
-    transition: Float[Array, "N N"],
-    process_noise: Float[Array, "N N"],
+    transition: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
 ) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
     """Rauch-Tung-Striebel backward smoother.
 
+    Accepts the same time-invariant / time-varying / operator forms for
+    ``transition`` and ``process_noise`` as :func:`kalman_filter`. When
+    a step was masked off in the filter (``mask[t] == 0``), the
+    smoother formula degenerates harmlessly because filtered ==
+    predicted at that step.
+
     Args:
-        filter_state: Output of ``kalman_filter``.
-        transition: State transition matrix A, shape ``(N, N)``.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
-        solver: Optional solver strategy. When ``None``, uses
-            structural dispatch.
+        filter_state: Output of :func:`kalman_filter`.
+        transition: State transition matrix or operator.
+        process_noise: Process noise covariance or operator. (Not
+            currently used by the standard RTS recurrence — kept for
+            API symmetry with :func:`kalman_filter`.)
+        solver: Optional solver strategy.
 
     Returns:
-        Tuple ``(smoothed_means, smoothed_covs)`` with shapes
-        ``(T, N)`` and ``(T, N, N)``.
+        Tuple ``(smoothed_means, smoothed_covs)``.
     """
+    del process_noise  # not used in the standard RTS recurrence
+
+    T = filter_state.filtered_means.shape[0]
+
+    # Materialise once outside the scan for the sandwich; matvec stays
+    # structural via the operator's mv.
+    A_dense = _materialise(transition)
+    A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
+    if A_dense.ndim == 2:
+        A_seq = jnp.broadcast_to(A_dense, (T, *A_dense.shape))
+    elif A_dense.ndim == 3:
+        if A_op is not None:
+            raise TypeError(
+                "Operator-typed transition cannot have a leading time axis."
+            )
+        A_seq = A_dense
+    else:
+        raise ValueError(f"transition must have ndim 2 or 3, got {A_dense.ndim}.")
 
     def step(carry, inputs):
         x_smooth, P_smooth = carry
-        x_filt, P_filt, x_pred, P_pred = inputs
+        x_filt, P_filt, x_pred, P_pred, A_next = inputs
 
-        # Smoother gain: G = P_filt Aᵀ P⁻pred⁻¹
+        # Smoother gain: G = P_filt A_{t+1}^T P_pred_{t+1}^{-1}
         P_pred_op = lx.MatrixLinearOperator(P_pred, lx.positive_semidefinite_tag)
-        G = P_filt @ transition.T  # (N, N)
+        G = P_filt @ A_next.T  # (N, N)
         G = solve_rows(P_pred_op, G, solver=solver)  # (N, N)
 
         x_smooth_new = x_filt + G @ (x_smooth - x_pred)
@@ -145,23 +216,25 @@ def rts_smoother(
 
         return (x_smooth_new, P_smooth_new), (x_smooth_new, P_smooth_new)
 
-    T = filter_state.filtered_means.shape[0]
     init_carry = (
         filter_state.filtered_means[T - 1],
         filter_state.filtered_covs[T - 1],
     )
 
-    # Reverse the sequences for backward pass (exclude last time step)
+    # Reverse the sequences for backward pass (exclude last time step).
+    # ``A_next[t]`` is the transition that maps step ``t`` to step ``t+1``,
+    # i.e. ``A_seq[t+1]``.
     inputs = (
         filter_state.filtered_means[:-1][::-1],
         filter_state.filtered_covs[:-1][::-1],
         filter_state.predicted_means[1:][::-1],
         filter_state.predicted_covs[1:][::-1],
+        A_seq[1:][::-1],
     )
 
     _, (s_means_rev, s_covs_rev) = jax.lax.scan(step, init_carry, inputs)
 
-    # Reverse back and prepend last filtered state
+    # Reverse back and prepend last filtered state.
     s_means = jnp.concatenate(
         [s_means_rev[::-1], filter_state.filtered_means[T - 1 :]], axis=0
     )
@@ -191,9 +264,9 @@ def kalman_gain(
     Returns:
         Kalman gain matrix of shape ``(N, M)``.
     """
-    P_mat = P.as_matrix()
-    H_mat = H.as_matrix()
-    R_mat = R.as_matrix()
+    P_mat = _materialise(P)
+    H_mat = _materialise(H)
+    R_mat = _materialise(R)
 
     S = H_mat @ P_mat @ H_mat.T + R_mat  # (M, M)
     S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -74,30 +74,37 @@ def parallel_kalman_filter(
         x_pred = A_op.mv(x_filt) if A_op is not None else A_t @ x_filt
         P_pred = A_t @ P_filt @ A_t.T + Q_t
 
-        v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
-        S = H_t @ P_pred @ H_t.T + R_t
-        S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
+        # Update gated by mask via ``lax.cond`` — the predict-only
+        # branch skips the Cholesky / cho_solve / logdet entirely so
+        # masked timesteps don't perform the expensive update work and
+        # don't leak gradients through the dropped path.
+        def _do_update(_):
+            v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
+            S = H_t @ P_pred @ H_t.T + R_t
+            S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
 
-        # In the default (no custom solver) path, factor S exactly once
-        # via Cholesky and reuse it for the gain, log-det, and the
-        # quadratic term — avoiding three independent factorizations.
-        if solver is None:
-            L_S = cholesky(S_op).as_matrix()
-            K = jax.scipy.linalg.cho_solve((L_S, True), H_t @ P_pred).T
-            Sinv_v = jax.scipy.linalg.cho_solve((L_S, True), v)
-            ld = cholesky_logdet(L_S)
-        else:
-            K = solve_matrix(S_op, H_t @ P_pred, solver=solver).T
-            Sinv_v = dispatch_solve(S_op, v, solver)
-            ld = dispatch_logdet(S_op, solver)
+            if solver is None:
+                L_S = cholesky(S_op).as_matrix()
+                K = jax.scipy.linalg.cho_solve((L_S, True), H_t @ P_pred).T
+                Sinv_v = jax.scipy.linalg.cho_solve((L_S, True), v)
+                ld = cholesky_logdet(L_S)
+            else:
+                K = solve_matrix(S_op, H_t @ P_pred, solver=solver).T
+                Sinv_v = dispatch_solve(S_op, v, solver)
+                ld = dispatch_logdet(S_op, solver)
 
-        x_updated = x_pred + K @ v
-        P_updated = P_pred - K @ S @ K.T
-        ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
+            x_upd = x_pred + K @ v
+            P_upd = P_pred - K @ S @ K.T
+            ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
+            return x_upd, P_upd, ll_inc
 
-        x_new = jnp.where(mask_t, x_updated, x_pred)
-        P_new = jnp.where(mask_t, P_updated, P_pred)
-        ll_new = ll + jnp.where(mask_t, ll_inc, jnp.array(0.0))
+        def _skip_update(_):
+            return x_pred, P_pred, jnp.array(0.0)
+
+        x_new, P_new, ll_inc = jax.lax.cond(
+            mask_t, _do_update, _skip_update, operand=None
+        )
+        ll_new = ll + ll_inc
 
         return (x_new, P_new, ll_new), (x_new, P_new, x_pred, P_pred)
 

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -6,78 +6,104 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg
 import lineax as lx
-from jaxtyping import Array, Float
+from jaxtyping import Array, Bool, Float
 
 from gaussx._linalg._linalg import solve_matrix, solve_rows
 from gaussx._primitives._cholesky import cholesky
 from gaussx._primitives._logdet import cholesky_logdet
 from gaussx._ssm._kalman import FilterState
+from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._dispatch import dispatch_logdet, dispatch_solve
 
 
 def parallel_kalman_filter(
-    transition: Float[Array, "N N"],
-    obs_model: Float[Array, "M N"],
-    process_noise: Float[Array, "N N"],
-    obs_noise: Float[Array, "M M"],
+    transition: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    obs_model: Float[Array, "*T M N"] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    obs_noise: Float[Array, "*T M M"] | lx.AbstractLinearOperator,
     observations: Float[Array, "T M"],
     init_mean: Float[Array, " N"],
     init_cov: Float[Array, "N N"],
     *,
+    mask: Bool[Array, " T"] | None = None,
     solver: AbstractSolverStrategy | None = None,
 ) -> FilterState:
     """Kalman filter with dense array operations via ``jax.lax.scan``.
 
-    Same interface as ``kalman_filter`` but operates on raw JAX arrays
-    instead of lineax operators, avoiding per-step operator construction
-    overhead. Faster on GPU/TPU for long time series.
+    Same generalised contract as :func:`gaussx.kalman_filter`:
+
+    - Time-invariant inputs (single ``(N, N)`` etc.) auto-broadcast along ``T``.
+    - Time-varying inputs accepted as ``(T, …)`` arrays.
+    - Operator-typed inputs accepted in the time-invariant signature only.
+    - Optional ``mask`` skips the update step (predict only) per timestep.
 
     Args:
-        transition: State transition matrix A, shape ``(N, N)``.
-        obs_model: Observation matrix H, shape ``(M, N)``.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
-        obs_noise: Observation noise covariance R, shape ``(M, M)``.
-        observations: Observed data y, shape ``(T, M)``.
-        init_mean: Initial state mean x0, shape ``(N,)``.
-        init_cov: Initial state covariance P0, shape ``(N, N)``.
+        transition: State transition matrix or operator.
+        obs_model: Observation matrix or operator.
+        process_noise: Process noise covariance or operator.
+        obs_noise: Observation noise covariance or operator.
+        observations: Observed data, shape ``(T, M)``.
+        init_mean: Initial state mean, shape ``(N,)``.
+        init_cov: Initial state covariance, shape ``(N, N)``.
+        mask: Optional ``(T,)`` boolean mask. ``False`` runs predict-only
+            and contributes 0 to the log-likelihood. Defaults to all-True.
         solver: Optional solver strategy for structured linear algebra.
-            When ``None``, falls back to structural dispatch.
+            When ``None``, factors ``S`` once via Cholesky and reuses
+            for the gain, log-det, and quadratic term.
 
     Returns:
         A ``FilterState`` with filtered/predicted means, covariances,
         and total log-likelihood.
     """
-    M = obs_model.shape[0]
+    M = observations.shape[-1]
+    T = observations.shape[0]
     log_2pi = jnp.log(2.0 * jnp.pi)
 
-    def step(carry, y_t):
+    A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
+        transition, obs_model, process_noise, obs_noise, T=T, mask=mask
+    )
+
+    A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
+    H_op = obs_model if isinstance(obs_model, lx.AbstractLinearOperator) else None
+
+    def step(carry, inputs):
         x_filt, P_filt, ll = carry
-        x_pred = transition @ x_filt
-        P_pred = transition @ P_filt @ transition.T + process_noise
-        v = y_t - obs_model @ x_pred
-        S = obs_model @ P_pred @ obs_model.T + obs_noise
+        A_t, H_t, Q_t, R_t, y_t, mask_t = inputs
+
+        x_pred = A_op.mv(x_filt) if A_op is not None else A_t @ x_filt
+        P_pred = A_t @ P_filt @ A_t.T + Q_t
+
+        v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
+        S = H_t @ P_pred @ H_t.T + R_t
         S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
+
         # In the default (no custom solver) path, factor S exactly once
         # via Cholesky and reuse it for the gain, log-det, and the
         # quadratic term — avoiding three independent factorizations.
         if solver is None:
             L_S = cholesky(S_op).as_matrix()
-            K = jax.scipy.linalg.cho_solve((L_S, True), obs_model @ P_pred).T
+            K = jax.scipy.linalg.cho_solve((L_S, True), H_t @ P_pred).T
             Sinv_v = jax.scipy.linalg.cho_solve((L_S, True), v)
             ld = cholesky_logdet(L_S)
         else:
-            K = solve_matrix(S_op, obs_model @ P_pred, solver=solver).T
+            K = solve_matrix(S_op, H_t @ P_pred, solver=solver).T
             Sinv_v = dispatch_solve(S_op, v, solver)
             ld = dispatch_logdet(S_op, solver)
-        x_new = x_pred + K @ v
-        P_new = P_pred - K @ S @ K.T
+
+        x_updated = x_pred + K @ v
+        P_updated = P_pred - K @ S @ K.T
         ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
-        return (x_new, P_new, ll + ll_inc), (x_new, P_new, x_pred, P_pred)
+
+        x_new = jnp.where(mask_t, x_updated, x_pred)
+        P_new = jnp.where(mask_t, P_updated, P_pred)
+        ll_new = ll + jnp.where(mask_t, ll_inc, jnp.array(0.0))
+
+        return (x_new, P_new, ll_new), (x_new, P_new, x_pred, P_pred)
 
     init = (init_mean, init_cov, jnp.array(0.0))
     (_, _, ll), (f_means, f_covs, p_means, p_covs) = jax.lax.scan(
-        step, init, observations
+        step, init, (A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
     )
     return FilterState(
         filtered_means=f_means,
@@ -90,8 +116,8 @@ def parallel_kalman_filter(
 
 def parallel_rts_smoother(
     filter_state: FilterState,
-    transition: Float[Array, "N N"],
-    process_noise: Float[Array, "N N"],
+    transition: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, "*T N N"] | lx.AbstractLinearOperator,
     *,
     solver: AbstractSolverStrategy | None = None,
 ) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
@@ -99,32 +125,48 @@ def parallel_rts_smoother(
 
     The previous associative-scan formulation was not algebraically
     equivalent to the standard RTS recurrence. This implementation keeps
-    the public API but uses a validated dense backward scan.
+    the public API but uses a validated dense backward scan. Accepts the
+    same time-invariant / time-varying / operator forms for
+    ``transition`` as :func:`parallel_kalman_filter`.
 
     Args:
-        filter_state: Output of ``kalman_filter`` or
-            ``parallel_kalman_filter``.
-        transition: State transition matrix A, shape ``(N, N)``.
-        process_noise: Process noise covariance Q, shape ``(N, N)``.
-        solver: Optional solver strategy for structured linear algebra.
-            When ``None``, falls back to structural dispatch.
+        filter_state: Output of :func:`kalman_filter` or
+            :func:`parallel_kalman_filter`.
+        transition: State transition matrix or operator.
+        process_noise: Process noise covariance or operator. (Not used
+            by the RTS recurrence — kept for API symmetry.)
+        solver: Optional solver strategy.
 
     Returns:
         Tuple ``(smoothed_means, smoothed_covs)``.
     """
     del process_noise
 
+    T = filter_state.filtered_means.shape[0]
+
+    A_dense = _materialise(transition)
+    A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
+    if A_dense.ndim == 2:
+        A_seq = jnp.broadcast_to(A_dense, (T, *A_dense.shape))
+    elif A_dense.ndim == 3:
+        if A_op is not None:
+            raise TypeError(
+                "Operator-typed transition cannot have a leading time axis."
+            )
+        A_seq = A_dense
+    else:
+        raise ValueError(f"transition must have ndim 2 or 3, got {A_dense.ndim}.")
+
     def step(carry, inputs):
         x_smooth, P_smooth = carry
-        x_filt, P_filt, x_pred, P_pred = inputs
+        x_filt, P_filt, x_pred, P_pred, A_next = inputs
 
         P_pred_op = lx.MatrixLinearOperator(P_pred, lx.positive_semidefinite_tag)
-        G = solve_rows(P_pred_op, P_filt @ transition.T, solver=solver)
+        G = solve_rows(P_pred_op, P_filt @ A_next.T, solver=solver)
         x_smooth_new = x_filt + G @ (x_smooth - x_pred)
         P_smooth_new = P_filt + G @ (P_smooth - P_pred) @ G.T
         return (x_smooth_new, P_smooth_new), (x_smooth_new, P_smooth_new)
 
-    T = filter_state.filtered_means.shape[0]
     init_carry = (
         filter_state.filtered_means[T - 1],
         filter_state.filtered_covs[T - 1],
@@ -134,6 +176,7 @@ def parallel_rts_smoother(
         filter_state.filtered_covs[:-1][::-1],
         filter_state.predicted_means[1:][::-1],
         filter_state.predicted_covs[1:][::-1],
+        A_seq[1:][::-1],
     )
     _, (s_means_rev, s_covs_rev) = jax.lax.scan(step, init_carry, inputs)
 

--- a/src/gaussx/_ssm/_utils.py
+++ b/src/gaussx/_ssm/_utils.py
@@ -1,0 +1,126 @@
+"""Shared internal helpers for SSM operators.
+
+These let the Kalman family accept ``Float[Array, ...]`` *or*
+``lineax.AbstractLinearOperator`` for ``transition``, ``obs_model``,
+``process_noise``, ``obs_noise`` while keeping the structural matvec hot
+path on the operator side and dropping to dense at the (one-shot)
+sandwich sites.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from jaxtyping import Array, Bool, Float
+
+
+def _materialise(
+    op_or_array: Float[Array, ...] | lx.AbstractLinearOperator,
+) -> Float[Array, ...]:
+    """Return a dense array view of an operator or pass arrays through.
+
+    Used at sandwich / additive sites (``A P A^T``, ``H P H^T``,
+    ``+ Q``, ``+ R``) where lineax operators don't compose without one
+    side being materialised. Structural advantages are preserved on
+    *linear* operations (matvec, downstream solve / logdet through
+    ``solver=``).
+    """
+    if isinstance(op_or_array, lx.AbstractLinearOperator):
+        return op_or_array.as_matrix()
+    return op_or_array
+
+
+def _matvec(
+    op_or_array: Float[Array, "M N"] | lx.AbstractLinearOperator,
+    vector: Float[Array, " N"],
+) -> Float[Array, " M"]:
+    """Apply ``A x`` whether ``A`` is a raw array or a lineax operator.
+
+    Preserves structural matvec for ``BlockDiag`` / ``Kronecker`` /
+    ``MaskedOperator`` / etc.
+    """
+    if isinstance(op_or_array, lx.AbstractLinearOperator):
+        return op_or_array.mv(vector)
+    return op_or_array @ vector
+
+
+def _is_operator_input(value: object) -> bool:
+    """True iff *value* is a lineax operator (and so signals TI mode)."""
+    return isinstance(value, lx.AbstractLinearOperator)
+
+
+def _normalise_tv_inputs(
+    transition: Float[Array, ...] | lx.AbstractLinearOperator,
+    obs_model: Float[Array, ...] | lx.AbstractLinearOperator,
+    process_noise: Float[Array, ...] | lx.AbstractLinearOperator,
+    obs_noise: Float[Array, ...] | lx.AbstractLinearOperator,
+    *,
+    T: int,
+    mask: Bool[Array, " T"] | None,
+) -> tuple[
+    Float[Array, "T N N"],
+    Float[Array, "T M N"],
+    Float[Array, "T N N"],
+    Float[Array, "T M M"],
+    Bool[Array, " T"],
+    bool,
+]:
+    """Normalise the four shape-bearing args + ``mask`` for the scan body.
+
+    Returns
+    -------
+    A_seq, H_seq, Q_seq, R_seq : ``(T, …)`` arrays ready to scan over.
+    mask_seq : ``(T,)`` boolean array (defaults to all-True).
+    is_time_invariant : True iff every shape-bearing input is either an
+        operator or a 2D array (and was broadcast to ``(T, …)`` here).
+
+    Raises
+    ------
+    TypeError when operator-form inputs are mixed with 3D ``(T, …)``
+    arrays — that path is intentionally not supported.
+    """
+    has_operator = any(
+        _is_operator_input(x) for x in (transition, obs_model, process_noise, obs_noise)
+    )
+    has_3d_array = any(
+        isinstance(x, jax.Array) and x.ndim == 3
+        for x in (transition, obs_model, process_noise, obs_noise)
+    )
+    if has_operator and has_3d_array:
+        raise TypeError(
+            "Time-varying (3D) inputs cannot be mixed with operator-typed "
+            "(lineax) inputs. Operator form is supported only in the "
+            "time-invariant signature; pass dense (T, ...) stacks for the "
+            "TV path."
+        )
+
+    A_dense = _materialise(transition)
+    H_dense = _materialise(obs_model)
+    Q_dense = _materialise(process_noise)
+    R_dense = _materialise(obs_noise)
+
+    def _broadcast_to_T(
+        x: Float[Array, ...], expected_ndim: int
+    ) -> Float[Array, ...]:
+        if x.ndim == expected_ndim - 1:
+            # 2D array → broadcast to (T, …)
+            return jnp.broadcast_to(x, (T, *x.shape))
+        if x.ndim == expected_ndim:
+            return x
+        raise ValueError(
+            f"Expected ndim {expected_ndim - 1} or {expected_ndim}, got "
+            f"{x.ndim} (shape={x.shape})."
+        )
+
+    A_seq = _broadcast_to_T(A_dense, expected_ndim=3)
+    H_seq = _broadcast_to_T(H_dense, expected_ndim=3)
+    Q_seq = _broadcast_to_T(Q_dense, expected_ndim=3)
+    R_seq = _broadcast_to_T(R_dense, expected_ndim=3)
+
+    if mask is None:
+        mask_seq = jnp.ones((T,), dtype=bool)
+    else:
+        mask_seq = jnp.asarray(mask, dtype=bool)
+
+    return A_seq, H_seq, Q_seq, R_seq, mask_seq, not has_3d_array

--- a/src/gaussx/_ssm/_utils.py
+++ b/src/gaussx/_ssm/_utils.py
@@ -9,7 +9,6 @@ sandwich sites.
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 import lineax as lx
 from jaxtyping import Array, Bool, Float
@@ -83,8 +82,10 @@ def _normalise_tv_inputs(
     has_operator = any(
         _is_operator_input(x) for x in (transition, obs_model, process_noise, obs_noise)
     )
+    # Detect 3D inputs across any array-like (jax.Array, numpy.ndarray,
+    # lists/tuples coerced through ``hasattr``) — not just ``jax.Array``.
     has_3d_array = any(
-        isinstance(x, jax.Array) and x.ndim == 3
+        not _is_operator_input(x) and getattr(x, "ndim", None) == 3
         for x in (transition, obs_model, process_noise, obs_noise)
     )
     if has_operator and has_3d_array:
@@ -100,9 +101,7 @@ def _normalise_tv_inputs(
     Q_dense = _materialise(process_noise)
     R_dense = _materialise(obs_noise)
 
-    def _broadcast_to_T(
-        x: Float[Array, ...], expected_ndim: int
-    ) -> Float[Array, ...]:
+    def _broadcast_to_T(x: Float[Array, ...], expected_ndim: int) -> Float[Array, ...]:
         if x.ndim == expected_ndim - 1:
             # 2D array → broadcast to (T, …)
             return jnp.broadcast_to(x, (T, *x.shape))
@@ -122,5 +121,15 @@ def _normalise_tv_inputs(
         mask_seq = jnp.ones((T,), dtype=bool)
     else:
         mask_seq = jnp.asarray(mask, dtype=bool)
+        # Allow scalar broadcast for ergonomic ``mask=True`` / ``mask=False``;
+        # otherwise require a 1D array of length T to give a clear error
+        # before the scan rather than a confusing tracing failure.
+        if mask_seq.ndim == 0:
+            mask_seq = jnp.broadcast_to(mask_seq, (T,))
+        elif mask_seq.shape != (T,):
+            raise ValueError(
+                f"mask must be a scalar or have shape ({T},); got shape "
+                f"{mask_seq.shape}."
+            )
 
     return A_seq, H_seq, Q_seq, R_seq, mask_seq, not has_3d_array

--- a/tests/ssm/test_dare.py
+++ b/tests/ssm/test_dare.py
@@ -77,3 +77,19 @@ class TestDARE:
         P_init = jnp.eye(D)
         result = dare(A, H, Q, R, P_init=P_init)
         assert result.converged
+
+
+def test_dare_obs_noise_diagonal_operator(getkey):
+    """dare with operator-typed R matches the array form."""
+    import lineax as lx
+
+    D, M = 3, 2
+    A = 0.9 * jnp.eye(D)
+    H = jax.random.normal(getkey(), (M, D)) * 0.5
+    Q = 0.1 * jnp.eye(D)
+    R_diag = jnp.array([0.3, 0.5])
+    R = jnp.diag(R_diag)
+    ref = dare(A, H, Q, R)
+    op = dare(A, H, Q, lx.DiagonalLinearOperator(R_diag))
+    assert jnp.allclose(ref.P_inf, op.P_inf, atol=1e-5)
+    assert jnp.allclose(ref.K_inf, op.K_inf, atol=1e-5)

--- a/tests/ssm/test_infinite_horizon_kalman.py
+++ b/tests/ssm/test_infinite_horizon_kalman.py
@@ -143,3 +143,21 @@ class TestInfiniteHorizonSmoother:
 
         s_means, _s_covs = smooth(filt)
         assert jnp.all(jnp.isfinite(s_means))
+
+
+def test_infinite_horizon_filter_obs_noise_diagonal_operator(getkey):
+    """infinite_horizon_filter with operator-typed R matches the array form."""
+    import lineax as lx
+
+    N, M, T = 3, 2, 8
+    A = 0.9 * jnp.eye(N)
+    H = jax.random.normal(getkey(), (M, N)) * 0.5
+    Q = 0.1 * jnp.eye(N)
+    R_diag = jnp.array([0.3, 0.5])
+    R = jnp.diag(R_diag)
+    obs = jax.random.normal(getkey(), (T, M))
+
+    ref = infinite_horizon_filter(A, H, Q, R, obs)
+    op = infinite_horizon_filter(A, H, Q, lx.DiagonalLinearOperator(R_diag), obs)
+    assert jnp.allclose(ref.filtered_means, op.filtered_means, atol=1e-5)
+    assert jnp.allclose(ref.log_likelihood, op.log_likelihood, atol=1e-4)

--- a/tests/ssm/test_kalman.py
+++ b/tests/ssm/test_kalman.py
@@ -344,3 +344,46 @@ def test_kalman_filter_tv_solver_matches_default(getkey):
 
     assert tree_allclose(default.filtered_means, dense.filtered_means, rtol=1e-5)
     assert tree_allclose(default.log_likelihood, dense.log_likelihood, rtol=1e-4)
+
+
+def test_mask_invalid_shape_raises(getkey):
+    """Wrong-shape mask must raise a clear ValueError before the scan."""
+    import pytest
+
+    N, M, T = 2, 1, 4
+    A = jnp.eye(N)
+    H = jnp.array([[1.0, 0.0]])
+    Q = 0.1 * jnp.eye(N)
+    R = 0.2 * jnp.eye(M)
+    y = jr.normal(getkey(), (T, M))
+    bad_mask = jnp.ones((T - 1,), dtype=bool)
+    with pytest.raises(ValueError, match=r"mask must be"):
+        kalman_filter(A, H, Q, R, y, jnp.zeros(N), jnp.eye(N), mask=bad_mask)
+
+
+def test_mask_scalar_broadcasts(getkey):
+    """Scalar mask should broadcast across T (ergonomic shortcut)."""
+    N, M, T = 2, 1, 4
+    A = 0.9 * jnp.eye(N)
+    H = jnp.array([[1.0, 0.0]])
+    Q = 0.1 * jnp.eye(N)
+    R = 0.2 * jnp.eye(M)
+    y = jr.normal(getkey(), (T, M))
+    full = kalman_filter(A, H, Q, R, y, jnp.zeros(N), jnp.eye(N), mask=jnp.array(True))
+    ref = kalman_filter(A, H, Q, R, y, jnp.zeros(N), jnp.eye(N))
+    assert tree_allclose(full.filtered_means, ref.filtered_means, rtol=1e-6)
+
+
+def test_mixed_numpy_3d_with_operator_raises(getkey):
+    """numpy.ndarray (not jax.Array) 3D stack must trigger the same TypeError."""
+    import numpy as np
+    import pytest
+
+    N, M, T = 2, 1, 4
+    A_seq_np = np.broadcast_to(0.9 * np.eye(N), (T, N, N))
+    H = jnp.array([[1.0, 0.0]])
+    Q_op = lx.DiagonalLinearOperator(jnp.array([0.1, 0.2]))
+    R = 0.2 * jnp.eye(M)
+    y = jr.normal(getkey(), (T, M))
+    with pytest.raises(TypeError, match="Time-varying"):
+        kalman_filter(A_seq_np, H, Q_op, R, y, jnp.zeros(N), jnp.eye(N))

--- a/tests/ssm/test_kalman.py
+++ b/tests/ssm/test_kalman.py
@@ -97,3 +97,250 @@ def test_kalman_gain_shape(getkey):
 
     K = kalman_gain(P, H, R)
     assert K.shape == (N, M)
+
+
+# ----------------------------------------------------------------
+# Operator-typed inputs (time-invariant)
+# ----------------------------------------------------------------
+
+
+class TestOperatorInputs:
+    def _model(self, getkey, N=3, M=2, T=8):
+        A = 0.9 * jnp.eye(N)
+        H = jr.normal(getkey(), (M, N))
+        Q = 0.1 * jnp.eye(N)
+        R_diag = jnp.array([0.3, 0.5])[:M]
+        R = jnp.diag(R_diag)
+        y = jr.normal(getkey(), (T, M))
+        return A, H, Q, R, R_diag, y, jnp.zeros(N), jnp.eye(N)
+
+    def test_obs_noise_diagonal_operator(self, getkey):
+        A, H, Q, R, R_diag, y, x0, P0 = self._model(getkey)
+        ref = kalman_filter(A, H, Q, R, y, x0, P0)
+        op = kalman_filter(A, H, Q, lx.DiagonalLinearOperator(R_diag), y, x0, P0)
+        assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+        assert tree_allclose(ref.filtered_covs, op.filtered_covs, rtol=1e-5)
+        assert tree_allclose(ref.log_likelihood, op.log_likelihood, rtol=1e-5)
+
+    def test_process_noise_diagonal_operator(self, getkey):
+        N, M, T = 3, 2, 6
+        A = 0.9 * jnp.eye(N)
+        H = jr.normal(getkey(), (M, N))
+        Q_diag = jnp.array([0.1, 0.2, 0.3])
+        Q = jnp.diag(Q_diag)
+        R = 0.5 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+        ref = kalman_filter(A, H, Q, R, y, x0, P0)
+        op = kalman_filter(A, H, lx.DiagonalLinearOperator(Q_diag), R, y, x0, P0)
+        assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+
+    def test_transition_block_diag_operator(self, getkey):
+        from gaussx import BlockDiag
+
+        # Block-diagonal A from two channels
+        A1 = 0.9 * jnp.eye(2)
+        A2 = 0.7 * jnp.eye(2)
+        A_dense = jnp.block([[A1, jnp.zeros((2, 2))], [jnp.zeros((2, 2)), A2]])
+        N = 4
+        M = 2
+        T = 6
+        H = jr.normal(getkey(), (M, N))
+        Q = 0.1 * jnp.eye(N)
+        R = 0.5 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+        ref = kalman_filter(A_dense, H, Q, R, y, x0, P0)
+        A_op = BlockDiag(lx.MatrixLinearOperator(A1), lx.MatrixLinearOperator(A2))
+        op = kalman_filter(A_op, H, Q, R, y, x0, P0)
+        assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+        assert tree_allclose(ref.log_likelihood, op.log_likelihood, rtol=1e-5)
+
+
+# ----------------------------------------------------------------
+# Time-varying inputs and mask
+# ----------------------------------------------------------------
+
+
+class TestTimeVarying:
+    def test_ti_broadcast_matches_ti_form(self, getkey):
+        """(N, N) inputs broadcast to (T, N, N) match the time-invariant call."""
+        N, M, T = 3, 2, 7
+        A = 0.9 * jnp.eye(N)
+        H = jr.normal(getkey(), (M, N))
+        Q = 0.1 * jnp.eye(N)
+        R = 0.5 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+        ref = kalman_filter(A, H, Q, R, y, x0, P0)
+
+        A_seq = jnp.broadcast_to(A, (T, N, N))
+        H_seq = jnp.broadcast_to(H, (T, M, N))
+        Q_seq = jnp.broadcast_to(Q, (T, N, N))
+        R_seq = jnp.broadcast_to(R, (T, M, M))
+        tv = kalman_filter(A_seq, H_seq, Q_seq, R_seq, y, x0, P0)
+
+        assert tree_allclose(ref.filtered_means, tv.filtered_means, rtol=1e-6)
+        assert tree_allclose(ref.filtered_covs, tv.filtered_covs, rtol=1e-6)
+        assert tree_allclose(ref.log_likelihood, tv.log_likelihood, rtol=1e-6)
+
+    def test_tv_per_step_matches_manual_loop(self, getkey):
+        """TV path with per-step matrices matches a hand-rolled loop."""
+        N, M, T = 2, 1, 5
+        # Random per-step (A_t, Q_t, H_t, R_t)
+        A_seq = jnp.stack(
+            [0.9 * jnp.eye(N) + 0.05 * jr.normal(getkey(), (N, N)) for _ in range(T)]
+        )
+        H_seq = jr.normal(getkey(), (T, M, N))
+        Q_seq = jnp.stack([0.1 * jnp.eye(N) for _ in range(T)])
+        R_seq = jnp.stack([0.5 * jnp.eye(M) for _ in range(T)])
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+        out = kalman_filter(A_seq, H_seq, Q_seq, R_seq, y, x0, P0)
+
+        # Manual reference
+        x, P = x0, P0
+        log_2pi = jnp.log(2.0 * jnp.pi)
+        ll = 0.0
+        for t in range(T):
+            x_pred = A_seq[t] @ x
+            P_pred = A_seq[t] @ P @ A_seq[t].T + Q_seq[t]
+            v = y[t] - H_seq[t] @ x_pred
+            S = H_seq[t] @ P_pred @ H_seq[t].T + R_seq[t]
+            S_inv = jnp.linalg.inv(S)
+            K = P_pred @ H_seq[t].T @ S_inv
+            x = x_pred + K @ v
+            P = P_pred - K @ S @ K.T
+            _, ld = jnp.linalg.slogdet(S)
+            ll = ll - 0.5 * (v @ S_inv @ v + ld + M * log_2pi)
+
+        assert tree_allclose(out.filtered_means[-1], x, atol=1e-5)
+        assert tree_allclose(out.filtered_covs[-1], P, atol=1e-5)
+        assert tree_allclose(out.log_likelihood, ll, atol=1e-4)
+
+    def test_mask_predict_only(self, getkey):
+        """Masked steps should run predict only and contribute 0 log-likelihood."""
+        N, M, T = 3, 2, 6
+        A = 0.95 * jnp.eye(N)
+        H = jr.normal(getkey(), (M, N))
+        Q = 0.05 * jnp.eye(N)
+        R = 0.3 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+        # Mask off steps 1 and 3
+        mask = jnp.array([True, False, True, False, True, True])
+        out = kalman_filter(A, H, Q, R, y, x0, P0, mask=mask)
+
+        # On masked steps, filtered == predicted.
+        idx = jnp.where(~mask)[0]
+        assert tree_allclose(
+            out.filtered_means[idx], out.predicted_means[idx], atol=1e-7
+        )
+        assert tree_allclose(out.filtered_covs[idx], out.predicted_covs[idx], atol=1e-7)
+
+    def test_mask_log_likelihood_matches_subset(self, getkey):
+        """LL with masked steps == LL of an unmasked filter run on the
+        observed-only timeline that a user would build manually."""
+        # We construct a setup where masked steps correspond to extra
+        # prediction steps; the LL should equal the unmasked filter.
+        N, M, T = 2, 1, 5
+        A = 0.9 * jnp.eye(N)
+        H = jnp.array([[1.0, 0.0]])
+        Q = 0.1 * jnp.eye(N)
+        R = 0.2 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+        mask = jnp.array([True, True, False, True, True])
+        out = kalman_filter(A, H, Q, R, y, x0, P0, mask=mask)
+
+        # Drop the masked step's contribution: it should be 0.
+        # The LL with mask must equal a hand-rolled filter that skips the
+        # update on that step.
+        x, P = x0, P0
+        log_2pi = jnp.log(2.0 * jnp.pi)
+        ll = 0.0
+        for t in range(T):
+            x_pred = A @ x
+            P_pred = A @ P @ A.T + Q
+            if mask[t]:
+                v = y[t] - H @ x_pred
+                S = H @ P_pred @ H.T + R
+                S_inv = jnp.linalg.inv(S)
+                K = P_pred @ H.T @ S_inv
+                x = x_pred + K @ v
+                P = P_pred - K @ S @ K.T
+                _, ld = jnp.linalg.slogdet(S)
+                ll = ll - 0.5 * (v @ S_inv @ v + ld + M * log_2pi)
+            else:
+                x = x_pred
+                P = P_pred
+
+        assert tree_allclose(out.log_likelihood, ll, atol=1e-5)
+
+    def test_mixed_tv_array_with_operator_raises(self, getkey):
+        """3D TV stack mixed with an operator should raise TypeError."""
+        import pytest
+
+        N, M, T = 2, 1, 4
+        A_seq = jnp.broadcast_to(0.9 * jnp.eye(N), (T, N, N))
+        H = jnp.array([[1.0, 0.0]])
+        Q_op = lx.DiagonalLinearOperator(jnp.array([0.1, 0.2]))
+        R = 0.2 * jnp.eye(M)
+        y = jr.normal(getkey(), (T, M))
+        with pytest.raises(TypeError, match="Time-varying"):
+            kalman_filter(A_seq, H, Q_op, R, y, jnp.zeros(N), jnp.eye(N))
+
+
+# ----------------------------------------------------------------
+# rts_smoother time-varying
+# ----------------------------------------------------------------
+
+
+def test_rts_smoother_tv(getkey):
+    """RTS smoother with TV transition matches manual recurrence."""
+    N, M, T = 2, 1, 6
+    A_seq = jnp.stack(
+        [0.9 * jnp.eye(N) + 0.02 * jr.normal(getkey(), (N, N)) for _ in range(T)]
+    )
+    H = jnp.array([[1.0, 0.0]])
+    Q = 0.05 * jnp.eye(N)
+    R = 0.2 * jnp.eye(M)
+    y = jr.normal(getkey(), (T, M))
+    x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+    state = kalman_filter(A_seq, H, Q, R, y, x0, P0)
+    s_means, s_covs = rts_smoother(state, A_seq, Q)
+
+    # Last smoothed = last filtered.
+    assert tree_allclose(s_means[-1], state.filtered_means[-1], rtol=1e-6)
+    assert tree_allclose(s_covs[-1], state.filtered_covs[-1], rtol=1e-6)
+
+
+# ----------------------------------------------------------------
+# solver= regression with TV path
+# ----------------------------------------------------------------
+
+
+def test_kalman_filter_tv_solver_matches_default(getkey):
+    """TV path with solver=DenseSolver() matches the default dispatch path."""
+    from gaussx import DenseSolver
+
+    N, M, T = 3, 2, 6
+    A = 0.9 * jnp.eye(N)
+    H = jr.normal(getkey(), (M, N))
+    Q = 0.1 * jnp.eye(N)
+    R = 0.5 * jnp.eye(M)
+    y = jr.normal(getkey(), (T, M))
+    x0, P0 = jnp.zeros(N), jnp.eye(N)
+    A_seq = jnp.broadcast_to(A, (T, N, N))
+
+    default = kalman_filter(A_seq, H, Q, R, y, x0, P0)
+    dense = kalman_filter(A_seq, H, Q, R, y, x0, P0, solver=DenseSolver())
+
+    assert tree_allclose(default.filtered_means, dense.filtered_means, rtol=1e-5)
+    assert tree_allclose(default.log_likelihood, dense.log_likelihood, rtol=1e-4)

--- a/tests/ssm/test_parallel_kalman.py
+++ b/tests/ssm/test_parallel_kalman.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import jax.random as jr
+import lineax as lx
 
 from gaussx import DenseSolver, FilterState, kalman_filter, rts_smoother
 from gaussx._ssm._parallel_kalman import (
@@ -114,3 +115,78 @@ def test_parallel_rts_with_dense_solver_matches_default(getkey):
 
     assert tree_allclose(dense_means, default_means, rtol=1e-5)
     assert tree_allclose(dense_covs, default_covs, rtol=1e-5)
+
+
+# ----------------------------------------------------------------
+# Operator-typed inputs (time-invariant)
+# ----------------------------------------------------------------
+
+
+def test_parallel_kf_obs_noise_diagonal_operator(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    obs = jr.normal(getkey(), (5, 2))
+    R_diag = jnp.diag(R)
+
+    ref = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
+    op = parallel_kalman_filter(A, H, Q, lx.DiagonalLinearOperator(R_diag), obs, x0, P0)
+    assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+    assert tree_allclose(ref.log_likelihood, op.log_likelihood, rtol=1e-5)
+
+
+def test_parallel_kf_transition_block_diag_operator(getkey):
+    from gaussx import BlockDiag
+
+    A1 = 0.9 * jnp.eye(2)
+    A2 = 0.7 * jnp.eye(2)
+    A_dense = jnp.block([[A1, jnp.zeros((2, 2))], [jnp.zeros((2, 2)), A2]])
+    N, M, T = 4, 2, 6
+    H = jr.normal(getkey(), (M, N))
+    Q = 0.1 * jnp.eye(N)
+    R = 0.5 * jnp.eye(M)
+    obs = jr.normal(getkey(), (T, M))
+    x0, P0 = jnp.zeros(N), jnp.eye(N)
+
+    ref = parallel_kalman_filter(A_dense, H, Q, R, obs, x0, P0)
+    A_op = BlockDiag(lx.MatrixLinearOperator(A1), lx.MatrixLinearOperator(A2))
+    op = parallel_kalman_filter(A_op, H, Q, R, obs, x0, P0)
+    assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+
+
+# ----------------------------------------------------------------
+# Time-varying inputs and mask
+# ----------------------------------------------------------------
+
+
+def test_parallel_kf_ti_broadcast_matches(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    T = 6
+    obs = jr.normal(getkey(), (T, 2))
+    ref = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
+    A_seq = jnp.broadcast_to(A, (T, *A.shape))
+    H_seq = jnp.broadcast_to(H, (T, *H.shape))
+    Q_seq = jnp.broadcast_to(Q, (T, *Q.shape))
+    R_seq = jnp.broadcast_to(R, (T, *R.shape))
+    tv = parallel_kalman_filter(A_seq, H_seq, Q_seq, R_seq, obs, x0, P0)
+    assert tree_allclose(ref.filtered_means, tv.filtered_means, rtol=1e-6)
+    assert tree_allclose(ref.log_likelihood, tv.log_likelihood, rtol=1e-6)
+
+
+def test_parallel_kf_mask_predict_only(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    T = 6
+    obs = jr.normal(getkey(), (T, 2))
+    mask = jnp.array([True, False, True, False, True, True])
+    out = parallel_kalman_filter(A, H, Q, R, obs, x0, P0, mask=mask)
+    idx = jnp.where(~mask)[0]
+    assert tree_allclose(out.filtered_means[idx], out.predicted_means[idx], atol=1e-7)
+
+
+def test_parallel_rts_smoother_tv(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    T = 6
+    A_seq = jnp.broadcast_to(A, (T, *A.shape))
+    obs = jr.normal(getkey(), (T, 2))
+    state = parallel_kalman_filter(A_seq, H, Q, R, obs, x0, P0)
+    s_means, _s_covs = parallel_rts_smoother(state, A_seq, Q)
+    # Last smoothed == last filtered.
+    assert tree_allclose(s_means[-1], state.filtered_means[-1], rtol=1e-6)

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.10"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Two related changes to the Kalman filter family, motivated by pyrox's Markov GP needs.

## 1. Operator typing

`transition`, `obs_model`, `process_noise`, and `obs_noise` in `kalman_filter`, `rts_smoother`, `parallel_kalman_filter`, `parallel_rts_smoother`, `infinite_horizon_filter`, `infinite_horizon_smoother`, and `dare` now accept either raw `Float[Array, ...]` or `lineax.AbstractLinearOperator`. Structural matvecs (`A @ x`, `H @ x`) inside the per-step scan run through the operator's `mv` — winning for `BlockDiag` from `SumSDE`, `Kronecker` from `ProductSDE.discretise` (PR #159), `MaskedOperator` for `H`, and `DiagonalLinearOperator` for scalar/diagonal noise. Sandwiches (`A P A^T`, `H P H^T`) materialise once outside the scan.

## 2. Time-varying generalisation

The same public entry points now accept `(T, ...)` stacks for `transition`, `obs_model`, `process_noise`, `obs_noise` (e.g. straight from `SDEKernel.discretise_sequence`) plus a per-step boolean `mask=` keyword that runs predict-only (predict + skip update + zero log-likelihood contribution) when `False`. Time-invariant 2D inputs auto-broadcast. Operator-typed inputs are TI-only; mixing 3D stacks with operators raises `TypeError`.

Closes the gaussx-side blocker for **pyrox#124 item 4** (delete `pyrox.gp._markov._kalman_filter` / `_rts_smoother` and route through `gaussx`).

## Scope notes

- `infinite_horizon_*` got operator typing only — TV doesn't apply to a steady-state filter.
- `dare` got operator typing on all four of `A`, `H`, `Q`, `R`.
- Operator-typed *time-varying* stacks (per-step `BlockDiag`/`Kronecker`) are out of scope — a bigger lift on lineax. Deferred to follow-up issues (linked below).

## New helper module

`src/gaussx/_ssm/_utils.py` — `_materialise` / `_matvec` / `_normalise_tv_inputs`, shared across the Kalman family.

## Tests

Added across `tests/ssm/test_kalman.py` and `tests/ssm/test_parallel_kalman.py`:
- TI ↔ TV equivalence (broadcast `(N, N)` vs explicit `(T, N, N)` match).
- TV correctness vs a hand-rolled per-step loop.
- Mask predict-only: filtered == predicted on masked steps; log-likelihood matches a hand-rolled mask-aware filter.
- Operator forms for `obs_noise` (Diagonal), `process_noise` (Diagonal), `transition` (BlockDiag) — all match the dense-array reference.
- `TypeError` when 3D arrays are mixed with operator inputs.
- `solver=` regression for the TV path.
- `dare` and `infinite_horizon_filter` regression with Diagonal `R`.

## Test plan

- [x] All 117 `tests/ssm/` tests pass (`uv run pytest tests/ssm/ -m "not slow"`).
- [x] All 1084 non-slow repo tests pass.
- [x] `ruff format .` and `ruff check .` clean.
- [x] `ty check src/gaussx` clean.

## Follow-up issues

To be filed alongside this PR:
- **A** — feat(linalg): both-sides operator sandwich `A_op @ P_op @ A_op.T` without materialisation. Eliminates the one-shot `O(N²)` sandwich materialisation lifted out of the scan.
- **B** — feat(ssm): keep innovation covariance `S = H P H^T + R` as `LowRankUpdate` when `R` is structured. Asymptotic Woodbury win for high-`M` low-rank-`H` setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Fvisjv7vkRwUa2uQfPBrCu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvisjv7vkRwUa2uQfPBrCu)_