### PR TITLE
refactor: dedup helpers, DRY constants/primitives, fill docstring gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "matfree>=0.5",
     "jaxtyping>=0.3",
     "einops>=0.8",
+    "einx>=0.4.3",
 ]
 
 [project.urls]

--- a/src/gaussx/_distributions/_mvn.py
+++ b/src/gaussx/_distributions/_mvn.py
@@ -14,53 +14,11 @@ from gaussx._distributions._gaussian import (
     _gaussian_log_prob_residual,
     gaussian_entropy,
 )
+from gaussx._distributions._utils import _reshape_batch, _reshape_samples
 from gaussx._primitives._cholesky import cholesky as _cholesky
 from gaussx._primitives._diag import diag as _diag
 from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
-
-
-def _axis_names(count: int) -> tuple[str, ...]:
-    names = []
-    for index in range(count):
-        value = index
-        chars = []
-        while True:
-            value, remainder = divmod(value, 26)
-            chars.append(chr(ord("a") + remainder))
-            if value == 0:
-                break
-            value -= 1
-        names.append("".join(reversed(chars)))
-    return tuple(names)
-
-
-def _reshape_batch(
-    values: Float[Array, " flat"],
-    batch_shape: tuple[int, ...],
-) -> Float[Array, "*batch"]:
-    if not batch_shape:
-        return values[0]
-    batch_axes = _axis_names(len(batch_shape))
-    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
-    batch_pattern = " ".join(batch_axes)
-    return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
-
-
-def _reshape_samples(
-    values: Float[Array, "flat N"],
-    batch_shape: tuple[int, ...],
-) -> Float[Array, "*batch N"]:
-    if not batch_shape:
-        return values[0]
-    batch_axes = _axis_names(len(batch_shape))
-    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
-    batch_pattern = " ".join(batch_axes)
-    return rearrange(
-        values,
-        f"({batch_pattern}) N -> {batch_pattern} N",
-        **axis_lengths,
-    )
 
 
 class MultivariateNormal(dist.Distribution):

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -10,6 +10,7 @@ from einops import rearrange
 from jaxtyping import Array, Float
 from numpyro.distributions.util import lazy_property, validate_sample
 
+from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._distributions._utils import _reshape_batch, _reshape_samples
 from gaussx._primitives._cholesky import cholesky as _cholesky
 from gaussx._primitives._diag import diag as _diag
@@ -79,7 +80,7 @@ class MultivariateNormalPrecision(dist.Distribution):
         quad = jnp.sum(residual * self.prec_operator.mv(residual), axis=-1)
         ld = self.solver.logdet(self.prec_operator)
         n = self.loc.shape[-1]
-        return -0.5 * (n * jnp.log(2.0 * jnp.pi) - ld + quad)
+        return -0.5 * (n * _LOG_2PI - ld + quad)
 
     @validate_sample
     def log_prob(self, value: Float[Array, "*batch N"]) -> Float[Array, "*batch"]:
@@ -122,4 +123,4 @@ class MultivariateNormalPrecision(dist.Distribution):
     def entropy(self) -> Float[Array, ""]:
         n = self.loc.shape[-1]
         ld = self.solver.logdet(self.prec_operator)
-        return 0.5 * (n * (1.0 + jnp.log(2.0 * jnp.pi)) - ld)
+        return 0.5 * (n * (1.0 + _LOG_2PI) - ld)

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -10,55 +10,13 @@ from einops import rearrange
 from jaxtyping import Array, Float
 from numpyro.distributions.util import lazy_property, validate_sample
 
+from gaussx._distributions._utils import _reshape_batch, _reshape_samples
 from gaussx._primitives._cholesky import cholesky as _cholesky
 from gaussx._primitives._diag import diag as _diag
 from gaussx._primitives._inv import inv as _inv
 from gaussx._primitives._solve import solve as _solve
 from gaussx._strategies._auto import AutoSolver
 from gaussx._strategies._base import AbstractSolverStrategy
-
-
-def _axis_names(count: int) -> tuple[str, ...]:
-    names = []
-    for index in range(count):
-        value = index
-        chars = []
-        while True:
-            value, remainder = divmod(value, 26)
-            chars.append(chr(ord("a") + remainder))
-            if value == 0:
-                break
-            value -= 1
-        names.append("".join(reversed(chars)))
-    return tuple(names)
-
-
-def _reshape_batch(
-    values: Float[Array, " flat"],
-    batch_shape: tuple[int, ...],
-) -> Float[Array, "*batch"]:
-    if not batch_shape:
-        return values[0]
-    batch_axes = _axis_names(len(batch_shape))
-    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
-    batch_pattern = " ".join(batch_axes)
-    return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
-
-
-def _reshape_samples(
-    values: Float[Array, "flat N"],
-    batch_shape: tuple[int, ...],
-) -> Float[Array, "*batch N"]:
-    if not batch_shape:
-        return values[0]
-    batch_axes = _axis_names(len(batch_shape))
-    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
-    batch_pattern = " ".join(batch_axes)
-    return rearrange(
-        values,
-        f"({batch_pattern}) N -> {batch_pattern} N",
-        **axis_lengths,
-    )
 
 
 class MultivariateNormalPrecision(dist.Distribution):

--- a/src/gaussx/_distributions/_utils.py
+++ b/src/gaussx/_distributions/_utils.py
@@ -7,10 +7,10 @@ from jaxtyping import Array, Float
 
 
 def _axis_names(count: int) -> tuple[str, ...]:
-    """Generate ``count`` spreadsheet-style axis names for einops patterns.
+    """Generate ``count`` spreadsheet-style axis names for rearrange patterns.
 
     Produces ``("a", "b", ..., "z", "aa", "ab", ...)`` so that an arbitrary
-    number of batch axes can be referenced by name in an einops pattern.
+    number of batch axes can be referenced by name in an einops/einx pattern.
 
     Args:
         count: Number of axis names to generate.

--- a/src/gaussx/_distributions/_utils.py
+++ b/src/gaussx/_distributions/_utils.py
@@ -1,0 +1,77 @@
+"""Shared helpers for batched distribution reshaping."""
+
+from __future__ import annotations
+
+import einx
+from jaxtyping import Array, Float
+
+
+def _axis_names(count: int) -> tuple[str, ...]:
+    """Generate ``count`` spreadsheet-style axis names for einops patterns.
+
+    Produces ``("a", "b", ..., "z", "aa", "ab", ...)`` so that an arbitrary
+    number of batch axes can be referenced by name in an einops pattern.
+
+    Args:
+        count: Number of axis names to generate.
+
+    Returns:
+        Tuple of ``count`` unique lowercase axis names.
+    """
+    names = []
+    for index in range(count):
+        value = index
+        chars = []
+        while True:
+            value, remainder = divmod(value, 26)
+            chars.append(chr(ord("a") + remainder))
+            if value == 0:
+                break
+            value -= 1
+        names.append("".join(reversed(chars)))
+    return tuple(names)
+
+
+def _reshape_batch(
+    values: Float[Array, " flat"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch"]:
+    """Reshape a flat batch vector back to its original batch shape.
+
+    Args:
+        values: Flat values of shape ``(prod(batch_shape),)``.
+        batch_shape: Target batch shape. When empty, the single scalar entry
+            is returned unwrapped.
+
+    Returns:
+        Array reshaped to ``batch_shape``.
+    """
+    if not batch_shape:
+        return values[0]
+    batch_axes = _axis_names(len(batch_shape))
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    return einx.id(f"({batch_pattern}) -> {batch_pattern}", values, **axis_lengths)  # ty: ignore[invalid-argument-type]
+
+
+def _reshape_samples(
+    values: Float[Array, "flat N"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch N"]:
+    """Reshape flat samples back to their original batch shape.
+
+    Args:
+        values: Flat samples of shape ``(prod(batch_shape), N)``.
+        batch_shape: Target batch shape. When empty, the single sample is
+            returned unwrapped.
+
+    Returns:
+        Array reshaped to ``(*batch_shape, N)``.
+    """
+    if not batch_shape:
+        return values[0]
+    batch_axes = _axis_names(len(batch_shape))
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    pattern = f"({batch_pattern}) N -> {batch_pattern} N"
+    return einx.id(pattern, values, **axis_lengths)  # ty: ignore[invalid-argument-type]

--- a/src/gaussx/_expfam/_gaussian.py
+++ b/src/gaussx/_expfam/_gaussian.py
@@ -8,6 +8,7 @@ import lineax as lx
 from einops import einsum
 from jaxtyping import Array, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._expfam._natural import mean_cov_to_natural, natural_to_mean_cov
 from gaussx._primitives._logdet import logdet
 from gaussx._primitives._solve import solve
@@ -129,8 +130,7 @@ def log_partition(expfam: GaussianExpFam) -> Float[Array, ""]:
     ld = -0.5 * logdet(neg2_eta2)
 
     # Add base measure contribution: N/2 * log(2pi)
-    log_2pi = jnp.log(2.0 * jnp.pi)
-    return quad + ld + 0.5 * N * log_2pi
+    return quad + ld + 0.5 * N * _LOG_2PI
 
 
 def fisher_info(

--- a/src/gaussx/_gp/_collapsed_elbo.py
+++ b/src/gaussx/_gp/_collapsed_elbo.py
@@ -7,6 +7,7 @@ import lineax as lx
 from jax import lax
 from jaxtyping import Array, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._primitives._cholesky import cholesky
 from gaussx._strategies._base import AbstractSolverStrategy
 
@@ -50,7 +51,6 @@ def collapsed_elbo(
     del solver  # cholesky does not accept a solver; parameter reserved for future use
     N = y.shape[0]
     M = K_zz.shape[0]
-    log_2pi = jnp.log(2.0 * jnp.pi)
 
     # L_zz L_zzᵀ = K_zz + jitter · I
     K_zz_jitter = K_zz + jitter * jnp.eye(M)
@@ -94,4 +94,4 @@ def collapsed_elbo(
     # where tr(Q_ff) = ‖V‖²_F
     trace_penalty = -0.5 / noise_var * (jnp.sum(K_diag) - jnp.sum(V**2))
 
-    return -0.5 * (log_det + quad + N * log_2pi) + trace_penalty
+    return -0.5 * (log_det + quad + N * _LOG_2PI) + trace_penalty

--- a/src/gaussx/_gp/_elbo.py
+++ b/src/gaussx/_gp/_elbo.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
+
 
 def variational_elbo_gaussian(
     y: Float[Array, " N"],
@@ -39,9 +41,8 @@ def variational_elbo_gaussian(
         Scalar ELBO value.
     """
     N = y.shape[-1]
-    log_2pi = jnp.log(2.0 * jnp.pi)
     residual = y - f_loc
-    ell = -0.5 * N * jnp.log(noise_var) - 0.5 * N * log_2pi
+    ell = -0.5 * N * jnp.log(noise_var) - 0.5 * N * _LOG_2PI
     ell = ell - 0.5 / noise_var * (jnp.sum(residual**2) + jnp.sum(f_var))
     return ell - kl
 

--- a/src/gaussx/_gp/_kronecker_gp.py
+++ b/src/gaussx/_gp/_kronecker_gp.py
@@ -9,22 +9,8 @@ import lineax as lx
 from einops import rearrange
 from jaxtyping import Array, Float
 
+from gaussx._distributions._utils import _axis_names
 from gaussx._primitives._eig import eig
-
-
-def _axis_names(count: int) -> tuple[str, ...]:
-    names = []
-    for index in range(count):
-        value = index
-        chars = []
-        while True:
-            value, remainder = divmod(value, 26)
-            chars.append(chr(ord("a") + remainder))
-            if value == 0:
-                break
-            value -= 1
-        names.append("".join(reversed(chars)))
-    return tuple(names)
 
 
 def _normalize_axis(axis: int, ndim: int) -> int:

--- a/src/gaussx/_kernels/_eigenpro.py
+++ b/src/gaussx/_kernels/_eigenpro.py
@@ -147,6 +147,17 @@ def eigenpro_step_size(
     function is JIT-friendly with either. Non-positive batch sizes raise
     (eagerly when ``batch_size`` is a Python int; traced via
     ``eqx.error_if`` when it is a JAX array).
+
+    Args:
+        precond: The EigenPro preconditioner carrying ``beta`` and the top
+            eigenvalue.
+        batch_size: Mini-batch size, as a Python int or scalar JAX array.
+
+    Returns:
+        Scalar preconditioned step size.
+
+    Raises:
+        ValueError: If ``batch_size`` is a Python int below 1.
     """
     if isinstance(batch_size, int) and batch_size < 1:
         raise ValueError("batch_size must be a positive integer.")
@@ -172,6 +183,17 @@ def eigenpro_correction(
     ``step_size`` may be a Python float or a scalar JAX array. Passing a
     JAX scalar avoids recompilation under ``jax.jit`` when the value
     changes between training steps.
+
+    Args:
+        precond: The EigenPro preconditioner carrying the top eigenvectors
+            ``V`` and spectral weights ``D``.
+        K_batch_sub: Kernel block between the mini-batch and the subsampled
+            points, shape ``(B, m)``.
+        gradient: Per-example gradients for the mini-batch, shape ``(B, C)``.
+        step_size: Scalar step size, as a Python float or scalar JAX array.
+
+    Returns:
+        Eigenspace correction over the subsampled points, shape ``(m, C)``.
     """
     step_size_arr = jnp.asarray(step_size, dtype=gradient.dtype)
     projected_gradient = precond.V.T @ (K_batch_sub.T @ gradient)

--- a/src/gaussx/_operators/_kronecker_sum.py
+++ b/src/gaussx/_operators/_kronecker_sum.py
@@ -128,7 +128,23 @@ class KroneckerSum(lx.AbstractLinearOperator):
 
 
 class KroneckerSumSqrt(lx.AbstractLinearOperator):
-    r"""Symmetric square root of ``A \oplus B`` via per-factor eigenvectors."""
+    r"""Symmetric square root of ``A \oplus B`` via per-factor eigenvectors.
+
+    Represents the symmetric matrix ``S`` with ``S @ S = A \oplus B``
+    (where ``\oplus`` is the Kronecker sum ``A ⊗ I + I ⊗ B``). The square
+    root is never materialized: :meth:`mv` and :meth:`solve` apply ``S`` and
+    ``S^{-1}`` matrix-free using the per-factor eigendecompositions, so the
+    cost is governed by the factor sizes rather than the full ``n_a · n_b``
+    dimension.
+
+    Args:
+        A: Symmetric PSD factor, shape ``(n_a, n_a)``.
+        B: Symmetric PSD factor, shape ``(n_b, n_b)``.
+
+    Raises:
+        ValueError: If either factor is non-square, untagged as symmetric, or
+            if ``A \oplus B`` is not positive semidefinite.
+    """
 
     eigenvectors_a: Float[Array, "a a"]
     eigenvectors_b: Float[Array, "b b"]
@@ -205,6 +221,14 @@ class KroneckerSumSqrt(lx.AbstractLinearOperator):
         return rearrange(result, "b a -> (a b)")
 
     def solve(self, vector: Float[Array, " n"]) -> Float[Array, " n"]:
+        """Apply the inverse square root ``S^{-1}`` to ``vector``.
+
+        Args:
+            vector: Input vector, shape ``(n_a · n_b,)``.
+
+        Returns:
+            ``S^{-1} @ vector``, shape ``(n_a · n_b,)``.
+        """
         X = rearrange(vector, "(a b) -> b a", a=self._n_a, b=self._n_b)
         C = self.eigenvectors_b.T @ X @ self.eigenvectors_a
         C = C / self.sqrt_eigenvalues.T
@@ -232,7 +256,24 @@ def kronecker_sum_sample(
     key: jax.Array,
     num_samples: int = 1,
 ) -> Float[Array, "num_samples n_a n_b"]:
-    """Sample from ``𝒩(0, A ⊕ B)`` using per-factor eigendecompositions."""
+    """Sample from ``𝒩(0, A ⊕ B)`` using per-factor eigendecompositions.
+
+    Draws zero-mean samples with covariance ``A ⊕ B`` by applying the
+    matrix-free :class:`KroneckerSumSqrt` to standard normal noise, avoiding
+    materialization of the full ``(n_a · n_b, n_a · n_b)`` covariance.
+
+    Args:
+        A_op: Symmetric PSD factor, shape ``(n_a, n_a)``.
+        B_op: Symmetric PSD factor, shape ``(n_b, n_b)``.
+        key: PRNG key for the standard normal draws.
+        num_samples: Number of samples to draw.
+
+    Returns:
+        Samples of shape ``(num_samples, n_a, n_b)``.
+
+    Raises:
+        ValueError: If ``num_samples`` is less than 1.
+    """
     if num_samples <= 0:
         raise ValueError(f"num_samples must be at least 1, got {num_samples}.")
 

--- a/src/gaussx/_primitives/_sqrt.py
+++ b/src/gaussx/_primitives/_sqrt.py
@@ -148,7 +148,18 @@ class SqrtOperator(lx.AbstractLinearOperator):
 
 
 class SumKroneckerSqrt(SqrtOperator):
-    """Lazy Lanczos square-root operator for ``SumKronecker`` covariances."""
+    """Lazy Lanczos square-root operator for ``SumKronecker`` covariances.
+
+    Specialization of :class:`SqrtOperator` that narrows ``original`` to a
+    :class:`SumKronecker` operator. :meth:`mv` computes ``sqrt(A) v`` via
+    matfree's Lanczos matrix-function product without materializing the full
+    square root.
+
+    Args:
+        original: The ``SumKronecker`` covariance to take the square root of.
+        lanczos_order: Number of Lanczos iterations; clamped to the operator
+            size.
+    """
 
     original: SumKronecker
 

--- a/src/gaussx/_ssm/_infinite_horizon_kalman.py
+++ b/src/gaussx/_ssm/_infinite_horizon_kalman.py
@@ -9,6 +9,7 @@ import lineax as lx
 from einops import repeat
 from jaxtyping import Array, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._linalg._linalg import sandwich, solve_rows
 from gaussx._linalg._lyapunov import discrete_lyapunov_solve
 from gaussx._ssm._dare import DAREResult, dare
@@ -131,7 +132,6 @@ def infinite_horizon_filter(
         H_op, P_pred_inf, R_for_innovation, woodbury=woodbury_innovation
     )
     ld_inf = dispatch_logdet(S_inf, solver)  # scalar
-    log_2pi = jnp.log(2.0 * jnp.pi)
 
     # Steady-state filtered covariance: P_filt = (I − K∞ H) P⁻pred
     HP_pred_inf = _left_matmul(H_op, P_pred_inf)
@@ -146,7 +146,7 @@ def infinite_horizon_filter(
 
         # Log-likelihood increment.
         Sinv_v = dispatch_solve(S_inf, v, solver)  # (M,)
-        ll_inc = -0.5 * (v @ Sinv_v + ld_inf + M * log_2pi)
+        ll_inc = -0.5 * (v @ Sinv_v + ld_inf + M * _LOG_2PI)
 
         return (x_filt_new, ll + ll_inc), (x_filt_new, x_pred)
 

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import lineax as lx
 from jaxtyping import Array, Bool, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._linalg._linalg import sandwich, solve_rows
 from gaussx._ssm._utils import (
     _innovation_covariance,
@@ -110,7 +111,6 @@ def kalman_filter(
     """
     M = observations.shape[-1]
     T = observations.shape[0]
-    log_2pi = jnp.log(2.0 * jnp.pi)
 
     # Closure-friendly matvec: when an operator is supplied, prefer its
     # structural ``mv`` over the dense ``A @ x``. Otherwise the
@@ -182,7 +182,7 @@ def kalman_filter(
 
             Sinv_v = dispatch_solve(S_op, v, solver)
             ld = dispatch_logdet(S_op, solver)
-            ll_inc = -0.5 * (v @ Sinv_v + ld + M * log_2pi)
+            ll_inc = -0.5 * (v @ Sinv_v + ld + M * _LOG_2PI)
             return x_upd, P_upd, ll_inc
 
         def _skip_update(_):

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -26,6 +26,8 @@ import jax.scipy.linalg
 import lineax as lx
 from jaxtyping import Array, Bool, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
+from gaussx._primitives._logdet import cholesky_logdet
 from gaussx._ssm._kalman import FilterState, kalman_filter
 from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
 from gaussx._strategies._base import AbstractSolverStrategy
@@ -264,8 +266,6 @@ def parallel_kalman_filter(
             log_likelihood=jnp.zeros((), dtype=init_mean.dtype),
         )
 
-    log_2pi = jnp.log(2.0 * jnp.pi)
-
     A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
         transition, obs_model, process_noise, obs_noise, T=T, mask=mask
     )
@@ -337,8 +337,8 @@ def parallel_kalman_filter(
         L = jnp.linalg.cholesky(S)
         Sinv_v = jax.scipy.linalg.cho_solve((L, True), v)
         quad = v @ Sinv_v
-        logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
-        contrib = -0.5 * (quad + logdet + M_obs * log_2pi)
+        logdet = cholesky_logdet(L)
+        contrib = -0.5 * (quad + logdet + M_obs * _LOG_2PI)
         return jnp.where(m, contrib, jnp.zeros_like(contrib))
 
     ll_contribs = jax.vmap(_ll_contrib)(

--- a/src/gaussx/_ssm/_parallel_kalman_sqrt.py
+++ b/src/gaussx/_ssm/_parallel_kalman_sqrt.py
@@ -8,6 +8,8 @@ import jax.scipy.linalg
 import lineax as lx
 from jaxtyping import Array, Bool, Float
 
+from gaussx._distributions._gaussian import _LOG_2PI
+from gaussx._primitives._logdet import cholesky_logdet
 from gaussx._ssm._kalman import FilterState
 from gaussx._ssm._parallel_kalman import (
     _bmv,
@@ -111,8 +113,6 @@ def parallel_kalman_filter_sqrt(
             log_likelihood=jnp.zeros((), dtype=init_mean.dtype),
         )
 
-    log_2pi = jnp.log(2.0 * jnp.pi)
-
     A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
         transition, obs_model, process_noise, obs_noise, T=T, mask=mask
     )
@@ -191,8 +191,8 @@ def parallel_kalman_filter_sqrt(
         L = jnp.linalg.cholesky(S)
         Sinv_v = jax.scipy.linalg.cho_solve((L, True), v)
         quad = v @ Sinv_v
-        logdet = 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
-        contrib = -0.5 * (quad + logdet + M_obs * log_2pi)
+        logdet = cholesky_logdet(L)
+        contrib = -0.5 * (quad + logdet + M_obs * _LOG_2PI)
         return jnp.where(m, contrib, jnp.zeros_like(contrib))
 
     ll_contribs = jax.vmap(_ll_contrib)(

--- a/src/gaussx/_strategies/_base.py
+++ b/src/gaussx/_strategies/_base.py
@@ -24,7 +24,15 @@ class AbstractSolveStrategy(eqx.Module):
         operator: lx.AbstractLinearOperator,
         vector: Float[Array, " n"],
     ) -> Float[Array, " n"]:
-        """Solve A x = b."""
+        """Solve ``A x = b``.
+
+        Args:
+            operator: Linear operator ``A``.
+            vector: Right-hand side ``b``, shape ``(n,)``.
+
+        Returns:
+            Solution ``x``, shape ``(n,)``.
+        """
         ...
 
 

--- a/src/gaussx/_strategies/_cg.py
+++ b/src/gaussx/_strategies/_cg.py
@@ -37,6 +37,15 @@ class CGSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         vector: Float[Array, " n"],
     ) -> Float[Array, " n"]:
+        """Solve ``A x = b`` with conjugate gradients.
+
+        Args:
+            operator: A PSD linear operator ``A``.
+            vector: Right-hand side ``b``, shape ``(n,)``.
+
+        Returns:
+            Solution ``x``, shape ``(n,)``.
+        """
         solver = lx.CG(rtol=self.rtol, atol=self.atol, max_steps=self.max_steps)
         return lx.linear_solve(operator, vector, solver).value
 

--- a/src/gaussx/_strategies/_composed.py
+++ b/src/gaussx/_strategies/_composed.py
@@ -43,7 +43,15 @@ class ComposedSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         vector: Float[Array, " n"],
     ) -> Float[Array, " n"]:
-        """Solve A x = b using the solve strategy."""
+        """Solve ``A x = b`` by delegating to ``solve_strategy``.
+
+        Args:
+            operator: Linear operator ``A``.
+            vector: Right-hand side ``b``, shape ``(n,)``.
+
+        Returns:
+            Solution ``x``, shape ``(n,)``.
+        """
         return self.solve_strategy.solve(operator, vector)
 
     def logdet(
@@ -52,5 +60,13 @@ class ComposedSolver(AbstractSolverStrategy):
         *,
         key: jax.Array | None = None,
     ) -> Float[Array, ""]:
-        """Compute log |det(A)| using the logdet strategy."""
+        """Compute ``log|det(A)|`` by delegating to ``logdet_strategy``.
+
+        Args:
+            operator: Linear operator ``A``.
+            key: Optional PRNG key forwarded to stochastic estimators.
+
+        Returns:
+            Scalar log-determinant.
+        """
         return self.logdet_strategy.logdet(operator, key=key)

--- a/src/gaussx/_strategies/_dense.py
+++ b/src/gaussx/_strategies/_dense.py
@@ -25,6 +25,15 @@ class DenseSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         vector: Float[Array, " n"],
     ) -> Float[Array, " n"]:
+        """Solve ``A x = b`` via structural dispatch (``gaussx.solve``).
+
+        Args:
+            operator: Linear operator ``A``.
+            vector: Right-hand side ``b``, shape ``(n,)``.
+
+        Returns:
+            Solution ``x``, shape ``(n,)``.
+        """
         return _solve(operator, vector)
 
     def logdet(
@@ -33,4 +42,14 @@ class DenseSolver(AbstractSolverStrategy):
         *,
         key: jax.Array | None = None,
     ) -> Float[Array, ""]:
+        """Compute ``log|det(A)|`` via structural dispatch (``gaussx.logdet``).
+
+        Args:
+            operator: Linear operator ``A``.
+            key: Unused; present for protocol compatibility with stochastic
+                estimators.
+
+        Returns:
+            Scalar log-determinant.
+        """
         return _logdet(operator)

--- a/src/gaussx/_strategies/_minres.py
+++ b/src/gaussx/_strategies/_minres.py
@@ -183,6 +183,15 @@ class MINRESSolver(AbstractSolverStrategy):
         operator: lx.AbstractLinearOperator,
         vector: Float[Array, " n"],
     ) -> Float[Array, " n"]:
+        """Solve ``(A + shift I) x = b`` with MINRES.
+
+        Args:
+            operator: A symmetric (possibly indefinite) linear operator ``A``.
+            vector: Right-hand side ``b``, shape ``(n,)``.
+
+        Returns:
+            Solution ``x``, shape ``(n,)``.
+        """
         return _minres_solve(
             operator.mv,
             vector,

--- a/src/gaussx/_tags.py
+++ b/src/gaussx/_tags.py
@@ -64,31 +64,67 @@ negative_semidefinite_tag = lx.negative_semidefinite_tag
 
 @ft.singledispatch
 def is_kronecker(operator: lx.AbstractLinearOperator) -> bool:
-    """Check whether *operator* carries the Kronecker tag."""
+    """Check whether *operator* carries the Kronecker tag.
+
+    Args:
+        operator: Linear operator to inspect.
+
+    Returns:
+        ``True`` if the operator carries the Kronecker tag, else ``False``.
+    """
     return False
 
 
 @ft.singledispatch
 def is_block_diagonal(operator: lx.AbstractLinearOperator) -> bool:
-    """Check whether *operator* carries the block-diagonal tag."""
+    """Check whether *operator* carries the block-diagonal tag.
+
+    Args:
+        operator: Linear operator to inspect.
+
+    Returns:
+        ``True`` if the operator carries the block-diagonal tag, else ``False``.
+    """
     return False
 
 
 @ft.singledispatch
 def is_low_rank(operator: lx.AbstractLinearOperator) -> bool:
-    """Check whether *operator* carries the low-rank tag."""
+    """Check whether *operator* carries the low-rank tag.
+
+    Args:
+        operator: Linear operator to inspect.
+
+    Returns:
+        ``True`` if the operator carries the low-rank tag, else ``False``.
+    """
     return False
 
 
 @ft.singledispatch
 def is_kronecker_sum(operator: lx.AbstractLinearOperator) -> bool:
-    """Check whether *operator* carries the Kronecker sum tag."""
+    """Check whether *operator* carries the Kronecker sum tag.
+
+    Args:
+        operator: Linear operator to inspect.
+
+    Returns:
+        ``True`` if the operator carries the Kronecker sum tag, else ``False``.
+    """
     return False
 
 
 @ft.singledispatch
 def is_block_tridiagonal(operator: lx.AbstractLinearOperator) -> bool:
-    """Check whether *operator* carries the block-tridiagonal tag."""
+    """Check whether *operator* carries the block-tridiagonal tag.
+
+    Args:
+        operator: Linear operator to inspect.
+
+    Returns:
+        ``True`` if the operator carries the block-tridiagonal tag, else
+        ``False``.
+    """
     return False
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -489,6 +489,20 @@ wheels = [
 ]
 
 [[package]]
+name = "einx"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozendict" },
+    { name = "numpy" },
+    { name = "sympy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/96/df2cfa7418b175dddcf30a88711d01b79a32c3ac4d64b379ed89a3de2c08/einx-0.4.3.tar.gz", hash = "sha256:be7d81ea1908b9f00e4a467840998fc483c33aa32aaaaa3ada6c8386f693edf9", size = 120087, upload-time = "2026-04-01T09:50:41.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/28/6768d342b2b888f9facdddbd430daf015cab936e2598281ab436b1be1b4a/einx-0.4.3-py3-none-any.whl", hash = "sha256:47ce54a0144f6dffcfacdd8fe2cc9e2e5e6485dda2471330ab75ee747dd22f39", size = 163766, upload-time = "2026-04-01T09:50:40.165Z" },
+]
+
+[[package]]
 name = "equinox"
 version = "0.13.8"
 source = { registry = "https://pypi.org/simple" }
@@ -581,11 +595,21 @@ wheels = [
 ]
 
 [[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
+]
+
+[[package]]
 name = "gaussx"
 version = "0.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },
+    { name = "einx" },
     { name = "equinox" },
     { name = "jax" },
     { name = "jaxlib" },
@@ -628,6 +652,7 @@ typecheck = [
 [package.metadata]
 requires-dist = [
     { name = "einops", specifier = ">=0.8" },
+    { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
     { name = "jax", specifier = ">=0.10" },
     { name = "jaxlib", specifier = ">=0.10" },
@@ -1400,6 +1425,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
     { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
     { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -2223,6 +2257,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A focused cleanup pass over `src/gaussx/`: remove genuine code duplication, apply DRY where a canonical helper/constant/primitive already exists, and fill the remaining public-API docstring gaps. Changes are surgical and behavior-preserving — no public signatures changed.

The codebase was already in good shape (most common helpers like `_sym`, `_to_frozenset`, `_resolve_dtype` were already centralized; docstring coverage was ~91%), so this is a tidy rather than a rewrite.

## Changes

**Deduplication**
- Consolidated the byte-identical `_axis_names`, `_reshape_batch`, and `_reshape_samples` helpers (previously copy-pasted across `_distributions/_mvn.py`, `_distributions/_mvn_prec.py`, and `_gp/_kronecker_gp.py`) into a new shared `_distributions/_utils.py`.

**DRY (constants & primitives)**
- Replaced ad-hoc `log(2*pi)` recomputations in the SSM, GP, expfam, and precision-MVN modules with the canonical `_LOG_2PI` constant from `_distributions._gaussian` (already used by `_quadrature` and `_inference`).
- Replaced the two inlined `2 * sum(log(diag(L)))` log-determinants in the parallel Kalman log-likelihood paths with the existing `cholesky_logdet` primitive.

**Docstrings (Google-style)**
- Added docstrings to previously undocumented/stub public symbols: solver-strategy `solve`/`logdet` overrides (Dense/CG/MinRes/Composed) and the `AbstractSolveStrategy.solve` protocol method; `KroneckerSumSqrt`, its `solve`, and `kronecker_sum_sample`; `SumKroneckerSqrt`; `eigenpro_step_size`/`eigenpro_correction` (formalized existing prose into Args/Returns); and the `is_*` structural tag predicates in `_tags.py`.

## einx

Per request, the shared reshape helpers in `_distributions/_utils.py` now use **`einx`** (`einx.id`) instead of `einops.rearrange`, and `einx` was added as a dependency. A repo-wide migration from einops to einx is deliberately **out of scope here** and tracked in #185.

A targeted `# ty: ignore[invalid-argument-type]` is applied on the `einx.id` calls — einx's public ops annotate tensor args with an internal `Tensor` type that `ty` resolves to a runtime stub class rather than `Any`, so JAX arrays would otherwise trip the type checker. See #185 for the consistent strategy to adopt during the sweep.

## Deliberately not done (judgment calls)

- **No docstrings on `cov_transform`'s `@overload` stubs** — adding docstrings to overload stubs is non-idiomatic (they're never executed; mkdocstrings documents the implementation, which already has a full docstring).
- **No generic cholesky+solve helper in the SSM module** — most sites factor `S` once and reuse the Cholesky factor for *multiple* solves, so a `(L, solution)` helper wouldn't fit and would reduce clarity. The genuine DRY win there (the duplicated logdet line) is covered by the `cholesky_logdet` change above.
- **`DenseFallbackWarning`** left as a one-line docstring — a `UserWarning` subclass doesn't warrant Args/Returns.

## Verification

All four gates green, run on the repo root:
- `pytest -q -n auto -m "not slow"` → **1175 passed** (9 pre-existing `SVDLowRankUpdate` deprecation warnings, unrelated)
- `ruff check .` → clean
- `ruff format --check .` → clean
- `ty check src/gaussx` → clean

Behavioral changes (einx swap, `_LOG_2PI`, `cholesky_logdet`) are exercised by the distributions, SSM, expfam, GP-ELBO, and Kronecker-GP suites.

Closes nothing; follow-up tracked in #185.

---
_Generated by [Claude Code](https://claude.ai/code/session_013vBCXLnk9W6aBkYpvq9iV5)_