### PR TITLE
refactor: port tensor reshaping/contraction from einops to einx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ All implementation lives in `src/gaussx/`. The public API is re-exported through
 | `lineax` | Linear operators, solvers |
 | `matfree` | Krylov methods, stochastic trace |
 | `jaxtyping` | Array type annotations |
-| `einops` | Tensor reshaping (D9: einops for all reshape/einsum) |
+| `einx` | Tensor reshaping/contraction (D9: einx for all reshape/einsum, via `gaussx._einx`) |
 
 ## Common Commands
 
@@ -83,7 +83,7 @@ uv run --group typecheck ty check src/gaussx  # Typecheck — package only
 - All operators are `equinox.Module` subclasses (immutable, PyTree-compatible)
 - All primitives are pure functions with isinstance-based dispatch
 - Use `jaxtyping` annotations for array shapes
-- Use `einops` for all tensor reshaping — no raw `jnp.reshape`/`jnp.transpose`/`jnp.einsum`
+- Use `einx` (via the `gaussx._einx` wrappers) for all tensor reshaping/contraction — no raw `jnp.reshape`/`jnp.transpose`/`jnp.einsum`
 - Google-style docstrings
 - Type hints on all public functions and methods
 - Pure functions where possible; side effects isolated and explicit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ Structured operators extending `lineax.AbstractLinearOperator`. Each is an `equi
 
 | Operator | Represents | Efficient `mv` |
 |----------|-----------|----------------|
-| `Kronecker(A, B, ...)` | $A \otimes B \otimes \cdots$ | Roth's column lemma via einops |
+| `Kronecker(A, B, ...)` | $A \otimes B \otimes \cdots$ | Roth's column lemma via einx |
 | `BlockDiag(A, B, ...)` | $\mathrm{diag}(A, B, \ldots)$ | Per-block, concatenate |
 | `BlockTriDiag(D, A)` | Symmetric block-tridiagonal precision | Banded block matvec |
 | `LowRankUpdate(L, U, d, V)` | $L + U \mathrm{diag}(d) V^\top$ | Base mv + rank-k update |
@@ -128,7 +128,7 @@ Query functions (`is_kronecker`, `is_block_diagonal`, `is_low_rank`, plus all li
 | `lineax` | Linear operators, solvers | Yes |
 | `matfree` | Krylov methods, stochastic trace | Yes |
 | `jaxtyping` | Array type annotations | Yes |
-| `einops` | Tensor reshaping (Principle 5) | Yes |
+| `einx` | Tensor reshaping/contraction (Principle 5) | Yes |
 | `numpyro` | Distributions (Layer 2) | Planned |
 
 ## Package Layout

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -63,7 +63,7 @@ Meanwhile, the existing tools each solve *part* of the problem:
 | 2 | **Structure drives dispatch** | Operators carry structural tags (PSD, symmetric, Kronecker, ...). Primitives inspect types + tags via isinstance to select the efficient code path. No magic. |
 | 3 | **Math-first layers** | Layer 0 functions match the equations in papers: `solve(A, b)`, `logdet(A)`, `cholesky(A)`. A researcher should read the code and see the math. |
 | 4 | **One distribution, many strategies** | `MultivariateNormal` accepts any covariance operator and any solver strategy. The distribution handles the math, the solver handles the numerics. |
-| 5 | **einops for readability** | All tensor reshaping uses `rearrange` and `einsum`. Kronecker `mv` reads like Roth's column lemma. |
+| 5 | **einx for readability** | All tensor reshaping uses `rearrange` and `einsum`. Kronecker `mv` reads like Roth's column lemma. |
 
 ## What gaussx is NOT
 
@@ -85,7 +85,7 @@ Meanwhile, the existing tools each solve *part* of the problem:
                     └──────┬───────┘
                            │ extends
                     ┌──────▼───────┐
-                    │    gaussx    │  ← equinox, jaxtyping, einops
+                    │    gaussx    │  ← equinox, jaxtyping, einx
                     └──────┬───────┘
                            │ consumed by
            ┌───────────────┼───────────────┐

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "lineax>=0.1.1",
     "matfree>=0.5",
     "jaxtyping>=0.3",
-    "einops>=0.8",
     "einx>=0.4.3",
 ]
 
@@ -46,6 +45,7 @@ dev = [
     "pre-commit>=3.7",
     "beartype>=0.18",
     "numpyro>=0.21",
+    "einops>=0.8",
 ]
 lint = [
     "ruff>=0.15.10",

--- a/src/gaussx/_distributions/_mvn.py
+++ b/src/gaussx/_distributions/_mvn.py
@@ -6,7 +6,6 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 import numpyro.distributions as dist
-from einops import rearrange
 from jaxtyping import Array, Float
 from numpyro.distributions.util import lazy_property, validate_sample
 
@@ -15,6 +14,7 @@ from gaussx._distributions._gaussian import (
     gaussian_entropy,
 )
 from gaussx._distributions._utils import _reshape_batch, _reshape_samples
+from gaussx._einx import rearrange
 from gaussx._primitives._cholesky import cholesky as _cholesky
 from gaussx._primitives._diag import diag as _diag
 from gaussx._strategies._auto import AutoSolver

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -6,12 +6,12 @@ import jax
 import jax.numpy as jnp
 import lineax as lx
 import numpyro.distributions as dist
-from einops import rearrange
 from jaxtyping import Array, Float
 from numpyro.distributions.util import lazy_property, validate_sample
 
 from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._distributions._utils import _reshape_batch, _reshape_samples
+from gaussx._einx import rearrange
 from gaussx._primitives._cholesky import cholesky as _cholesky
 from gaussx._primitives._diag import diag as _diag
 from gaussx._primitives._inv import inv as _inv

--- a/src/gaussx/_distributions/_utils.py
+++ b/src/gaussx/_distributions/_utils.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import einx
 from jaxtyping import Array, Float
+
+from gaussx._einx import rearrange
 
 
 def _axis_names(count: int) -> tuple[str, ...]:
     """Generate ``count`` spreadsheet-style axis names for rearrange patterns.
 
     Produces ``("a", "b", ..., "z", "aa", "ab", ...)`` so that an arbitrary
-    number of batch axes can be referenced by name in an einops/einx pattern.
+    number of batch axes can be referenced by name in an einx pattern.
 
     Args:
         count: Number of axis names to generate.
@@ -51,7 +52,7 @@ def _reshape_batch(
     batch_axes = _axis_names(len(batch_shape))
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
-    return einx.id(f"({batch_pattern}) -> {batch_pattern}", values, **axis_lengths)  # ty: ignore[invalid-argument-type]
+    return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
 
 
 def _reshape_samples(
@@ -74,4 +75,4 @@ def _reshape_samples(
     axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
     batch_pattern = " ".join(batch_axes)
     pattern = f"({batch_pattern}) N -> {batch_pattern} N"
-    return einx.id(pattern, values, **axis_lengths)  # ty: ignore[invalid-argument-type]
+    return rearrange(values, pattern, **axis_lengths)

--- a/src/gaussx/_einx.py
+++ b/src/gaussx/_einx.py
@@ -1,0 +1,84 @@
+"""Typed einx adapters for tensor reshaping and contraction.
+
+einx (https://github.com/fferflo/einx) is the tensor-manipulation backend
+for gaussx. These thin wrappers expose einops-compatible signatures with
+permissive typing, so the rest of the package can reshape and contract
+arrays without tripping the type checker on einx's internal ``Tensor``
+annotations. Import these helpers instead of using ``einx`` (or ``einops``)
+directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import einx
+from jaxtyping import Array
+
+
+def rearrange(tensor: Array, pattern: str, **axes: int) -> Array:
+    """Reorder/reshape ``tensor`` according to an einx pattern.
+
+    einops-compatible wrapper around :func:`einx.id`.
+
+    Args:
+        tensor: Input array.
+        pattern: einx rearrange pattern, e.g. ``"a b -> b a"``.
+        **axes: Named axis lengths referenced in ``pattern``.
+
+    Returns:
+        The rearranged array.
+    """
+    return einx.id(pattern, tensor, **axes)  # ty: ignore[invalid-argument-type]
+
+
+def repeat(tensor: Array, pattern: str, **axes: int) -> Array:
+    """Broadcast/repeat ``tensor`` along new axes via an einx pattern.
+
+    einops-compatible wrapper around :func:`einx.id`.
+
+    Args:
+        tensor: Input array.
+        pattern: einx pattern introducing new axes, e.g. ``"a -> a r"``.
+        **axes: Named lengths for the introduced axes.
+
+    Returns:
+        The expanded array.
+    """
+    return einx.id(pattern, tensor, **axes)  # ty: ignore[invalid-argument-type]
+
+
+def reduce(tensor: Array, pattern: str, reduction: str, **axes: int) -> Array:
+    """Reduce ``tensor`` along axes dropped by an einx pattern.
+
+    einops-compatible wrapper that dispatches to the matching einx reduction
+    (``einx.sum``, ``einx.prod``, ``einx.mean``, ...).
+
+    Args:
+        tensor: Input array.
+        pattern: einx reduction pattern, e.g. ``"a b -> a"``.
+        reduction: Reduction name (``"sum"``, ``"prod"``, ``"mean"``, ...).
+        **axes: Named axis lengths referenced in ``pattern``.
+
+    Returns:
+        The reduced array.
+    """
+    op = getattr(einx, reduction)
+    return op(pattern, tensor, **axes)
+
+
+def einsum(*operands: Any) -> Array:
+    """Contract tensors via an einx pattern (``einops.einsum``-compatible).
+
+    The trailing positional argument is the pattern; all preceding arguments
+    are the input tensors. Wraps :func:`einx.dot`.
+
+    Args:
+        *operands: Input tensors followed by the einx pattern string, e.g.
+            ``einsum(a, b, "i j, j k -> i k")``.
+
+    Returns:
+        The contracted array.
+    """
+    *tensors, pattern = operands
+    return einx.dot(pattern, *tensors)

--- a/src/gaussx/_expfam/_gaussian.py
+++ b/src/gaussx/_expfam/_gaussian.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 import lineax as lx
-from einops import einsum
 from jaxtyping import Array, Float
 
 from gaussx._distributions._gaussian import _LOG_2PI
+from gaussx._einx import einsum
 from gaussx._expfam._natural import mean_cov_to_natural, natural_to_mean_cov
 from gaussx._primitives._logdet import logdet
 from gaussx._primitives._solve import solve

--- a/src/gaussx/_gp/_base_conditional.py
+++ b/src/gaussx/_gp/_base_conditional.py
@@ -6,9 +6,9 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg as jsla
 import lineax as lx
-from einops import rearrange, repeat
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange, repeat
 from gaussx._primitives._cholesky import cholesky
 from gaussx._strategies._base import AbstractSolverStrategy
 

--- a/src/gaussx/_gp/_kronecker_gp.py
+++ b/src/gaussx/_gp/_kronecker_gp.py
@@ -6,10 +6,10 @@ import functools as ft
 
 import jax.numpy as jnp
 import lineax as lx
-from einops import rearrange
 from jaxtyping import Array, Float
 
 from gaussx._distributions._utils import _axis_names
+from gaussx._einx import rearrange
 from gaussx._primitives._eig import eig
 
 

--- a/src/gaussx/_gp/_prediction_cache.py
+++ b/src/gaussx/_gp/_prediction_cache.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import equinox as eqx
 import lineax as lx
-from einops import reduce
 from jaxtyping import Array, Float
 
+from gaussx._einx import reduce
 from gaussx._strategies._base import AbstractSolveStrategy
 from gaussx._strategies._dispatch import dispatch_solve
 

--- a/src/gaussx/_gp/_svgp.py
+++ b/src/gaussx/_gp/_svgp.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 import lineax as lx
-from einops import reduce
 from jaxtyping import Array, Float
 
+from gaussx._einx import reduce
 from gaussx._primitives._cholesky import cholesky
 
 

--- a/src/gaussx/_inference/_blr.py
+++ b/src/gaussx/_inference/_blr.py
@@ -7,10 +7,10 @@ from collections.abc import Callable
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import reduce
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
+from gaussx._einx import reduce
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._dispatch import dispatch_solve
 

--- a/src/gaussx/_kernels/_grid.py
+++ b/src/gaussx/_kernels/_grid.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
-from einops import rearrange
 from jaxtyping import Array, Float, Int
+
+from gaussx._einx import rearrange
 
 
 def create_grid(

--- a/src/gaussx/_linalg/_batched_matvec.py
+++ b/src/gaussx/_linalg/_batched_matvec.py
@@ -6,8 +6,9 @@ from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
-from einops import rearrange
 from jaxtyping import Array, Float
+
+from gaussx._einx import rearrange
 
 
 def batched_kernel_matvec(

--- a/src/gaussx/_linalg/_diag_inv.py
+++ b/src/gaussx/_linalg/_diag_inv.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import reduce
 from jaxtyping import Array, Float
 
+from gaussx._einx import reduce
 from gaussx._linalg._safe_cholesky import safe_cholesky
 from gaussx._strategies._base import AbstractSolveStrategy
 from gaussx._strategies._dispatch import dispatch_solve

--- a/src/gaussx/_linalg/_linalg.py
+++ b/src/gaussx/_linalg/_linalg.py
@@ -8,9 +8,9 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg
 import lineax as lx
-from einops import reduce
 from jaxtyping import Array, Float
 
+from gaussx._einx import reduce
 from gaussx._linalg._schur import conditional_variance as _conditional_variance
 from gaussx._primitives._cholesky import cholesky
 from gaussx._primitives._solve import solve

--- a/src/gaussx/_linalg/_mixed_precision.py
+++ b/src/gaussx/_linalg/_mixed_precision.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
-from einops import reduce
 from jaxtyping import Array, Float
+
+from gaussx._einx import reduce
 
 
 def stable_squared_distances(

--- a/src/gaussx/_operators/_block_tridiag.py
+++ b/src/gaussx/_operators/_block_tridiag.py
@@ -6,9 +6,9 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import einsum, rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import einsum, rearrange
 from gaussx._operators._block_diag import _to_frozenset
 
 

--- a/src/gaussx/_operators/_implicit_cross_kernel.py
+++ b/src/gaussx/_operators/_implicit_cross_kernel.py
@@ -9,9 +9,9 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import rearrange
 from jaxtyping import Array, Float, PyTree
 
+from gaussx._einx import rearrange
 from gaussx._operators._block_diag import _to_frozenset
 from gaussx._operators._utils import vmap_over_batch_dims
 

--- a/src/gaussx/_operators/_kronecker.py
+++ b/src/gaussx/_operators/_kronecker.py
@@ -6,9 +6,9 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange
 from gaussx._operators._block_diag import _resolve_dtype, _to_frozenset
 
 

--- a/src/gaussx/_operators/_kronecker_sum.py
+++ b/src/gaussx/_operators/_kronecker_sum.py
@@ -6,9 +6,9 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange
 from gaussx._operators._block_diag import _resolve_dtype, _to_frozenset
 
 

--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -6,9 +6,9 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange
 from gaussx._operators._block_diag import _resolve_dtype, _to_frozenset
 from gaussx._operators._kronecker import Kronecker
 

--- a/src/gaussx/_primitives/_diag.py
+++ b/src/gaussx/_primitives/_diag.py
@@ -60,7 +60,7 @@ def _diag_kronecker(operator: Kronecker) -> Float[Array, " n"]:
 
 def _diag_block_tridiag(operator: BlockTriDiag) -> Float[Array, " n"]:
     """Extract block-diagonal entries of a block-tridiagonal operator."""
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     # diagonal blocks contain the diagonal entries
     block_diags = jax.vmap(jnp.diag)(operator.diagonal)  # (N, d)

--- a/src/gaussx/_primitives/_solve.py
+++ b/src/gaussx/_primitives/_solve.py
@@ -97,7 +97,7 @@ def _solve_kronecker(
     Uses the same reshape trick as Kronecker.mv but with
     per-factor solves: solve(A_i^T, ...) instead of mat @ ....
     """
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     x = vector
     for i in range(len(operator.operators) - 1, -1, -1):
@@ -189,7 +189,7 @@ def _solve_kronecker_sum(
     BlockDiag, Kronecker, KroneckerSum) skip materialization; otherwise
     falls back to ``jnp.linalg.eigh`` on the materialized factor.
     """
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     # The decomposition requires symmetric factors so the eigenvector
     # matrices are orthonormal (the formula uses ``Q^T`` as the inverse
@@ -231,7 +231,7 @@ def _solve_lower_block_tridiag(
     """Forward substitution for lower block-bidiagonal system."""
     N = operator._num_blocks
     d = operator._block_size
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     b = rearrange(vector, "(N d) -> N d", N=N, d=d)
 
@@ -256,7 +256,7 @@ def _solve_upper_block_tridiag(
     """Backward substitution for upper block-bidiagonal system."""
     N = operator._num_blocks
     d = operator._block_size
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     b = rearrange(vector, "(N d) -> N d", N=N, d=d)
 

--- a/src/gaussx/_quadrature/_gp_predict.py
+++ b/src/gaussx/_quadrature/_gp_predict.py
@@ -60,7 +60,7 @@ def kernel_expectations(
         k_vec = jax.vmap(lambda xi: kernel_fn(x, xi))(X_train)
         return jnp.outer(k_vec, k_vec)
 
-    from einops import rearrange
+    from gaussx._einx import rearrange
 
     N_train = X_train.shape[0]
     psi2_flat_fn = lambda x: rearrange(psi2_fn(x), "i j -> (i j)")

--- a/src/gaussx/_quadrature/_likelihoods.py
+++ b/src/gaussx/_quadrature/_likelihoods.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from einops import rearrange
 from jaxtyping import Array, Float, Int
 
+from gaussx._einx import rearrange
 from gaussx._quadrature._likelihood import AbstractLikelihood
 
 

--- a/src/gaussx/_quadrature/_psi_statistics.py
+++ b/src/gaussx/_quadrature/_psi_statistics.py
@@ -7,9 +7,9 @@ from typing import Protocol, cast, runtime_checkable
 
 import jax
 import jax.numpy as jnp
-from einops import rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange
 from gaussx._quadrature._integrator import AbstractIntegrator
 from gaussx._quadrature._types import GaussianState
 

--- a/src/gaussx/_quadrature/_quadrature.py
+++ b/src/gaussx/_quadrature/_quadrature.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import jax.numpy as jnp
 import lineax as lx
 import numpy as np
-from einops import rearrange, reduce
 from jaxtyping import Array, Float
 
+from gaussx._einx import rearrange, reduce
 from gaussx._primitives._sqrt import sqrt
 
 

--- a/src/gaussx/_ssm/_infinite_horizon_kalman.py
+++ b/src/gaussx/_ssm/_infinite_horizon_kalman.py
@@ -6,10 +6,10 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import repeat
 from jaxtyping import Array, Float
 
 from gaussx._distributions._gaussian import _LOG_2PI
+from gaussx._einx import repeat
 from gaussx._linalg._linalg import sandwich, solve_rows
 from gaussx._linalg._lyapunov import discrete_lyapunov_solve
 from gaussx._ssm._dare import DAREResult, dare

--- a/src/gaussx/_ssm/_spingp.py
+++ b/src/gaussx/_ssm/_spingp.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import einsum, rearrange, repeat
 from jaxtyping import Array, Float
 
+from gaussx._einx import einsum, rearrange, repeat
 from gaussx._operators._block_tridiag import BlockTriDiag
 from gaussx._primitives._inv import inv
 from gaussx._primitives._logdet import logdet

--- a/src/gaussx/_ssm/_ssm_natural.py
+++ b/src/gaussx/_ssm/_ssm_natural.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
-from einops import einsum, rearrange
 from jaxtyping import Array, Float
 
+from gaussx._einx import einsum, rearrange
 from gaussx._operators._block_tridiag import BlockTriDiag
 from gaussx._primitives._inv import inv
 from gaussx._strategies._base import AbstractSolverStrategy

--- a/uv.lock
+++ b/uv.lock
@@ -608,7 +608,6 @@ name = "gaussx"
 version = "0.0.15"
 source = { editable = "." }
 dependencies = [
-    { name = "einops" },
     { name = "einx" },
     { name = "equinox" },
     { name = "jax" },
@@ -626,6 +625,7 @@ numpyro = [
 [package.dev-dependencies]
 dev = [
     { name = "beartype" },
+    { name = "einops" },
     { name = "numpyro" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -651,7 +651,6 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
-    { name = "einops", specifier = ">=0.8" },
     { name = "einx", specifier = ">=0.4.3" },
     { name = "equinox", specifier = ">=0.13.8" },
     { name = "jax", specifier = ">=0.10" },
@@ -666,6 +665,7 @@ provides-extras = ["numpyro"]
 [package.metadata.requires-dev]
 dev = [
     { name = "beartype", specifier = ">=0.18" },
+    { name = "einops", specifier = ">=0.8" },
     { name = "numpyro", specifier = ">=0.21" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.0" },


### PR DESCRIPTION
Closes #185.

## Summary

Migrates the whole package from `einops` to [`einx`](https://github.com/fferflo/einx) as the tensor-manipulation backend.

The core of the change is a new thin adapter module, **`gaussx/_einx.py`**, exposing `rearrange` / `repeat` / `reduce` / `einsum` with **einops-compatible signatures** but powered by einx (`einx.id`, `einx.sum`/`einx.prod`, `einx.dot`). Because the signatures match einops exactly, every call site migrates with a pure import swap — no argument reordering — keeping the diff minimal and reviewable (28 modules, mostly one line each).

## Why a wrapper (the design decision from #185)

einx's public ops annotate their tensor arguments with an internal `Tensor` type that `ty` resolves to a runtime stub class rather than `Any`, so passing JAX arrays trips `invalid-argument-type`. Routing everything through `_einx.py` centralizes that friction: the **only two `# ty: ignore` directives** live in `rearrange`/`repeat` (where `**axes` forwarding could collide with einx's `backend` kwarg), instead of being scattered across ~50 call sites. It's also a single place to adjust if einx's API shifts.

## Mapping (verified equivalent to einops on every pattern actually used)

| einops | einx (via `_einx`) |
|---|---|
| `rearrange(x, p)` | `einx.id(p, x)` |
| `repeat(x, p, **a)` | `einx.id(p, x, **a)` |
| `reduce(x, p, "sum"/"prod")` | `einx.sum/prod(p, x)` |
| `einsum(a, b, p)` | `einx.dot(p, a, b)` |

Included tricky cases that all matched: scalar reduce `"i j -> "`, ellipsis-flatten `"D ... -> (...)"`, and batched outer products `"N i, N j -> N i j"`.

## Dependency change

`einops` is no longer a runtime dependency — moved from `[project].dependencies` to the `dev` group, where `tests/operators/test_kronecker_sum.py` still uses it as an independent reshape oracle. Confirmed `einops` is not imported at runtime (`einops in sys.modules` is `False` after `import gaussx`). `einx` added as the runtime dependency.

Convention D9 references updated in `CLAUDE.md`, `docs/architecture.md`, and `docs/vision.md`.

## Verification

All four gates green locally:
- `pytest -q -n auto` (full suite, incl. slow MCMC/SVI) → **1187 passed** (10 pre-existing warnings, unrelated)
- `ruff check .` → clean
- `ruff format --check .` → clean
- `ty check src/gaussx` → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_013vBCXLnk9W6aBkYpvq9iV5)_