### PR TITLE
fix(ssm): real parallel Kalman filter / RTS smoother via associative_scan

### DIFF
--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -28,9 +28,9 @@ from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
-def _sym(X: Float[Array, "N N"]) -> Float[Array, "N N"]:
-    """Symmetrise a covariance-like matrix to absorb floating-point noise."""
-    return 0.5 * (X + X.T)
+def _sym(X: Float[Array, "... N N"]) -> Float[Array, "... N N"]:
+    """Symmetrise the trailing two axes (works on batched stacks too)."""
+    return 0.5 * (X + jnp.swapaxes(X, -1, -2))
 
 
 # ----------------------------------------------------------------
@@ -94,29 +94,41 @@ def _generic_filter_element_active(F, H, Q, R, y):
 # ----------------------------------------------------------------
 
 
+def _bmv(M, v):
+    """Batched matrix-vector product over the trailing axes."""
+    return jnp.einsum("...ij,...j->...i", M, v)
+
+
 def _filter_combine(elem1, elem2):
     """Combine two filtering elements (Särkkä 2021, §III.A).
 
     ``elem1`` is the earlier-time block, ``elem2`` the later-time block.
+    Operates on the trailing two axes; ``lax.associative_scan`` passes
+    batched chunks with a leading scan axis, so all matrix transposes
+    use ``swapaxes(-1, -2)`` rather than ``.T`` and matrix-vector
+    products use the explicit ``_bmv`` helper (Python ``@`` on
+    ``(..., N, N)`` and ``(..., N)`` does not broadcast a matvec).
     """
     A1, b1, C1, eta1, J1 = elem1
     A2, b2, C2, eta2, J2 = elem2
-    N = A1.shape[0]
+    N = A1.shape[-1]
     eye = jnp.eye(N, dtype=A1.dtype)
+    A2_T = jnp.swapaxes(A2, -1, -2)
 
     # temp1 = A2 @ (I + C1 J2)^{-1}
+    #       = swapaxes(solve((I + C1 J2)^T, A2^T), -1, -2)
     I_C1J2 = eye + C1 @ J2
-    temp1 = jnp.linalg.solve(I_C1J2.T, A2.T).T
+    temp1 = jnp.swapaxes(jnp.linalg.solve(jnp.swapaxes(I_C1J2, -1, -2), A2_T), -1, -2)
 
     A = temp1 @ A1
-    b = temp1 @ (b1 + C1 @ eta2) + b2
-    C = _sym(temp1 @ C1 @ A2.T + C2)
+    b = _bmv(temp1, b1 + _bmv(C1, eta2)) + b2
+    C = _sym(temp1 @ C1 @ A2_T + C2)
 
-    # temp2 = A1.T @ (I + J2 C1)^{-1}
+    # temp2 = A1^T @ (I + J2 C1)^{-1}
     I_J2C1 = eye + J2 @ C1
-    temp2 = jnp.linalg.solve(I_J2C1.T, A1).T
+    temp2 = jnp.swapaxes(jnp.linalg.solve(jnp.swapaxes(I_J2C1, -1, -2), A1), -1, -2)
 
-    eta = temp2 @ (eta2 - J2 @ b1) + eta1
+    eta = _bmv(temp2, eta2 - _bmv(J2, b1)) + eta1
     J = _sym(temp2 @ J2 @ A1 + J1)
 
     return A, b, C, eta, J
@@ -125,14 +137,19 @@ def _filter_combine(elem1, elem2):
 def _smoother_combine(elem1, elem2):
     """Combine two smoothing elements (Särkkä 2021, §III.B).
 
-    Encodes ``m_smooth_t = E_t m_smooth_{t+1} + g_t`` so combining
-    left-to-right gives ``E_left @ E_right`` and ``E_left @ g_right + g_left``.
+    Encodes ``m_smooth_t = E_t m_smooth_{t+1} + g_t``. Used inside
+    ``lax.associative_scan(..., reverse=True)``, which reverses the
+    sequence, runs a forward scan, then reverses the result — so under
+    the forward-scan call ``combine(left, right)`` the left arg is the
+    accumulated *later-time* chain and the right arg is the next
+    *earlier-time* element. The combined result represents the
+    earlier→later span starting at the right element's time.
     """
-    E1, g1, L1 = elem1
-    E2, g2, L2 = elem2
-    E = E1 @ E2
-    g = E1 @ g2 + g1
-    L = _sym(E1 @ L2 @ E1.T + L1)
+    E_later, g_later, L_later = elem1
+    E_earlier, g_earlier, L_earlier = elem2
+    E = E_earlier @ E_later
+    g = _bmv(E_earlier, g_later) + g_earlier
+    L = _sym(E_earlier @ L_later @ jnp.swapaxes(E_earlier, -1, -2) + L_earlier)
     return E, g, L
 
 

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -1,7 +1,7 @@
 """Parallel Kalman filter and RTS smoother via associative scan.
 
-Implements the Särkkä–García-Fernández (IEEE TAC 2021) parallel
-formulation of the linear-Gaussian Kalman filter and Rauch–Tung–Striebel
+Implements the Särkkä-García-Fernández (IEEE TAC 2021) parallel
+formulation of the linear-Gaussian Kalman filter and Rauch-Tung-Striebel
 smoother. The forward (filtering) and backward (smoothing) recurrences
 are recast as inclusive associative scans of per-step elements, which
 :func:`jax.lax.associative_scan` evaluates with ``O(log T)`` depth on
@@ -216,23 +216,29 @@ def parallel_kalman_filter(
         y_eff = jnp.where(m, y, jnp.zeros_like(y))
         return _generic_filter_element_active(F, H_eff, Q, R_eff, y_eff)
 
-    elems = jax.vmap(_build_step)(
-        A_seq, H_seq, Q_seq, R_seq, observations, mask_seq
-    )
+    elems = jax.vmap(_build_step)(A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
 
     # Patch element 0 to absorb the initial prior. Outer ``lax.cond``
     # genuinely skips the inactive branch (no ``vmap`` wrapping here).
     first = jax.lax.cond(
         mask_seq[0],
         lambda: _first_filter_element_active(
-            A_seq[0], H_seq[0], Q_seq[0], R_seq[0], observations[0],
-            init_mean, init_cov,
+            A_seq[0],
+            H_seq[0],
+            Q_seq[0],
+            R_seq[0],
+            observations[0],
+            init_mean,
+            init_cov,
         ),
         lambda: _first_filter_element_masked(
-            A_seq[0], Q_seq[0], init_mean, init_cov,
+            A_seq[0],
+            Q_seq[0],
+            init_mean,
+            init_cov,
         ),
     )
-    elems = tuple(arr.at[0].set(val) for arr, val in zip(elems, first))
+    elems = tuple(arr.at[0].set(val) for arr, val in zip(elems, first, strict=True))
 
     # ----- Associative scan -----
     _A_out, b_out, C_out, _eta_out, _J_out = jax.lax.associative_scan(

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -1,4 +1,19 @@
-"""Parallel Kalman filter and RTS smoother via associative scan."""
+"""Parallel Kalman filter and RTS smoother via associative scan.
+
+Implements the Särkkä–García-Fernández (IEEE TAC 2021) parallel
+formulation of the linear-Gaussian Kalman filter and Rauch–Tung–Striebel
+smoother. The forward (filtering) and backward (smoothing) recurrences
+are recast as inclusive associative scans of per-step elements, which
+:func:`jax.lax.associative_scan` evaluates with ``O(log T)`` depth on
+parallel hardware (GPU / TPU). On sequential hardware (CPU) the total
+work is strictly larger than :func:`gaussx.kalman_filter`'s ``O(T)``
+``lax.scan``; the win is on accelerators with large ``T``.
+
+The element math is the covariance-form combinators from §III.A /
+§III.B of the paper. The covariance form is known to lose conditioning
+on long sequences and in float32 — a square-root variant is tracked in
+#165.
+"""
 
 from __future__ import annotations
 
@@ -8,13 +23,121 @@ import jax.scipy.linalg
 import lineax as lx
 from jaxtyping import Array, Bool, Float
 
-from gaussx._linalg._linalg import solve_matrix, solve_rows
-from gaussx._primitives._cholesky import cholesky
-from gaussx._primitives._logdet import cholesky_logdet
 from gaussx._ssm._kalman import FilterState
 from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
-from gaussx._strategies._dispatch import dispatch_logdet, dispatch_solve
+
+
+# ----------------------------------------------------------------
+# Filter element builders
+# ----------------------------------------------------------------
+
+
+def _first_filter_element_active(F, H, Q, R, y, m0, P0):
+    """t=0 element absorbing the initial prior (predict + update)."""
+    N = F.shape[0]
+    m_pred = F @ m0
+    P_pred = F @ P0 @ F.T + Q
+    S = H @ P_pred @ H.T + R
+    # K = P_pred H^T S^{-1}
+    K = jnp.linalg.solve(S, H @ P_pred).T
+    A = jnp.zeros((N, N), dtype=F.dtype)
+    b = m_pred + K @ (y - H @ m_pred)
+    C = P_pred - K @ H @ P_pred
+    eta = jnp.zeros(N, dtype=F.dtype)
+    J = jnp.zeros((N, N), dtype=F.dtype)
+    return A, b, C, eta, J
+
+
+def _first_filter_element_masked(F, Q, m0, P0):
+    """t=0 predict-only element (mask=False at index 0)."""
+    N = F.shape[0]
+    A = jnp.zeros((N, N), dtype=F.dtype)
+    b = F @ m0
+    C = F @ P0 @ F.T + Q
+    eta = jnp.zeros(N, dtype=F.dtype)
+    J = jnp.zeros((N, N), dtype=F.dtype)
+    return A, b, C, eta, J
+
+
+def _generic_filter_element_active(F, H, Q, R, y):
+    """Generic t>=1 element: predict from x_{t-1} fixed, then update with y."""
+    N = F.shape[0]
+    S = H @ Q @ H.T + R
+    # K = Q H^T S^{-1}
+    K = jnp.linalg.solve(S, H @ Q).T
+    A = (jnp.eye(N, dtype=F.dtype) - K @ H) @ F
+    b = K @ y
+    C = Q - K @ H @ Q
+    HF = H @ F
+    Sinv_y = jnp.linalg.solve(S, y)
+    eta = HF.T @ Sinv_y
+    Sinv_HF = jnp.linalg.solve(S, HF)
+    J = HF.T @ Sinv_HF
+    return A, b, C, eta, J
+
+
+def _generic_filter_element_masked(F, Q):
+    """Predict-only element for masked steps."""
+    N = F.shape[0]
+    A = F
+    b = jnp.zeros(N, dtype=F.dtype)
+    C = Q
+    eta = jnp.zeros(N, dtype=F.dtype)
+    J = jnp.zeros((N, N), dtype=F.dtype)
+    return A, b, C, eta, J
+
+
+# ----------------------------------------------------------------
+# Associative combinators
+# ----------------------------------------------------------------
+
+
+def _filter_combine(elem1, elem2):
+    """Combine two filtering elements (Särkkä 2021, §III.A).
+
+    ``elem1`` is the earlier-time block, ``elem2`` the later-time block.
+    """
+    A1, b1, C1, eta1, J1 = elem1
+    A2, b2, C2, eta2, J2 = elem2
+    N = A1.shape[0]
+    I = jnp.eye(N, dtype=A1.dtype)
+
+    # temp1 = A2 @ (I + C1 J2)^{-1}
+    I_C1J2 = I + C1 @ J2
+    temp1 = jnp.linalg.solve(I_C1J2.T, A2.T).T
+
+    A = temp1 @ A1
+    b = temp1 @ (b1 + C1 @ eta2) + b2
+    C = temp1 @ C1 @ A2.T + C2
+
+    # temp2 = A1.T @ (I + J2 C1)^{-1}
+    I_J2C1 = I + J2 @ C1
+    temp2 = jnp.linalg.solve(I_J2C1.T, A1).T
+
+    eta = temp2 @ (eta2 - J2 @ b1) + eta1
+    J = temp2 @ J2 @ A1 + J1
+
+    return A, b, C, eta, J
+
+
+def _smoother_combine(elem1, elem2):
+    """Combine two smoothing elements (Särkkä 2021, §III.B).
+
+    ``elem1`` is the earlier-time block, ``elem2`` the later-time block;
+    the recurrence is m_smooth_t = E_t m_smooth_{t+1} + g_t.
+    """
+    E1, g1, L1 = elem1
+    E2, g2, L2 = elem2
+    E = E1 @ E2
+    g = E1 @ g2 + g1
+    L = E1 @ L2 @ E1.T + L1
+    return E, g, L
+
+
+# ----------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------
 
 
 def parallel_kalman_filter(
@@ -29,14 +152,12 @@ def parallel_kalman_filter(
     mask: Bool[Array, " T"] | None = None,
     solver: AbstractSolverStrategy | None = None,
 ) -> FilterState:
-    """Kalman filter with dense array operations via ``jax.lax.scan``.
+    """Parallel Kalman filter via :func:`jax.lax.associative_scan`.
 
-    Same generalised contract as :func:`gaussx.kalman_filter`:
-
-    - Time-invariant inputs (single ``(N, N)`` etc.) auto-broadcast along ``T``.
-    - Time-varying inputs accepted as ``(T, …)`` arrays.
-    - Operator-typed inputs accepted in the time-invariant signature only.
-    - Optional ``mask`` skips the update step (predict only) per timestep.
+    Numerically equivalent to :func:`gaussx.kalman_filter` but with
+    ``O(log T)`` parallel depth on accelerators. Same generalised
+    contract (TI / TV / operator-typed inputs, optional mask, scalar
+    log-likelihood).
 
     Args:
         transition: State transition matrix or operator.
@@ -46,16 +167,20 @@ def parallel_kalman_filter(
         observations: Observed data, shape ``(T, M)``.
         init_mean: Initial state mean, shape ``(N,)``.
         init_cov: Initial state covariance, shape ``(N, N)``.
-        mask: Optional ``(T,)`` boolean mask. ``False`` runs predict-only
+        mask: Optional ``(T,)`` boolean mask; ``False`` runs predict-only
             and contributes 0 to the log-likelihood. Defaults to all-True.
-        solver: Optional solver strategy for structured linear algebra.
-            When ``None``, factors ``S`` once via Cholesky and reuses
-            for the gain, log-det, and quadratic term.
+        solver: Accepted for API symmetry with :func:`kalman_filter` but
+            not currently threaded through the per-element solves; the
+            covariance-form combinator uses unstructured dense solves.
+            See #165 for the square-root variant tracking the structured
+            path.
 
     Returns:
-        A ``FilterState`` with filtered/predicted means, covariances,
-        and total log-likelihood.
+        :class:`FilterState` with filtered / predicted means and covs
+        and the total log-likelihood.
     """
+    del solver  # not currently threaded through; see docstring + #165
+
     M = observations.shape[-1]
     T = observations.shape[0]
     log_2pi = jnp.log(2.0 * jnp.pi)
@@ -64,60 +189,71 @@ def parallel_kalman_filter(
         transition, obs_model, process_noise, obs_noise, T=T, mask=mask
     )
 
-    A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
-    H_op = obs_model if isinstance(obs_model, lx.AbstractLinearOperator) else None
-
-    def step(carry, inputs):
-        x_filt, P_filt, ll = carry
-        A_t, H_t, Q_t, R_t, y_t, mask_t = inputs
-
-        x_pred = A_op.mv(x_filt) if A_op is not None else A_t @ x_filt
-        P_pred = A_t @ P_filt @ A_t.T + Q_t
-
-        # Update gated by mask via ``lax.cond`` — the predict-only
-        # branch skips the Cholesky / cho_solve / logdet entirely so
-        # masked timesteps don't perform the expensive update work and
-        # don't leak gradients through the dropped path.
-        def _do_update(_):
-            v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
-            S = H_t @ P_pred @ H_t.T + R_t
-            S_op = lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
-
-            if solver is None:
-                L_S = cholesky(S_op).as_matrix()
-                K = jax.scipy.linalg.cho_solve((L_S, True), H_t @ P_pred).T
-                Sinv_v = jax.scipy.linalg.cho_solve((L_S, True), v)
-                ld = cholesky_logdet(L_S)
-            else:
-                K = solve_matrix(S_op, H_t @ P_pred, solver=solver).T
-                Sinv_v = dispatch_solve(S_op, v, solver)
-                ld = dispatch_logdet(S_op, solver)
-
-            x_upd = x_pred + K @ v
-            P_upd = P_pred - K @ S @ K.T
-            ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
-            return x_upd, P_upd, ll_inc
-
-        def _skip_update(_):
-            return x_pred, P_pred, jnp.array(0.0)
-
-        x_new, P_new, ll_inc = jax.lax.cond(
-            mask_t, _do_update, _skip_update, operand=None
+    # ----- Build per-step elements -----
+    def _build_generic(F, H, Q, R, y, m):
+        return jax.lax.cond(
+            m,
+            lambda: _generic_filter_element_active(F, H, Q, R, y),
+            lambda: _generic_filter_element_masked(F, Q),
         )
-        ll_new = ll + ll_inc
 
-        return (x_new, P_new, ll_new), (x_new, P_new, x_pred, P_pred)
-
-    init = (init_mean, init_cov, jnp.array(0.0))
-    (_, _, ll), (f_means, f_covs, p_means, p_covs) = jax.lax.scan(
-        step, init, (A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
+    elems = jax.vmap(_build_generic)(
+        A_seq, H_seq, Q_seq, R_seq, observations, mask_seq
     )
+
+    # Patch element 0 to absorb the initial prior.
+    first = jax.lax.cond(
+        mask_seq[0],
+        lambda: _first_filter_element_active(
+            A_seq[0], H_seq[0], Q_seq[0], R_seq[0], observations[0],
+            init_mean, init_cov,
+        ),
+        lambda: _first_filter_element_masked(
+            A_seq[0], Q_seq[0], init_mean, init_cov,
+        ),
+    )
+    elems = tuple(arr.at[0].set(val) for arr, val in zip(elems, first))
+
+    # ----- Associative scan -----
+    _A_out, b_out, C_out, _eta_out, _J_out = jax.lax.associative_scan(
+        _filter_combine, elems
+    )
+    filtered_means = b_out
+    filtered_covs = C_out
+
+    # ----- Reconstruct predicted means / covs from filtered + transition -----
+    prev_means = jnp.concatenate([init_mean[None], filtered_means[:-1]], axis=0)
+    prev_covs = jnp.concatenate([init_cov[None], filtered_covs[:-1]], axis=0)
+
+    def _predict_step(F, m, P, Q):
+        return F @ m, F @ P @ F.T + Q
+
+    predicted_means, predicted_covs = jax.vmap(_predict_step)(
+        A_seq, prev_means, prev_covs, Q_seq
+    )
+
+    # ----- Log-likelihood from innovations (mask-gated) -----
+    def _ll_contrib(y, m_pred, P_pred, H, R, m):
+        v = y - H @ m_pred
+        S = H @ P_pred @ H.T + R
+        L = jnp.linalg.cholesky(S)
+        Sinv_v = jax.scipy.linalg.cho_solve((L, True), v)
+        quad = v @ Sinv_v
+        logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
+        contrib = -0.5 * (quad + logdet + M * log_2pi)
+        return jnp.where(m, contrib, jnp.zeros_like(contrib))
+
+    ll_contribs = jax.vmap(_ll_contrib)(
+        observations, predicted_means, predicted_covs, H_seq, R_seq, mask_seq
+    )
+    log_likelihood = jnp.sum(ll_contribs)
+
     return FilterState(
-        filtered_means=f_means,
-        filtered_covs=f_covs,
-        predicted_means=p_means,
-        predicted_covs=p_covs,
-        log_likelihood=ll,
+        filtered_means=filtered_means,
+        filtered_covs=filtered_covs,
+        predicted_means=predicted_means,
+        predicted_covs=predicted_covs,
+        log_likelihood=log_likelihood,
     )
 
 
@@ -128,29 +264,33 @@ def parallel_rts_smoother(
     *,
     solver: AbstractSolverStrategy | None = None,
 ) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
-    """Dense RTS smoother for outputs produced by ``parallel_kalman_filter``.
+    """Parallel RTS smoother via reverse :func:`jax.lax.associative_scan`.
 
-    The previous associative-scan formulation was not algebraically
-    equivalent to the standard RTS recurrence. This implementation keeps
-    the public API but uses a validated dense backward scan. Accepts the
-    same time-invariant / time-varying / operator forms for
-    ``transition`` as :func:`parallel_kalman_filter`.
+    Pairs with :func:`parallel_kalman_filter`. Numerically equivalent to
+    :func:`gaussx.rts_smoother` with ``O(log T)`` parallel depth.
 
     Args:
-        filter_state: Output of :func:`kalman_filter` or
-            :func:`parallel_kalman_filter`.
+        filter_state: Output of :func:`parallel_kalman_filter` or
+            :func:`gaussx.kalman_filter`.
         transition: State transition matrix or operator.
-        process_noise: Process noise covariance or operator. (Not used
-            by the RTS recurrence — kept for API symmetry.)
-        solver: Optional solver strategy.
+        process_noise: Unused — kept for API symmetry with the sequential
+            smoother.
+        solver: Accepted for API symmetry; not currently threaded
+            through. See #165.
 
     Returns:
         Tuple ``(smoothed_means, smoothed_covs)``.
     """
-    del process_noise
+    del process_noise, solver
 
-    T = filter_state.filtered_means.shape[0]
+    f_means = filter_state.filtered_means
+    f_covs = filter_state.filtered_covs
+    p_means = filter_state.predicted_means
+    p_covs = filter_state.predicted_covs
+    T = f_means.shape[0]
+    N = f_means.shape[-1]
 
+    # Normalise transition to a (T, N, N) stack — operators TI-only.
     A_dense = _materialise(transition)
     A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
     if A_dense.ndim == 2:
@@ -164,33 +304,31 @@ def parallel_rts_smoother(
     else:
         raise ValueError(f"transition must have ndim 2 or 3, got {A_dense.ndim}.")
 
-    def step(carry, inputs):
-        x_smooth, P_smooth = carry
-        x_filt, P_filt, x_pred, P_pred, A_next = inputs
+    # ----- Build per-step smoother elements -----
+    # Inner elements (t = 0..T-2): standard smoother gain w.r.t. the
+    # predicted state at t+1 reached through A_seq[t+1].
+    def _build_inner(f_mean, f_cov, p_mean_next, p_cov_next, A_next):
+        # G = f_cov @ A_next.T @ inv(p_cov_next)   (p_cov is symmetric)
+        rhs = f_cov @ A_next.T  # (N, N)
+        G = jnp.linalg.solve(p_cov_next, rhs.T).T
+        E = G
+        g = f_mean - G @ p_mean_next
+        L = f_cov - G @ p_cov_next @ G.T
+        return E, g, L
 
-        P_pred_op = lx.MatrixLinearOperator(P_pred, lx.positive_semidefinite_tag)
-        G = solve_rows(P_pred_op, P_filt @ A_next.T, solver=solver)
-        x_smooth_new = x_filt + G @ (x_smooth - x_pred)
-        P_smooth_new = P_filt + G @ (P_smooth - P_pred) @ G.T
-        return (x_smooth_new, P_smooth_new), (x_smooth_new, P_smooth_new)
+    inner_E, inner_g, inner_L = jax.vmap(_build_inner)(
+        f_means[:-1], f_covs[:-1], p_means[1:], p_covs[1:], A_seq[1:]
+    )
+    last_E = jnp.zeros((1, N, N), dtype=f_means.dtype)
+    last_g = f_means[-1:]
+    last_L = f_covs[-1:]
 
-    init_carry = (
-        filter_state.filtered_means[T - 1],
-        filter_state.filtered_covs[T - 1],
-    )
-    inputs = (
-        filter_state.filtered_means[:-1][::-1],
-        filter_state.filtered_covs[:-1][::-1],
-        filter_state.predicted_means[1:][::-1],
-        filter_state.predicted_covs[1:][::-1],
-        A_seq[1:][::-1],
-    )
-    _, (s_means_rev, s_covs_rev) = jax.lax.scan(step, init_carry, inputs)
+    E = jnp.concatenate([inner_E, last_E], axis=0)
+    g = jnp.concatenate([inner_g, last_g], axis=0)
+    L = jnp.concatenate([inner_L, last_L], axis=0)
 
-    s_means = jnp.concatenate(
-        [s_means_rev[::-1], filter_state.filtered_means[T - 1 :]], axis=0
+    # ----- Reverse associative scan -----
+    _E_out, smoothed_means, smoothed_covs = jax.lax.associative_scan(
+        _smoother_combine, (E, g, L), reverse=True
     )
-    s_covs = jnp.concatenate(
-        [s_covs_rev[::-1], filter_state.filtered_covs[T - 1 :]], axis=0
-    )
-    return s_means, s_covs
+    return smoothed_means, smoothed_covs

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -28,6 +28,11 @@ from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
+def _sym(X: Float[Array, "N N"]) -> Float[Array, "N N"]:
+    """Symmetrise a covariance-like matrix to absorb floating-point noise."""
+    return 0.5 * (X + X.T)
+
+
 # ----------------------------------------------------------------
 # Filter element builders
 # ----------------------------------------------------------------
@@ -37,13 +42,14 @@ def _first_filter_element_active(F, H, Q, R, y, m0, P0):
     """t=0 element absorbing the initial prior (predict + update)."""
     N = F.shape[0]
     m_pred = F @ m0
-    P_pred = F @ P0 @ F.T + Q
-    S = H @ P_pred @ H.T + R
-    # K = P_pred H^T S^{-1}
-    K = jnp.linalg.solve(S, H @ P_pred).T
+    P_pred = _sym(F @ P0 @ F.T + Q)
+    HPpred = H @ P_pred  # (M, N)
+    S = _sym(HPpred @ H.T + R)
+    L_S = jnp.linalg.cholesky(S)
+    K = jax.scipy.linalg.cho_solve((L_S, True), HPpred).T  # (N, M)
     A = jnp.zeros((N, N), dtype=F.dtype)
     b = m_pred + K @ (y - H @ m_pred)
-    C = P_pred - K @ H @ P_pred
+    C = _sym(P_pred - K @ HPpred)
     eta = jnp.zeros(N, dtype=F.dtype)
     J = jnp.zeros((N, N), dtype=F.dtype)
     return A, b, C, eta, J
@@ -54,37 +60,32 @@ def _first_filter_element_masked(F, Q, m0, P0):
     N = F.shape[0]
     A = jnp.zeros((N, N), dtype=F.dtype)
     b = F @ m0
-    C = F @ P0 @ F.T + Q
+    C = _sym(F @ P0 @ F.T + Q)
     eta = jnp.zeros(N, dtype=F.dtype)
     J = jnp.zeros((N, N), dtype=F.dtype)
     return A, b, C, eta, J
 
 
 def _generic_filter_element_active(F, H, Q, R, y):
-    """Generic t>=1 element: predict from x_{t-1} fixed, then update with y."""
+    """Generic t>=1 element: predict from x_{t-1} fixed, then update with y.
+
+    ``S = H Q H^T + R`` is factored once; the gain, innovation solve,
+    and information solve all reuse the Cholesky factor.
+    """
     N = F.shape[0]
-    S = H @ Q @ H.T + R
-    # K = Q H^T S^{-1}
-    K = jnp.linalg.solve(S, H @ Q).T
+    HQ = H @ Q  # (M, N)
+    S = _sym(HQ @ H.T + R)
+    L_S = jnp.linalg.cholesky(S)
+    # K = Q H^T S^{-1} = (S^{-1} (H Q))^T
+    K = jax.scipy.linalg.cho_solve((L_S, True), HQ).T  # (N, M)
     A = (jnp.eye(N, dtype=F.dtype) - K @ H) @ F
     b = K @ y
-    C = Q - K @ H @ Q
-    HF = H @ F
-    Sinv_y = jnp.linalg.solve(S, y)
+    C = _sym(Q - K @ HQ)
+    HF = H @ F  # (M, N)
+    Sinv_y = jax.scipy.linalg.cho_solve((L_S, True), y)  # (M,)
+    Sinv_HF = jax.scipy.linalg.cho_solve((L_S, True), HF)  # (M, N)
     eta = HF.T @ Sinv_y
-    Sinv_HF = jnp.linalg.solve(S, HF)
-    J = HF.T @ Sinv_HF
-    return A, b, C, eta, J
-
-
-def _generic_filter_element_masked(F, Q):
-    """Predict-only element for masked steps."""
-    N = F.shape[0]
-    A = F
-    b = jnp.zeros(N, dtype=F.dtype)
-    C = Q
-    eta = jnp.zeros(N, dtype=F.dtype)
-    J = jnp.zeros((N, N), dtype=F.dtype)
+    J = _sym(HF.T @ Sinv_HF)
     return A, b, C, eta, J
 
 
@@ -101,22 +102,22 @@ def _filter_combine(elem1, elem2):
     A1, b1, C1, eta1, J1 = elem1
     A2, b2, C2, eta2, J2 = elem2
     N = A1.shape[0]
-    I = jnp.eye(N, dtype=A1.dtype)
+    eye = jnp.eye(N, dtype=A1.dtype)
 
     # temp1 = A2 @ (I + C1 J2)^{-1}
-    I_C1J2 = I + C1 @ J2
+    I_C1J2 = eye + C1 @ J2
     temp1 = jnp.linalg.solve(I_C1J2.T, A2.T).T
 
     A = temp1 @ A1
     b = temp1 @ (b1 + C1 @ eta2) + b2
-    C = temp1 @ C1 @ A2.T + C2
+    C = _sym(temp1 @ C1 @ A2.T + C2)
 
     # temp2 = A1.T @ (I + J2 C1)^{-1}
-    I_J2C1 = I + J2 @ C1
+    I_J2C1 = eye + J2 @ C1
     temp2 = jnp.linalg.solve(I_J2C1.T, A1).T
 
     eta = temp2 @ (eta2 - J2 @ b1) + eta1
-    J = temp2 @ J2 @ A1 + J1
+    J = _sym(temp2 @ J2 @ A1 + J1)
 
     return A, b, C, eta, J
 
@@ -124,14 +125,14 @@ def _filter_combine(elem1, elem2):
 def _smoother_combine(elem1, elem2):
     """Combine two smoothing elements (Särkkä 2021, §III.B).
 
-    ``elem1`` is the earlier-time block, ``elem2`` the later-time block;
-    the recurrence is m_smooth_t = E_t m_smooth_{t+1} + g_t.
+    Encodes ``m_smooth_t = E_t m_smooth_{t+1} + g_t`` so combining
+    left-to-right gives ``E_left @ E_right`` and ``E_left @ g_right + g_left``.
     """
     E1, g1, L1 = elem1
     E2, g2, L2 = elem2
     E = E1 @ E2
     g = E1 @ g2 + g1
-    L = E1 @ L2 @ E1.T + L1
+    L = _sym(E1 @ L2 @ E1.T + L1)
     return E, g, L
 
 
@@ -157,7 +158,8 @@ def parallel_kalman_filter(
     Numerically equivalent to :func:`gaussx.kalman_filter` but with
     ``O(log T)`` parallel depth on accelerators. Same generalised
     contract (TI / TV / operator-typed inputs, optional mask, scalar
-    log-likelihood).
+    log-likelihood). Empty observation windows (``T == 0``) return a
+    zero-length :class:`FilterState` with ``log_likelihood == 0``.
 
     Args:
         transition: State transition matrix or operator.
@@ -173,7 +175,7 @@ def parallel_kalman_filter(
             not currently threaded through the per-element solves; the
             covariance-form combinator uses unstructured dense solves.
             See #165 for the square-root variant tracking the structured
-            path.
+            solver path.
 
     Returns:
         :class:`FilterState` with filtered / predicted means and covs
@@ -181,27 +183,45 @@ def parallel_kalman_filter(
     """
     del solver  # not currently threaded through; see docstring + #165
 
-    M = observations.shape[-1]
+    M_obs = observations.shape[-1]
     T = observations.shape[0]
+    N = init_mean.shape[0]
+
+    # Empty observation window: match kalman_filter's empty-scan output.
+    if T == 0:
+        return FilterState(
+            filtered_means=jnp.zeros((0, N), dtype=init_mean.dtype),
+            filtered_covs=jnp.zeros((0, N, N), dtype=init_cov.dtype),
+            predicted_means=jnp.zeros((0, N), dtype=init_mean.dtype),
+            predicted_covs=jnp.zeros((0, N, N), dtype=init_cov.dtype),
+            log_likelihood=jnp.zeros((), dtype=init_mean.dtype),
+        )
+
     log_2pi = jnp.log(2.0 * jnp.pi)
 
     A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
         transition, obs_model, process_noise, obs_noise, T=T, mask=mask
     )
 
-    # ----- Build per-step elements -----
-    def _build_generic(F, H, Q, R, y, m):
-        return jax.lax.cond(
-            m,
-            lambda: _generic_filter_element_active(F, H, Q, R, y),
-            lambda: _generic_filter_element_masked(F, Q),
-        )
+    # Build per-step elements. ``vmap`` of ``lax.cond`` evaluates both
+    # branches and selects, so we instead substitute mask-aware safe
+    # inputs (H=0, R=I, y=0 for masked steps) into a single active path.
+    # With those substitutions the active builder collapses to
+    # (F, 0, Q, 0, 0) — exactly the predict-only element — and the
+    # Cholesky operates on the well-conditioned identity, so even
+    # garbage in masked H / R / y can't NaN the gradient.
+    def _build_step(F, H, Q, R, y, m):
+        H_eff = jnp.where(m, H, jnp.zeros_like(H))
+        R_eff = jnp.where(m, R, jnp.eye(M_obs, dtype=R.dtype))
+        y_eff = jnp.where(m, y, jnp.zeros_like(y))
+        return _generic_filter_element_active(F, H_eff, Q, R_eff, y_eff)
 
-    elems = jax.vmap(_build_generic)(
+    elems = jax.vmap(_build_step)(
         A_seq, H_seq, Q_seq, R_seq, observations, mask_seq
     )
 
-    # Patch element 0 to absorb the initial prior.
+    # Patch element 0 to absorb the initial prior. Outer ``lax.cond``
+    # genuinely skips the inactive branch (no ``vmap`` wrapping here).
     first = jax.lax.cond(
         mask_seq[0],
         lambda: _first_filter_element_active(
@@ -219,28 +239,33 @@ def parallel_kalman_filter(
         _filter_combine, elems
     )
     filtered_means = b_out
-    filtered_covs = C_out
+    filtered_covs = jax.vmap(_sym)(C_out)
 
-    # ----- Reconstruct predicted means / covs from filtered + transition -----
+    # Reconstruct predicted means / covs from filtered + transition.
     prev_means = jnp.concatenate([init_mean[None], filtered_means[:-1]], axis=0)
     prev_covs = jnp.concatenate([init_cov[None], filtered_covs[:-1]], axis=0)
 
     def _predict_step(F, m, P, Q):
-        return F @ m, F @ P @ F.T + Q
+        return F @ m, _sym(F @ P @ F.T + Q)
 
     predicted_means, predicted_covs = jax.vmap(_predict_step)(
         A_seq, prev_means, prev_covs, Q_seq
     )
 
-    # ----- Log-likelihood from innovations (mask-gated) -----
+    # Log-likelihood from innovations. Same safe substitution as the
+    # element builder so masked steps don't drive the Cholesky through
+    # ill-conditioned user-supplied R / NaN gradients.
     def _ll_contrib(y, m_pred, P_pred, H, R, m):
-        v = y - H @ m_pred
-        S = H @ P_pred @ H.T + R
+        H_eff = jnp.where(m, H, jnp.zeros_like(H))
+        R_eff = jnp.where(m, R, jnp.eye(M_obs, dtype=R.dtype))
+        y_eff = jnp.where(m, y, jnp.zeros_like(y))
+        v = y_eff - H_eff @ m_pred
+        S = _sym(H_eff @ P_pred @ H_eff.T + R_eff)
         L = jnp.linalg.cholesky(S)
         Sinv_v = jax.scipy.linalg.cho_solve((L, True), v)
         quad = v @ Sinv_v
         logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
-        contrib = -0.5 * (quad + logdet + M * log_2pi)
+        contrib = -0.5 * (quad + logdet + M_obs * log_2pi)
         return jnp.where(m, contrib, jnp.zeros_like(contrib))
 
     ll_contribs = jax.vmap(_ll_contrib)(
@@ -290,7 +315,12 @@ def parallel_rts_smoother(
     T = f_means.shape[0]
     N = f_means.shape[-1]
 
-    # Normalise transition to a (T, N, N) stack — operators TI-only.
+    if T == 0:
+        return (
+            jnp.zeros((0, N), dtype=f_means.dtype),
+            jnp.zeros((0, N, N), dtype=f_covs.dtype),
+        )
+
     A_dense = _materialise(transition)
     A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
     if A_dense.ndim == 2:
@@ -304,16 +334,13 @@ def parallel_rts_smoother(
     else:
         raise ValueError(f"transition must have ndim 2 or 3, got {A_dense.ndim}.")
 
-    # ----- Build per-step smoother elements -----
-    # Inner elements (t = 0..T-2): standard smoother gain w.r.t. the
-    # predicted state at t+1 reached through A_seq[t+1].
     def _build_inner(f_mean, f_cov, p_mean_next, p_cov_next, A_next):
-        # G = f_cov @ A_next.T @ inv(p_cov_next)   (p_cov is symmetric)
+        # G = f_cov @ A_next.T @ inv(p_cov_next); p_cov_next is symmetric.
         rhs = f_cov @ A_next.T  # (N, N)
         G = jnp.linalg.solve(p_cov_next, rhs.T).T
         E = G
         g = f_mean - G @ p_mean_next
-        L = f_cov - G @ p_cov_next @ G.T
+        L = _sym(f_cov - G @ p_cov_next @ G.T)
         return E, g, L
 
     inner_E, inner_g, inner_L = jax.vmap(_build_inner)(
@@ -327,8 +354,8 @@ def parallel_rts_smoother(
     g = jnp.concatenate([inner_g, last_g], axis=0)
     L = jnp.concatenate([inner_L, last_L], axis=0)
 
-    # ----- Reverse associative scan -----
     _E_out, smoothed_means, smoothed_covs = jax.lax.associative_scan(
         _smoother_combine, (E, g, L), reverse=True
     )
+    smoothed_covs = jax.vmap(_sym)(smoothed_covs)
     return smoothed_means, smoothed_covs

--- a/tests/ssm/test_parallel_kalman.py
+++ b/tests/ssm/test_parallel_kalman.py
@@ -1,10 +1,19 @@
-"""Tests for parallel Kalman filter and RTS smoother."""
+"""Tests for the parallel Kalman filter and RTS smoother.
+
+The parallel implementation is the Särkkä–García-Fernández covariance
+form via :func:`jax.lax.associative_scan`. These tests pin numerical
+parity against the validated sequential filter / smoother in
+``_kalman.py`` and exercise the API surface (TI / TV broadcast, mask,
+operator inputs, JIT, vmap, grad).
+"""
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
+import pytest
 
 from gaussx import DenseSolver, FilterState, kalman_filter, rts_smoother
 from gaussx._ssm._parallel_kalman import (
@@ -24,10 +33,14 @@ def _make_model(getkey, N=2, M=2):
     return A, H, Q, R, x0, P0
 
 
-def test_parallel_kf_matches_sequential(getkey):
-    """Parallel KF should produce same results as sequential KF."""
+# ----------------------------------------------------------------
+# Parity with the sequential filter / smoother
+# ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("T", [1, 2, 8, 64])
+def test_parallel_kf_matches_sequential(getkey, T):
     A, H, Q, R, x0, P0 = _make_model(getkey)
-    T = 10
     obs = jr.normal(getkey(), (T, 2))
 
     seq_state = kalman_filter(A, H, Q, R, obs, x0, P0)
@@ -35,45 +48,17 @@ def test_parallel_kf_matches_sequential(getkey):
 
     assert tree_allclose(par_state.filtered_means, seq_state.filtered_means, rtol=1e-4)
     assert tree_allclose(par_state.filtered_covs, seq_state.filtered_covs, rtol=1e-4)
+    assert tree_allclose(
+        par_state.predicted_means, seq_state.predicted_means, rtol=1e-4
+    )
+    assert tree_allclose(par_state.predicted_covs, seq_state.predicted_covs, rtol=1e-4)
     assert tree_allclose(par_state.log_likelihood, seq_state.log_likelihood, rtol=1e-3)
 
 
-def test_parallel_kf_returns_filter_state(getkey):
+@pytest.mark.parametrize("T", [1, 2, 8, 64])
+def test_parallel_rts_matches_sequential(getkey, T):
     A, H, Q, R, x0, P0 = _make_model(getkey)
-    obs = jr.normal(getkey(), (5, 2))
-    state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    assert isinstance(state, FilterState)
-    assert state.filtered_means.shape == (5, 2)
-    assert state.filtered_covs.shape == (5, 2, 2)
-
-
-def test_parallel_rts_last_matches_filter(getkey):
-    """Last smoothed state should equal last filtered state."""
-    A, H, Q, R, x0, P0 = _make_model(getkey)
-    T = 8
     obs = jr.normal(getkey(), (T, 2))
-
-    state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    par_means, par_covs = parallel_rts_smoother(state, A, Q)
-
-    # Last smoothed == last filtered (by definition)
-    assert tree_allclose(par_means[-1], state.filtered_means[-1], rtol=1e-6)
-    assert tree_allclose(par_covs[-1], state.filtered_covs[-1], rtol=1e-6)
-
-
-def test_parallel_rts_shape(getkey):
-    A, H, Q, R, x0, P0 = _make_model(getkey)
-    obs = jr.normal(getkey(), (6, 2))
-    state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    s_means, s_covs = parallel_rts_smoother(state, A, Q)
-    assert s_means.shape == (6, 2)
-    assert s_covs.shape == (6, 2, 2)
-
-
-def test_parallel_rts_matches_sequential(getkey):
-    """Dense RTS helper should match the validated sequential smoother."""
-    A, H, Q, R, x0, P0 = _make_model(getkey)
-    obs = jr.normal(getkey(), (7, 2))
 
     seq_state = kalman_filter(A, H, Q, R, obs, x0, P0)
     par_state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
@@ -85,13 +70,40 @@ def test_parallel_rts_matches_sequential(getkey):
     assert tree_allclose(par_covs, seq_covs, rtol=1e-4)
 
 
+def test_parallel_kf_returns_filter_state(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    obs = jr.normal(getkey(), (5, 2))
+    state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
+    assert isinstance(state, FilterState)
+    assert state.filtered_means.shape == (5, 2)
+    assert state.filtered_covs.shape == (5, 2, 2)
+    assert state.predicted_means.shape == (5, 2)
+    assert state.predicted_covs.shape == (5, 2, 2)
+
+
+def test_parallel_rts_last_matches_filter(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    T = 8
+    obs = jr.normal(getkey(), (T, 2))
+    state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
+    par_means, par_covs = parallel_rts_smoother(state, A, Q)
+    assert tree_allclose(par_means[-1], state.filtered_means[-1], rtol=1e-6)
+    assert tree_allclose(par_covs[-1], state.filtered_covs[-1], rtol=1e-6)
+
+
+# ----------------------------------------------------------------
+# solver= kwarg passthrough (currently a no-op; pinned for API stability)
+# ----------------------------------------------------------------
+
+
 def test_parallel_kf_with_dense_solver_matches_default(getkey):
-    """Passing solver=DenseSolver() must match the default dispatch path."""
     A, H, Q, R, x0, P0 = _make_model(getkey)
     obs = jr.normal(getkey(), (6, 2))
 
     default_state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    dense_state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0, solver=DenseSolver())
+    dense_state = parallel_kalman_filter(
+        A, H, Q, R, obs, x0, P0, solver=DenseSolver()
+    )
 
     assert tree_allclose(
         dense_state.filtered_means, default_state.filtered_means, rtol=1e-5
@@ -105,13 +117,14 @@ def test_parallel_kf_with_dense_solver_matches_default(getkey):
 
 
 def test_parallel_rts_with_dense_solver_matches_default(getkey):
-    """Smoother solver=DenseSolver() must match the default dispatch path."""
     A, H, Q, R, x0, P0 = _make_model(getkey)
     obs = jr.normal(getkey(), (5, 2))
 
     state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
     default_means, default_covs = parallel_rts_smoother(state, A, Q)
-    dense_means, dense_covs = parallel_rts_smoother(state, A, Q, solver=DenseSolver())
+    dense_means, dense_covs = parallel_rts_smoother(
+        state, A, Q, solver=DenseSolver()
+    )
 
     assert tree_allclose(dense_means, default_means, rtol=1e-5)
     assert tree_allclose(dense_covs, default_covs, rtol=1e-5)
@@ -128,7 +141,9 @@ def test_parallel_kf_obs_noise_diagonal_operator(getkey):
     R_diag = jnp.diag(R)
 
     ref = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    op = parallel_kalman_filter(A, H, Q, lx.DiagonalLinearOperator(R_diag), obs, x0, P0)
+    op = parallel_kalman_filter(
+        A, H, Q, lx.DiagonalLinearOperator(R_diag), obs, x0, P0
+    )
     assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
     assert tree_allclose(ref.log_likelihood, op.log_likelihood, rtol=1e-5)
 
@@ -150,6 +165,16 @@ def test_parallel_kf_transition_block_diag_operator(getkey):
     A_op = BlockDiag(lx.MatrixLinearOperator(A1), lx.MatrixLinearOperator(A2))
     op = parallel_kalman_filter(A_op, H, Q, R, obs, x0, P0)
     assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
+
+
+def test_parallel_kf_rejects_3d_with_operator(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    T = 4
+    obs = jr.normal(getkey(), (T, 2))
+    H_seq = jnp.broadcast_to(H, (T, *H.shape))
+    A_op = lx.MatrixLinearOperator(A)
+    with pytest.raises(TypeError):
+        parallel_kalman_filter(A_op, H_seq, Q, R, obs, x0, P0)
 
 
 # ----------------------------------------------------------------
@@ -176,9 +201,13 @@ def test_parallel_kf_mask_predict_only(getkey):
     T = 6
     obs = jr.normal(getkey(), (T, 2))
     mask = jnp.array([True, False, True, False, True, True])
-    out = parallel_kalman_filter(A, H, Q, R, obs, x0, P0, mask=mask)
+    par = parallel_kalman_filter(A, H, Q, R, obs, x0, P0, mask=mask)
+    seq = kalman_filter(A, H, Q, R, obs, x0, P0, mask=mask)
+    assert tree_allclose(par.filtered_means, seq.filtered_means, rtol=1e-4)
+    assert tree_allclose(par.filtered_covs, seq.filtered_covs, rtol=1e-4)
+    assert tree_allclose(par.log_likelihood, seq.log_likelihood, rtol=1e-3)
     idx = jnp.where(~mask)[0]
-    assert tree_allclose(out.filtered_means[idx], out.predicted_means[idx], atol=1e-7)
+    assert tree_allclose(par.filtered_means[idx], par.predicted_means[idx], atol=1e-7)
 
 
 def test_parallel_rts_smoother_tv(getkey):
@@ -188,5 +217,55 @@ def test_parallel_rts_smoother_tv(getkey):
     obs = jr.normal(getkey(), (T, 2))
     state = parallel_kalman_filter(A_seq, H, Q, R, obs, x0, P0)
     s_means, _s_covs = parallel_rts_smoother(state, A_seq, Q)
-    # Last smoothed == last filtered.
     assert tree_allclose(s_means[-1], state.filtered_means[-1], rtol=1e-6)
+
+
+# ----------------------------------------------------------------
+# JIT / vmap / grad smoke tests
+# ----------------------------------------------------------------
+
+
+def test_parallel_kf_jit(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    obs = jr.normal(getkey(), (8, 2))
+
+    def fn(A_, H_, Q_, R_, obs_, x0_, P0_):
+        return parallel_kalman_filter(A_, H_, Q_, R_, obs_, x0_, P0_).log_likelihood
+
+    eager = fn(A, H, Q, R, obs, x0, P0)
+    jitted = jax.jit(fn)(A, H, Q, R, obs, x0, P0)
+    assert tree_allclose(eager, jitted, rtol=1e-6)
+
+
+def test_parallel_kf_vmap(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    B, T = 4, 6
+    obs_batch = jr.normal(getkey(), (B, T, 2))
+
+    def fn(obs_):
+        return parallel_kalman_filter(A, H, Q, R, obs_, x0, P0).log_likelihood
+
+    batched = jax.vmap(fn)(obs_batch)
+    sequential = jnp.stack([fn(obs_batch[b]) for b in range(B)])
+    assert tree_allclose(batched, sequential, rtol=1e-5)
+
+
+def test_parallel_kf_grad(getkey):
+    A, H, Q, R, x0, P0 = _make_model(getkey)
+    obs = jr.normal(getkey(), (8, 2))
+
+    def loss(log_q_diag):
+        Q_ = jnp.diag(jnp.exp(log_q_diag))
+        return -parallel_kalman_filter(
+            A, H, Q_, R, obs, x0, P0
+        ).log_likelihood
+
+    log_q = jnp.log(jnp.diag(Q))
+    g_par = jax.grad(loss)(log_q)
+
+    def loss_seq(log_q_diag):
+        Q_ = jnp.diag(jnp.exp(log_q_diag))
+        return -kalman_filter(A, H, Q_, R, obs, x0, P0).log_likelihood
+
+    g_seq = jax.grad(loss_seq)(log_q)
+    assert tree_allclose(g_par, g_seq, rtol=1e-3, atol=1e-5)

--- a/tests/ssm/test_parallel_kalman.py
+++ b/tests/ssm/test_parallel_kalman.py
@@ -1,6 +1,6 @@
 """Tests for the parallel Kalman filter and RTS smoother.
 
-The parallel implementation is the Särkkä–García-Fernández covariance
+The parallel implementation is the Särkkä-García-Fernández covariance
 form via :func:`jax.lax.associative_scan`. These tests pin numerical
 parity against the validated sequential filter / smoother in
 ``_kalman.py`` and exercise the API surface (TI / TV broadcast, mask,
@@ -101,9 +101,7 @@ def test_parallel_kf_with_dense_solver_matches_default(getkey):
     obs = jr.normal(getkey(), (6, 2))
 
     default_state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    dense_state = parallel_kalman_filter(
-        A, H, Q, R, obs, x0, P0, solver=DenseSolver()
-    )
+    dense_state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0, solver=DenseSolver())
 
     assert tree_allclose(
         dense_state.filtered_means, default_state.filtered_means, rtol=1e-5
@@ -122,9 +120,7 @@ def test_parallel_rts_with_dense_solver_matches_default(getkey):
 
     state = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
     default_means, default_covs = parallel_rts_smoother(state, A, Q)
-    dense_means, dense_covs = parallel_rts_smoother(
-        state, A, Q, solver=DenseSolver()
-    )
+    dense_means, dense_covs = parallel_rts_smoother(state, A, Q, solver=DenseSolver())
 
     assert tree_allclose(dense_means, default_means, rtol=1e-5)
     assert tree_allclose(dense_covs, default_covs, rtol=1e-5)
@@ -141,9 +137,7 @@ def test_parallel_kf_obs_noise_diagonal_operator(getkey):
     R_diag = jnp.diag(R)
 
     ref = parallel_kalman_filter(A, H, Q, R, obs, x0, P0)
-    op = parallel_kalman_filter(
-        A, H, Q, lx.DiagonalLinearOperator(R_diag), obs, x0, P0
-    )
+    op = parallel_kalman_filter(A, H, Q, lx.DiagonalLinearOperator(R_diag), obs, x0, P0)
     assert tree_allclose(ref.filtered_means, op.filtered_means, rtol=1e-5)
     assert tree_allclose(ref.log_likelihood, op.log_likelihood, rtol=1e-5)
 
@@ -256,9 +250,7 @@ def test_parallel_kf_grad(getkey):
 
     def loss(log_q_diag):
         Q_ = jnp.diag(jnp.exp(log_q_diag))
-        return -parallel_kalman_filter(
-            A, H, Q_, R, obs, x0, P0
-        ).log_likelihood
+        return -parallel_kalman_filter(A, H, Q_, R, obs, x0, P0).log_likelihood
 
     log_q = jnp.log(jnp.diag(Q))
     g_par = jax.grad(loss)(log_q)


### PR DESCRIPTION
## Problem

`parallel_kalman_filter` and `parallel_rts_smoother` were using `jax.lax.scan` for both passes — algorithmically identical to the sequential `kalman_filter` / `rts_smoother` in `_kalman.py`. Same `O(T)` depth, just duplicated code. The smoother docstring even admitted the previous associative-scan formulation was wrong and had been replaced with a sequential backward scan. This was a regression on the original "parallel" intent.

## Fix

Re-implement both functions as the Särkkä & García-Fernández (IEEE TAC 2021) covariance-form parallel formulation — per-step elements combined via `jax.lax.associative_scan`, giving `O(log T)` parallel depth on accelerators.

### Filter

- Build per-step elements `(A, b, C, η, J)` (Särkkä §III.A).
- The `t=0` element absorbs the initial prior `(init_mean, init_cov)` (predict + update from the prior in one element).
- Masked steps build a predict-only element (`H = 0` path: `b = 0`, `A = F_t`, `C = Q_t`, `η = J = 0`), keeping the combinator branchless.
- Filtered means / covs come straight from the scanned elements' `b` / `C`.
- Predicted means / covs are reconstructed post-scan via a `vmap`'d `predict(prev_filtered, A_t, Q_t)`.
- Log-likelihood is computed from innovations with `mask` gating — cleaner than threading a log-Z slot through the combinator.

### Smoother

- Build per-step elements `(E, g, L)` (Särkkä §III.B). Right boundary `e_{T-1} = (0, m_filt_{T-1}, P_filt_{T-1})`.
- Reverse `lax.associative_scan(combinator, elems, reverse=True)`. Smoothed means and covs come from the scanned `g` and `L`.

### Public API

Unchanged. TI / TV / operator-typed inputs accepted on the same terms (operators TI-only, `TypeError` on operator + 3D mix). `solver=` kwarg accepted but documented as not currently threaded through the per-element solves — would need a square-root reformulation to be meaningful (tracked in #165).

## Tests (`tests/ssm/test_parallel_kalman.py`)

- Parametrised parity against `kalman_filter` / `rts_smoother` for `T ∈ {1, 2, 8, 64}` (catches `T=1` / `T=2` combinator edge cases).
- Mask predict-only parity (parallel matches sequential filtered/cov/ll exactly under masking).
- TI ↔ TV broadcast parity.
- Operator-typed parity (`DiagonalLinearOperator` for `R`, `BlockDiag` for `A`).
- `TypeError` on 3D + operator mix.
- `solver=DenseSolver()` parity (no-op pin for API stability).
- JIT, `vmap` over batched observations, and `grad` parity against the sequential filter.

## Follow-ups

- **Square-root variant** for stability on long sequences and float32 → #165.
- Routing structured operators through the combinator (currently materialises `A`, `H`, `Q`, `R` once via `_normalise_tv_inputs`).
- Threading `solver=` through the per-element solves once a square-root path lands.

## Test plan

- [ ] `uv run pytest tests/ssm/test_parallel_kalman.py -v`
- [ ] `uv run pytest tests/ssm/ -m "not slow"` (ensure no collateral)
- [ ] `ruff format .` and `ruff check .`
- [ ] `ty check src/gaussx`

Closes the regression introduced in #162.

https://claude.ai/code/session_013bc5XZr5u5MXxTyTn1Amyp

---
_Generated by [Claude Code](https://claude.ai/code/session_013bc5XZr5u5MXxTyTn1Amyp)_