### PR TITLE
feat(solvers): unified solver substrate — front door, preconditioners, capacitance, tridiagonal

### DIFF
--- a/docs/design/unified-solvers.md
+++ b/docs/design/unified-solvers.md
@@ -1,0 +1,477 @@
+# Unified Solvers in gaussx — Design & Execution Plan
+
+**Status:** gaussx side (Phases 0–3) implemented; PDE-package wrappers in progress
+**Repos in scope:** `gaussx` (hub), `spectraldiffx`, `finitevolX`
+
+---
+
+## 1. Motivation
+
+Three JAX libraries have grown overlapping numerical-solver machinery:
+
+- **gaussx** — structured *probabilistic* linear algebra. Solves `A x = b` and
+  `logdet(A)` for PSD covariance/precision operators (CG, MINRES, LSMR,
+  preconditioned CG, BBMM, SLQ). Built on `lineax` + `matfree` + `equinox`.
+- **finitevolX** — finite-volume operators on Arakawa C-grids. Re-implements its
+  own CG loop (`solve_cg`), three preconditioners (spectral, Nyström,
+  multigrid), tridiagonal solves, and a masked-Laplacian operator.
+- **spectraldiffx** — pseudospectral PDE discretization. Owns spectral
+  Helmholtz/Poisson solvers and a **capacitance-matrix** solver for masked
+  irregular domains (a low-rank correction around a fast base solve).
+
+The duplication is concentrated in the **raw linear-solver + preconditioner
+layer**. The same CG loop, the same Nyström preconditioner idea, and the same
+Sherman–Morrison/Woodbury correction (capacitance) exist in two or three places,
+each separately tested and separately maintained.
+
+There is also a deeper **mathematical** reason to unify (see §3): elliptic PDE
+operators and Gaussian covariance/precision operators are, under the SPDE view,
+*the same objects*. gaussx already models a chunk of this (`Toeplitz`,
+`KroneckerSum`, `_ssm/_matern`, `_sde_kernel`, `spingp`).
+
+### Goals (ranked, from the scoping discussion)
+
+1. **Kill duplicated CG / preconditioner code** — one tested implementation.
+2. **Easier maintenance / testing** — solver numerics tested once, in gaussx.
+3. **Mathematical unification (SPDE / GP ↔ PDE)** — elliptic operators and
+   covariance operators share the same solver substrate.
+
+### Non-goals / explicit scope boundaries
+
+gaussx must remain *structured ops + raw solvers*. It will **not** acquire:
+
+- grids, coordinates, or grid spacing as first-class concepts;
+- boundary-condition modelling (Dirichlet/Neumann/periodic dispatch);
+- spectral transforms (FFT / DST / DCT / SHT);
+- mask → boundary-index extraction (which cells are land/ocean/boundary);
+- multigrid V-cycles or spectral Helmholtz field solvers.
+
+Those stay in `finitevolX` / `spectraldiffx`. They cross the boundary only as
+**passed-in callables/operators** (e.g. "here is an approximate inverse, use it
+as a preconditioner").
+
+---
+
+## 2. User stories
+
+- **As a finitevolX user**, I call `fvx.solve_cg(matvec, rhs, preconditioner=...)`
+  exactly as before, but the CG loop and the Nyström preconditioner are now
+  gaussx code — one implementation, fixed and tuned in one place.
+
+- **As a spectraldiffx user**, I call `build_capacitance_solver(mask, dx, dy)`
+  as before; internally it extracts the boundary ring (spectral concern) and
+  hands gaussx the *base solve callable* + *boundary indices*, getting back a
+  reusable capacitance operator.
+
+- **As a gaussx user doing GP regression on a grid**, I can build a
+  `NystromPreconditioner` or a `JacobiPreconditioner` and pass it straight into
+  `CGSolver` / `PreconditionedCGSolver`, instead of preconditioning living only
+  inside `PreconditionedCGSolver`.
+
+- **As a maintainer**, when a CG edge case (e.g. zero rhs, NaN guard, max-steps
+  behaviour) needs fixing, I fix it once in gaussx and all three libraries
+  inherit it.
+
+- **As a researcher bridging GP and PDE**, I can take an elliptic operator from a
+  PDE package and a covariance operator from gaussx and solve both through the
+  same `gaussx.linear_solve(A, b, solver=..., preconditioner=...)` front door.
+
+---
+
+## 3. Math background
+
+### 3.1 The SPDE / GMRF bridge (why this is one problem, not two)
+
+The Whittle–Matérn SPDE (Lindgren, Rue & Lindgren, 2011) states that a Gaussian
+field `u` with Matérn covariance is the stationary solution of
+
+```
+(κ² − Δ)^{α/2} u(x) = 𝒲(x),     α = ν + d/2
+```
+
+where `𝒲` is white noise and `Δ` the Laplacian. Discretised, the **precision**
+matrix `Q` of the Matérn field is a (power of a) **Helmholtz operator**
+`κ²I − Δ`. Consequences relevant here:
+
+- A **separable Laplacian** on a tensor grid is `Δ = Δ_x ⊕ Δ_y` — exactly
+  gaussx's `KroneckerSum`, which it already solves by eigendecomposition.
+- A **stationary kernel on a regular grid** is Toeplitz / BTTB = an FFT
+  convolution — exactly gaussx's `Toeplitz` (circulant embedding) and exactly
+  spectraldiffx's FFT-diagonalised Helmholtz inverse.
+- A **Helmholtz / Laplacian operator** diagonalised in a spectral basis is a
+  `diag-in-eigenbasis` operator: `solve` and `logdet` are elementwise on the
+  eigenvalues — the same shape as gaussx's structured primitives.
+
+So "the covariance operator" and "the elliptic operator" are the same algebraic
+object viewed from two communities. Unifying the *solvers* is the engineering
+expression of that fact.
+
+### 3.2 Conjugate Gradient + preconditioning
+
+For SPD `A`, CG solves `A x = b` in Krylov space. Convergence depends on
+`κ(A) = λ_max/λ_min`. A preconditioner `M ≈ A` (cheap to invert) replaces the
+spectrum of `A` with that of `M⁻¹A`. The four preconditioners in play:
+
+| Preconditioner | `M⁻¹` is… | Generic? |
+|---|---|---|
+| Jacobi | `diag(A)⁻¹` | yes |
+| Nyström / partial-Cholesky | low-rank approx inverse from a few matvecs | yes |
+| Spectral | an FFT/DST/DCT Helmholtz solve used as approx inverse | **no** (needs transforms) |
+| Multigrid | one V-cycle used as approx inverse | **no** (needs grid/mask) |
+
+The generic two move into gaussx as concrete classes. The PDE-specific two are
+*adapted* into gaussx's preconditioner protocol via a generic
+`OperatorPreconditioner(approx_inverse)` wrapper — the concrete approximate
+inverse is built in the PDE repo and passed in. This is what dodges the
+dependency cycle (gaussx must never import spectraldiffx/finitevolX).
+
+### 3.3 Capacitance matrix method (Sherman–Morrison / Woodbury)
+
+To solve `A u = f` on an irregular domain Ω embedded in a regular domain R for
+which a *fast* solver `B⁻¹` exists (FFT/DST/DCT):
+
+1. Treat the `N_b` boundary unknowns as constraints. Define Green's functions
+   `g_b = B⁻¹ e_b` for each boundary index `b` (one fast solve each, **offline**).
+2. Form the **capacitance matrix** `C` = restriction of the Green's functions to
+   the boundary rows; precompute `C⁻¹` (small, `N_b × N_b`).
+3. **Online:** `u = B⁻¹f − G (C⁻¹ (R_b B⁻¹ f − target))`, i.e. one fast base
+   solve plus an `N_b`-sized correction.
+
+This is precisely a **Woodbury / low-rank update** around the base solve — and
+gaussx *already* has `LowRankUpdate`, `SVDLowRankUpdate`, Woodbury and Schur
+machinery. The generic algebra (given `B⁻¹` and the boundary index set) belongs
+in gaussx; *which* cells are boundary and *which* `B⁻¹` to use stay in the PDE
+repos.
+
+---
+
+## 4. Current state
+
+### 4.1 gaussx (`src/gaussx/`)
+
+- `_strategies/_base.py` — `AbstractSolveStrategy.solve(operator, vector)`,
+  `AbstractLogdetStrategy.logdet(operator, *, key)`, `AbstractSolverStrategy`.
+  All `equinox.Module`, operate on `lineax.AbstractLinearOperator`.
+- `_strategies/{_cg,_minres,_lsmr,_dense,_bbmm,_precond_cg,_slq_logdet,_auto,
+  _composed}.py` — concrete strategies. **PSD-assuming.**
+- `_strategies/_dispatch.py` — `dispatch_solve` / `dispatch_logdet` (fall back to
+  primitives when `solver is None`).
+- `_precond_cg.py` — preconditioning is **buried inside** `PreconditionedCGSolver`
+  (partial pivoted Cholesky via `matfree.low_rank`). Not reusable standalone.
+- `_operators/` — `Kronecker`, `KroneckerSum`, `BlockDiag`, `BlockTriDiag`,
+  `LowRankUpdate`, `SVDLowRankUpdate`, `Toeplitz`, kernel operators, lazy algebra.
+- `_linalg/_woodbury.py`, `_schur.py` — low-rank correction algebra (capacitance
+  building blocks already exist here).
+- **No** raw-`matvec` front door, **no** standalone preconditioner objects,
+  **no** capacitance operator, **no** indefinite/negative-definite front-door
+  handling.
+
+### 4.2 finitevolX (`finitevolx/_src/solvers/`)
+
+- `iterative.py` — `solve_cg(matvec, rhs, x0, preconditioner, rtol, atol,
+  max_steps) -> (x, CGInfo)`, `CGInfo(iterations, residual_norm, converged)`,
+  `masked_laplacian(psi, mask, dx, dy, lambda_)`. Operates on **raw-array matvec**
+  for **negative-definite** masked Laplacians.
+- `preconditioners.py` — `make_preconditioner(kind, ...)`,
+  `make_spectral_preconditioner(dx, dy, lambda_, bc)`,
+  `make_nystrom_preconditioner(matvec, shape, rank, key)`,
+  `make_multigrid_preconditioner(mg_solver)`.
+- `tridiagonal.py` — `solve_tridiagonal`, `solve_tridiagonal_batched` (thin
+  wrappers over `lineax.Tridiagonal`).
+- `multigrid.py` — geometric V-cycle, Arakawa-C face staggering, mask
+  restriction/prolongation. **Stays in finitevolX.**
+- `spectral.py`, `spectral_transforms.py` — pure re-exports of spectraldiffx.
+- `elliptic.py` — convenience wrappers (`streamfunction_from_vorticity`,
+  `pressure_from_divergence`, `pv_inversion`) + `build_capacitance_solver`.
+- `inhomogeneous.py` — lifting trick (mask/BC concern). **Stays.**
+- Depends on `spectraldiffx`, `lineax`, `equinox`, `scipy`, `diffrax`.
+
+### 4.3 spectraldiffx (`spectraldiffx/_src/`)
+
+- `fourier/solvers.py` — `solve_helmholtz_*` / `solve_poisson_*` pure functions +
+  `SpectralHelmholtzSolver{1,2,3}D` modules. **Stays.**
+- `fourier/eigenvalues.py` — pure 1-D Laplacian eigenvalue functions. Stays
+  (spectral-native), portable in principle.
+- `fourier/capacitance.py` — `CapacitanceSolver(eqx.Module)` with `_C_inv`,
+  `_green_flat`, `_mask`, `_j_b`, `_i_b`, `dx`, `dy`, `lambda_`, `base_bc`;
+  `build_capacitance_solver(mask, dx, dy, lambda_, base_bc)`. **Tightly coupled to
+  the base spectral solve + mask boundary extraction.** This is the split target.
+- `chebyshev/solvers.py`, `spherical/solvers.py` — collocation / SHT mode
+  inversion. **Stay** (transform/grid coupled).
+- Depends on `jax`, `equinox`, `jaxtyping`, `finitediffx`, `kernex`.
+
+---
+
+## 5. Target state
+
+### 5.1 gaussx — new/extended surface
+
+```
+src/gaussx/
+  _operators/
+    _capacitance.py          # NEW: CapacitanceSolver (Woodbury-family op)
+  _preconditioners/          # NEW package
+    __init__.py
+    _base.py                 # AbstractPreconditioner protocol
+    _jacobi.py               # JacobiPreconditioner
+    _nystrom.py              # NystromPreconditioner
+    _partial_cholesky.py     # PartialCholeskyPreconditioner (factored from _precond_cg)
+    _operator.py             # OperatorPreconditioner  (the spectral/MG adapter slot)
+  _strategies/
+    _cg.py                   # EXTENDED: optional `preconditioner` field
+    _minres.py               # EXTENDED: optional `preconditioner` field
+    _precond_cg.py           # REFACTORED to delegate to PartialCholeskyPreconditioner
+  _solve_frontend.py         # NEW: as_linear_operator(), linear_solve()
+  _solvers_functional.py     # NEW: solve_tridiagonal(_batched) re-home (optional)
+```
+
+Public API additions (re-exported from `__init__.py`):
+
+- `gaussx.as_linear_operator(matvec, *, in_structure | shape, symmetric=False,
+  positive_semidefinite=False, negative_definite=False)`
+- `gaussx.linear_solve(A, b, *, solver=None, preconditioner=None)` — accepts an
+  operator **or** a raw `(matvec, shape)`; handles sign tags.
+- `gaussx.AbstractPreconditioner`, `JacobiPreconditioner`, `NystromPreconditioner`,
+  `PartialCholeskyPreconditioner`, `OperatorPreconditioner`
+- `gaussx.CapacitanceSolver`
+- `gaussx.solve_tridiagonal`, `gaussx.solve_tridiagonal_batched`
+
+### 5.2 finitevolX — thin wrappers
+
+- `iterative.solve_cg` → delegates to `gaussx.linear_solve` (keeps `CGInfo`
+  return shape and the negative-definite convention).
+- `preconditioners.make_nystrom_preconditioner` → `gaussx.NystromPreconditioner`.
+- `make_spectral_preconditioner` → builds the spectral approx-inverse callable
+  (spectraldiffx), wraps it in `gaussx.OperatorPreconditioner`.
+- `make_multigrid_preconditioner(mg)` → `gaussx.OperatorPreconditioner(mg)`.
+- `tridiagonal.*` → re-export `gaussx.solve_tridiagonal*`.
+- `multigrid.py`, `masked_laplacian`, `inhomogeneous.py`, `elliptic.py`
+  convenience wrappers — unchanged behaviour; only their solver internals are
+  delegated.
+
+### 5.3 spectraldiffx — thin wrapper
+
+- `fourier/capacitance.build_capacitance_solver` → extracts boundary indices from
+  the mask (spectral concern), defines `base_solve = λ rhs: solve_helmholtz_<bc>
+  (rhs, dx, dy, lambda_)`, and constructs `gaussx.CapacitanceSolver(base_solve,
+  boundary_indices, n)`. The returned object reshapes field ↔ flat.
+- `solve_helmholtz_*`, eigenvalues, Chebyshev, spherical — unchanged.
+
+### 5.4 Dependency direction (must stay acyclic)
+
+```
+finitevolX ──depends-on──▶ spectraldiffx ──depends-on──▶ gaussx
+        └───────────────depends-on──────────────────────▶ gaussx
+```
+
+gaussx depends on **neither** of the other two. Spectral/MG specifics enter
+gaussx solvers only as runtime callables/operators.
+
+---
+
+## 6. Demo API
+
+### 6.1 Raw-matvec front door + sign handling (gaussx)
+
+```python
+import gaussx
+import jax.numpy as jnp
+
+# A negative-definite 5-point Laplacian as a raw matvec (finitevolX style)
+def laplacian(x):           # x: (N,) flattened field
+    ...
+    return Lx
+
+A = gaussx.as_linear_operator(laplacian, shape=(N, N), symmetric=True,
+                              negative_definite=True)
+
+x = gaussx.linear_solve(A, b, solver=gaussx.CGSolver())   # routes neg-def correctly
+```
+
+### 6.2 Standalone preconditioners (gaussx)
+
+```python
+# Generic, gaussx-native
+P_jac = gaussx.JacobiPreconditioner(diagonal=A.diagonal())
+P_nys = gaussx.NystromPreconditioner(matvec=A.mv, shape=(N, N), rank=50, key=key)
+
+x = gaussx.linear_solve(A, b, solver=gaussx.CGSolver(), preconditioner=P_nys)
+
+# Adapter slot: any approximate-inverse operator/callable becomes a preconditioner
+P_spec = gaussx.OperatorPreconditioner(my_spectral_inverse)   # callable from spectraldiffx
+P_mg   = gaussx.OperatorPreconditioner(my_multigrid_solver)   # Mg object from finitevolX
+```
+
+### 6.3 Capacitance operator (gaussx core, PDE repos supply the parts)
+
+```python
+# base_solve: a fast regular-domain inverse (e.g. FFT Helmholtz) — passed in.
+# boundary_indices: flat indices of the constrained boundary ring — passed in.
+cap = gaussx.CapacitanceSolver(
+    base_solve=base_solve,            # Callable[[Array[N]], Array[N]]
+    boundary_indices=boundary_idx,    # Int[Array, "Nb"]
+    n=N,
+)
+u = cap(rhs_flat)                     # one base solve + Nb-sized correction
+```
+
+---
+
+## 7. API usage examples (end-to-end, post-refactor)
+
+### 7.1 finitevolX — unchanged call site, gaussx internals
+
+```python
+import finitevolx as fvx
+
+# Public API identical to today
+x, info = fvx.solve_cg(
+    matvec=lambda v: fvx.masked_laplacian(v.reshape(Ny, Nx), mask, dx, dy).ravel(),
+    rhs=b,
+    preconditioner=fvx.make_preconditioner("nystrom", matvec=mv, shape=(Ny, Nx)),
+    rtol=1e-6,
+)
+# info: CGInfo(iterations=..., residual_norm=..., converged=...)
+# Internally: fvx.solve_cg -> gaussx.linear_solve; nystrom -> gaussx.NystromPreconditioner
+```
+
+### 7.2 spectraldiffx — capacitance wrapper
+
+```python
+import spectraldiffx as sdx
+
+cap = sdx.build_capacitance_solver(mask, dx=dx, dy=dy, lambda_=0.0, base_bc="fft")
+psi = cap(rhs)        # field in, field out (wrapper reshapes; gaussx does the algebra)
+```
+
+### 7.3 gaussx — GP on a grid reuses the same preconditioner
+
+```python
+import gaussx
+
+K = gaussx.Toeplitz(first_col)                     # stationary kernel on 1-D grid
+P = gaussx.NystromPreconditioner(matvec=K.mv, shape=K.shape, rank=64, key=key)
+alpha = gaussx.linear_solve(K + noise, y,
+                            solver=gaussx.CGSolver(), preconditioner=P)
+```
+
+---
+
+## 8. Steps to execute
+
+Each phase is independently shippable, lands on
+`claude/gaussx-solver-refactor-scope-3hTFq` in the relevant repo, and keeps all
+existing public APIs green. **gaussx phases (0–3) must merge/publish before the
+wrapper phases (4–5).**
+
+### Phase 0 — gaussx: raw-matvec front door + sign handling
+- Add `src/gaussx/_solve_frontend.py`:
+  - `as_linear_operator(matvec, *, in_structure | shape, symmetric,
+    positive_semidefinite, negative_definite)` → wraps in
+    `lx.FunctionLinearOperator` with the right lineax tags.
+  - `linear_solve(A, b, *, solver=None, preconditioner=None)` — normalise `A`
+    (operator or `(matvec, shape)`), route negative-definite via MINRES or
+    negation, default `solver=AutoSolver()`.
+- Re-export both from `__init__.py`.
+- Tests: `tests/test_solve_frontend.py` — PSD via CG, indefinite via MINRES,
+  negative-definite Laplacian solve, `(matvec, shape)` input parity with operator
+  input.
+- Acceptance: `gaussx.linear_solve` solves a known neg-def Laplacian to `rtol`.
+
+### Phase 1 — gaussx: preconditioner protocol + generic preconditioners
+- Add `src/gaussx/_preconditioners/`:
+  - `_base.py` — `AbstractPreconditioner(eqx.Module)` with
+    `as_operator() -> lx.AbstractLinearOperator` (and/or `__call__(v)`).
+  - `_jacobi.py`, `_nystrom.py`, `_partial_cholesky.py` (factor the partial
+    pivoted Cholesky out of `_precond_cg.py`), `_operator.py`
+    (`OperatorPreconditioner(approx_inverse: Operator | Callable)`).
+- Refactor `_strategies/_cg.py` and `_minres.py` to accept an optional
+  `preconditioner: AbstractPreconditioner | None` field; wire into
+  `lx.linear_solve(..., options={"preconditioner": P.as_operator()})`.
+- Refactor `_precond_cg.py` to delegate to `PartialCholeskyPreconditioner`
+  (behaviour-preserving; keep the class + its defaults).
+- Re-export new classes.
+- Tests: each preconditioner reduces CG iteration count on an ill-conditioned
+  SPD system; `PreconditionedCGSolver` numerics unchanged (regression test).
+- Acceptance: `_precond_cg` regression test passes byte-for-byte on outputs
+  within tolerance; Nyström preconditioner cuts iterations measurably.
+
+### Phase 2 — gaussx: capacitance operator
+- Add `src/gaussx/_operators/_capacitance.py`:
+  - `CapacitanceSolver(eqx.Module)` holding precomputed `C_inv`, Green's columns,
+    `boundary_indices`, `n`. Constructor takes `base_solve: Callable`,
+    `boundary_indices: Int[Array, "Nb"]`, `n: int`. Built on existing
+    `_linalg/_woodbury.py` where possible.
+  - `__call__(rhs_flat) -> sol_flat`.
+- Re-export `gaussx.CapacitanceSolver`.
+- Tests: reproduce a known masked-domain Poisson solution; verify it equals a
+  dense reference solve on a small irregular mask; verify it equals
+  spectraldiffx's current `CapacitanceSolver` output on a fixed fixture
+  (port one spectraldiffx test as a golden file).
+- Acceptance: matches dense reference to `1e-8` on a 16×16 masked grid.
+
+### Phase 3 — gaussx: tridiagonal re-home (optional, low value)
+- Add `solve_tridiagonal`, `solve_tridiagonal_batched` (thin `lineax.Tridiagonal`
+  wrappers) and export. Skip if deemed not worth the surface.
+
+### Phase 4 — spectraldiffx: adopt gaussx capacitance
+- Add `gaussx` to `pyproject.toml` deps.
+- Rewrite `fourier/capacitance.build_capacitance_solver` to:
+  (a) extract boundary indices from the mask (unchanged logic),
+  (b) build `base_solve` from the chosen `solve_helmholtz_<bc>`,
+  (c) return a thin field↔flat wrapper around `gaussx.CapacitanceSolver`.
+- Keep `CapacitanceSolver` name as a deprecated alias if external code imports it
+  directly (one release of overlap).
+- Tests: existing capacitance tests must pass unchanged.
+- Acceptance: spectraldiffx capacitance test suite green against gaussx core.
+
+### Phase 5 — finitevolX: adopt gaussx solvers/preconditioners
+- Add/raise `gaussx` dependency in `pyproject.toml` (via spectraldiffx or direct).
+- `iterative.solve_cg` → wrap `gaussx.linear_solve` (preserve `CGInfo`, neg-def
+  convention, `x0`, tolerances, `max_steps`).
+- `preconditioners.make_nystrom_preconditioner` → `gaussx.NystromPreconditioner`.
+- `make_spectral_preconditioner` / `make_multigrid_preconditioner` → wrap their
+  approximate inverses in `gaussx.OperatorPreconditioner`.
+- `tridiagonal.*` → re-export gaussx functions (or keep local if Phase 3 skipped).
+- `masked_laplacian`, `multigrid.py`, `inhomogeneous.py`, `elliptic.py` — leave
+  behaviour; only swap solver internals.
+- Tests: finitevolX solver tests pass unchanged; add a parity test (old local CG
+  vs gaussx-backed CG on a fixed masked Laplacian).
+- Acceptance: full finitevolX test suite green; numerical parity within tol.
+
+### Phase 6 — cleanup, deprecation, docs
+- Remove dead local implementations after one release of deprecation shims.
+- Docs:
+  - gaussx: new "Preconditioners" + "Capacitance" + "Raw-matvec front door"
+    sections; SPDE bridge note linking covariance ↔ elliptic operators.
+  - finitevolX / spectraldiffx: note that solver internals now come from gaussx.
+- Cross-repo CHANGELOG entries.
+
+---
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Dependency cycle** (gaussx importing PDE repos) | Spectral/MG specifics enter only as runtime callables via `OperatorPreconditioner`; CI guard: gaussx imports must not reference spectraldiffx/finitevolX. |
+| **Sign-convention bugs** (PSD vs neg-def Laplacian) | Explicit `negative_definite` tag on the front door; parity tests against existing finitevolX outputs. |
+| **operator vs raw-matvec impedance** | `as_linear_operator` adapter + `linear_solve` accepting both; covered by Phase 0 tests. |
+| **Behavioural drift in `PreconditionedCGSolver`** | Refactor is delegation-only; golden regression test before/after. |
+| **Capacitance numerics regression** | Golden-file test ported from spectraldiffx; dense reference check. |
+| **Release ordering** | gaussx (0–3) published first; PDE repos pin the new gaussx version. |
+| **Scope creep back into gaussx** | §1 non-goals are normative; reviewers reject grid/BC/transform/mask code in gaussx. |
+
+---
+
+## 10. Definition of done
+
+- gaussx exposes: raw-matvec front door, preconditioner protocol + Jacobi /
+  Nyström / partial-Cholesky / operator-adapter, capacitance operator — all
+  tested, no import of the PDE repos.
+- finitevolX `solve_cg`, Nyström/spectral/multigrid preconditioners, and
+  tridiagonal route through gaussx with unchanged public APIs and numerical
+  parity.
+- spectraldiffx `build_capacitance_solver` routes through
+  `gaussx.CapacitanceSolver` with unchanged public API.
+- All three test suites green on `claude/gaussx-solver-refactor-scope-3hTFq`.
+- Dependency graph acyclic: `finitevolX → spectraldiffx → gaussx`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,8 @@ nav:
   - Home: index.md
   - Vision: vision.md
   - Architecture: architecture.md
+  - Design:
+      - Unified Solvers: design/unified-solvers.md
   - Examples:
       - Basics: notebooks/basics.ipynb
       - Operator Zoo: notebooks/operator_zoo.ipynb

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -108,6 +108,8 @@ from gaussx._linalg import (
     solve_columns as solve_columns,
     solve_matrix as solve_matrix,
     solve_rows as solve_rows,
+    solve_tridiagonal as solve_tridiagonal,
+    solve_tridiagonal_batched as solve_tridiagonal_batched,
     stable_rbf_kernel as stable_rbf_kernel,
     stable_squared_distances as stable_squared_distances,
     trace_product as trace_product,
@@ -116,6 +118,7 @@ from gaussx._linalg import (
 from gaussx._operators import (
     BlockDiag as BlockDiag,
     BlockTriDiag as BlockTriDiag,
+    CapacitanceSolver as CapacitanceSolver,
     ImplicitCrossKernelOperator as ImplicitCrossKernelOperator,
     ImplicitKernelOperator as ImplicitKernelOperator,
     InterpolatedOperator as InterpolatedOperator,
@@ -141,6 +144,13 @@ from gaussx._operators import (
     sumkronecker_sample as sumkronecker_sample,
     svd_low_rank_plus_diag as svd_low_rank_plus_diag,
     toeplitz_sample as toeplitz_sample,
+)
+from gaussx._preconditioners import (
+    AbstractPreconditioner as AbstractPreconditioner,
+    JacobiPreconditioner as JacobiPreconditioner,
+    NystromPreconditioner as NystromPreconditioner,
+    OperatorPreconditioner as OperatorPreconditioner,
+    PartialCholeskyPreconditioner as PartialCholeskyPreconditioner,
 )
 from gaussx._primitives import (
     DenseFallbackWarning as DenseFallbackWarning,

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -196,6 +196,10 @@ from gaussx._quadrature import (
     uncertain_svgp_predict as uncertain_svgp_predict,
     uncertain_vgp_predict as uncertain_vgp_predict,
 )
+from gaussx._solve_frontend import (
+    as_linear_operator as as_linear_operator,
+    linear_solve as linear_solve,
+)
 from gaussx._ssm import (
     ConstantSDE as ConstantSDE,
     CosineSDE as CosineSDE,

--- a/src/gaussx/_linalg/__init__.py
+++ b/src/gaussx/_linalg/__init__.py
@@ -21,6 +21,10 @@ from gaussx._linalg._mixed_precision import (
 )
 from gaussx._linalg._safe_cholesky import safe_cholesky
 from gaussx._linalg._schur import conditional_variance, schur_complement
+from gaussx._linalg._tridiagonal import (
+    solve_tridiagonal,
+    solve_tridiagonal_batched,
+)
 from gaussx._linalg._woodbury import woodbury_solve
 
 
@@ -38,6 +42,8 @@ __all__ = [
     "solve_columns",
     "solve_matrix",
     "solve_rows",
+    "solve_tridiagonal",
+    "solve_tridiagonal_batched",
     "stable_rbf_kernel",
     "stable_squared_distances",
     "trace_product",

--- a/src/gaussx/_linalg/_tridiagonal.py
+++ b/src/gaussx/_linalg/_tridiagonal.py
@@ -1,0 +1,57 @@
+"""Tridiagonal (Thomas-algorithm) solves."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import lineax as lx
+from jaxtyping import Array, Float
+
+
+def solve_tridiagonal(
+    lower: Float[Array, " n_minus_1"],
+    diag: Float[Array, " n"],
+    upper: Float[Array, " n_minus_1"],
+    rhs: Float[Array, " n"],
+) -> Float[Array, " n"]:
+    """Solve a tridiagonal system ``A x = d``.
+
+    Thin wrapper over :class:`lineax.TridiagonalLinearOperator`, which delegates
+    to ``jax.lax.linalg.tridiagonal_solve`` (LAPACK / cuSPARSE).
+
+    Args:
+        lower: Sub-diagonal of ``A``, length ``n - 1``.
+        diag: Main diagonal of ``A``, length ``n``.
+        upper: Super-diagonal of ``A``, length ``n - 1``.
+        rhs: Right-hand side, length ``n``.
+
+    Returns:
+        The solution ``x``, length ``n``.
+    """
+    operator = lx.TridiagonalLinearOperator(diag, lower, upper)
+    return lx.linear_solve(operator, rhs, solver=lx.Tridiagonal()).value
+
+
+def solve_tridiagonal_batched(
+    lower: Float[Array, "*batch n_minus_1"],
+    diag: Float[Array, "*batch n"],
+    upper: Float[Array, "*batch n_minus_1"],
+    rhs: Float[Array, "*batch n"],
+) -> Float[Array, "*batch n"]:
+    """Solve independent tridiagonal systems over leading batch dimensions.
+
+    Applies :func:`solve_tridiagonal` vmapped over all leading dimensions.
+
+    Args:
+        lower: Sub-diagonals, shape ``(*batch, n - 1)``.
+        diag: Main diagonals, shape ``(*batch, n)``.
+        upper: Super-diagonals, shape ``(*batch, n - 1)``.
+        rhs: Right-hand sides, shape ``(*batch, n)``.
+
+    Returns:
+        Solutions, shape ``(*batch, n)``.
+    """
+    n_batch = diag.ndim - 1
+    fn = solve_tridiagonal
+    for _ in range(n_batch):
+        fn = eqx.filter_vmap(fn)
+    return fn(lower, diag, upper, rhs)

--- a/src/gaussx/_operators/__init__.py
+++ b/src/gaussx/_operators/__init__.py
@@ -10,6 +10,7 @@ from gaussx._operators._block_tridiag import (
     LowerBlockTriDiag,
     UpperBlockTriDiag,
 )
+from gaussx._operators._capacitance import CapacitanceSolver
 from gaussx._operators._implicit_cross_kernel import (
     ImplicitCrossKernelOperator,
     _TransposedCrossKernelOperator,
@@ -592,6 +593,7 @@ def _(operator: UpperBlockTriDiag) -> bool:
 __all__ = [
     "BlockDiag",
     "BlockTriDiag",
+    "CapacitanceSolver",
     "ImplicitCrossKernelOperator",
     "ImplicitKernelOperator",
     "InterpolatedOperator",

--- a/src/gaussx/_operators/_capacitance.py
+++ b/src/gaussx/_operators/_capacitance.py
@@ -1,0 +1,95 @@
+"""Capacitance-matrix solver (Sherman-Morrison / Woodbury) for masked domains.
+
+The capacitance-matrix method extends a fast *base* solver ``B^{-1}`` (for which
+an efficient inverse exists -- e.g. an FFT/DST/DCT Helmholtz solve on a
+rectangle) to a problem with a small number of additional point constraints
+(e.g. enforcing ``u = 0`` on the irregular boundary of a masked sub-domain). It
+is a low-rank (Woodbury) correction around the base solve.
+
+This module owns only the *generic linear algebra*. The caller supplies:
+
+* ``base_solve`` -- a callable applying ``B^{-1}`` to a flat right-hand side;
+* ``boundary_indices`` -- the flat indices of the constrained degrees of freedom.
+
+Which degrees of freedom are constrained (mask / boundary extraction) and which
+base solver to use (the spectral transform) stay in the calling package
+(finitevolX / spectraldiffx).
+
+Reference: Buzbee, Golub & Nielson (1970), "On Direct Methods for Solving
+Poisson's Equations", SIAM J. Numer. Anal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+
+class CapacitanceSolver(eqx.Module):
+    r"""Solve a base system subject to homogeneous point constraints.
+
+    Given a fast base solver ``B^{-1}`` and a set of ``N_b`` constrained indices,
+    this enforces ``u = 0`` at those indices via the capacitance-matrix
+    correction:
+
+    1. Base solve:        ``u = B^{-1} f``
+    2. Sample boundary:   ``u_b = u[boundary]``
+    3. Correction:        ``alpha = C^{-1} u_b``
+    4. Subtract:          ``x = u - G^T alpha``
+
+    where ``G[k] = B^{-1} e_{b_k}`` are the Green's functions of the base solver
+    for unit sources at the constrained indices, and ``C[k, l] = G[l][b_k]`` is
+    the capacitance matrix. ``C^{-1}`` and ``G`` are precomputed at construction.
+
+    The solver operates on **flat** vectors. Any reshaping between fields and
+    flat vectors, and any masking of the exterior, is the caller's
+    responsibility -- keeping grid/mask concepts out of this class.
+
+    Args:
+        base_solve: Callable applying the base inverse ``B^{-1}`` to a flat
+            right-hand side of length ``n``.
+        boundary_indices: Flat indices of the constrained degrees of freedom,
+            shape ``(N_b,)``.
+        n: Length of the flat solution vector.
+
+    Attributes:
+        base_solve: The base inverse callable.
+        boundary_indices: The constrained indices.
+        green: Green's functions ``G``, shape ``(N_b, n)``.
+        capacitance_inv: Inverse capacitance matrix ``C^{-1}``, shape
+            ``(N_b, N_b)``.
+    """
+
+    base_solve: Callable[[Float[Array, " n"]], Float[Array, " n"]]
+    boundary_indices: Int[Array, " Nb"]
+    green: Float[Array, "Nb n"]
+    capacitance_inv: Float[Array, "Nb Nb"]
+
+    def __init__(
+        self,
+        base_solve: Callable[[Float[Array, " n"]], Float[Array, " n"]],
+        boundary_indices: Int[Array, " Nb"],
+        n: int,
+    ):
+        indices = jnp.asarray(boundary_indices)
+        n_b = indices.shape[0]
+        unit_sources = jnp.zeros((n_b, n)).at[jnp.arange(n_b), indices].set(1.0)
+        green = jax.vmap(base_solve)(unit_sources)  # [Nb, n]
+        capacitance = green[:, indices].T  # C[k, l] = green[l][b_k]
+
+        self.base_solve = base_solve
+        self.boundary_indices = indices
+        self.green = green
+        self.capacitance_inv = jnp.linalg.inv(capacitance)
+
+    def __call__(self, rhs: Float[Array, " n"]) -> Float[Array, " n"]:
+        """Solve the constrained system for a flat right-hand side ``rhs``."""
+        u = self.base_solve(rhs)
+        u_b = u[self.boundary_indices]
+        alpha = self.capacitance_inv @ u_b
+        correction = self.green.T @ alpha
+        return u - correction

--- a/src/gaussx/_preconditioners/__init__.py
+++ b/src/gaussx/_preconditioners/__init__.py
@@ -1,0 +1,16 @@
+"""GaussX preconditioners -- approximate inverses for iterative solvers."""
+
+from gaussx._preconditioners._base import AbstractPreconditioner
+from gaussx._preconditioners._jacobi import JacobiPreconditioner
+from gaussx._preconditioners._nystrom import NystromPreconditioner
+from gaussx._preconditioners._operator import OperatorPreconditioner
+from gaussx._preconditioners._partial_cholesky import PartialCholeskyPreconditioner
+
+
+__all__ = [
+    "AbstractPreconditioner",
+    "JacobiPreconditioner",
+    "NystromPreconditioner",
+    "OperatorPreconditioner",
+    "PartialCholeskyPreconditioner",
+]

--- a/src/gaussx/_preconditioners/_base.py
+++ b/src/gaussx/_preconditioners/_base.py
@@ -1,0 +1,61 @@
+"""Preconditioner protocol.
+
+A preconditioner supplies an approximate inverse ``M^{-1} ~= A^{-1}`` used to
+accelerate iterative solves. In gaussx a preconditioner is an
+:class:`equinox.Module` that knows how to produce a *positive-semidefinite*
+lineax operator applying ``M^{-1}``.
+
+The single abstract method, :meth:`as_operator`, takes the *system* operator
+``A`` as an argument. Static preconditioners (e.g. Jacobi, or an externally
+supplied approximate inverse) ignore it; data-dependent ones (e.g.
+partial-Cholesky) use it to build their factor lazily at solve time. This is
+the slot through which PDE-specific approximate inverses (spectral solves,
+multigrid V-cycles) enter gaussx -- they are wrapped by
+:class:`OperatorPreconditioner` and passed in, so gaussx never needs to import
+the packages that build them.
+"""
+
+from __future__ import annotations
+
+import abc
+
+import equinox as eqx
+import lineax as lx
+from jaxtyping import Array, Float
+
+
+class AbstractPreconditioner(eqx.Module):
+    """Protocol for preconditioners producing an approximate inverse.
+
+    Subclasses implement :meth:`as_operator`, returning a PSD lineax operator
+    that applies ``M^{-1}`` (or ``None`` to disable preconditioning).
+    """
+
+    @abc.abstractmethod
+    def as_operator(
+        self,
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> lx.AbstractLinearOperator | None:
+        """Return ``M^{-1}`` as a PSD lineax operator.
+
+        Args:
+            operator: The system operator ``A`` being solved. Used by
+                data-dependent preconditioners (e.g. partial-Cholesky); ignored
+                by static ones.
+
+        Returns:
+            A positive-semidefinite operator applying ``M^{-1}``, or ``None`` to
+            indicate that no preconditioning should be applied.
+        """
+        ...
+
+    def __call__(
+        self,
+        vector: Float[Array, " n"],
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> Float[Array, " n"]:
+        """Apply ``M^{-1}`` to *vector* (identity when disabled)."""
+        op = self.as_operator(operator)
+        if op is None:
+            return vector
+        return op.mv(vector)

--- a/src/gaussx/_preconditioners/_jacobi.py
+++ b/src/gaussx/_preconditioners/_jacobi.py
@@ -1,0 +1,44 @@
+"""Jacobi (diagonal) preconditioner."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import lineax as lx
+from jaxtyping import Array, Float
+
+from gaussx._preconditioners._base import AbstractPreconditioner
+
+
+class JacobiPreconditioner(AbstractPreconditioner):
+    """Diagonal preconditioner ``M^{-1} = diag(1 / diag(A))``.
+
+    The cheapest preconditioner: scales each coordinate by the reciprocal of
+    the corresponding diagonal entry of ``A``. Effective when ``A`` is
+    diagonally dominant.
+
+    Args:
+        diagonal: The diagonal of ``A``. When ``None``, it is extracted from the
+            operator passed to :meth:`as_operator` via :func:`gaussx.diag`.
+    """
+
+    diagonal: Float[Array, " n"] | None = None
+
+    def as_operator(
+        self,
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> lx.AbstractLinearOperator:
+        """Return ``diag(1 / d)`` as a PSD operator."""
+        d = self.diagonal
+        if d is None:
+            if operator is None:
+                raise ValueError(
+                    "JacobiPreconditioner needs either an explicit `diagonal` "
+                    "or an operator to extract one from."
+                )
+            from gaussx._primitives import diag
+
+            d = diag(operator)
+        inv = jnp.where(d != 0.0, 1.0 / d, 0.0)
+        return lx.TaggedLinearOperator(
+            lx.DiagonalLinearOperator(inv), lx.positive_semidefinite_tag
+        )

--- a/src/gaussx/_preconditioners/_nystrom.py
+++ b/src/gaussx/_preconditioners/_nystrom.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import lineax as lx
 from jaxtyping import Array, Float
 
+from gaussx._einx import einsum
 from gaussx._preconditioners._base import AbstractPreconditioner
 
 
@@ -72,14 +73,18 @@ class NystromPreconditioner(AbstractPreconditioner):
         q, _ = jnp.linalg.qr(omega)
 
         y = eqx.filter_vmap(operator.mv, in_axes=1, out_axes=1)(q)
-        b = q.T @ y
+        b = einsum(q, y, "n k, n j -> k j")
+        # Symmetrize before the eigendecomposition: b is symmetric in exact
+        # arithmetic, but floating-point asymmetry in the off-diagonals can
+        # perturb eigh. (Matches the convention in _distributions/_conditional.)
+        b = 0.5 * (b + b.T)
         eigvals, u = jnp.linalg.eigh(b)
 
         abs_eigvals = jnp.abs(eigvals)
         eps = jnp.finfo(abs_eigvals.dtype).eps * n
         s_inv = jnp.where(abs_eigvals > eps, 1.0 / abs_eigvals, 0.0)
 
-        w = q @ u
+        w = einsum(q, u, "n k, k j -> n j")
         # Fallback for uncaptured directions: random probing captures the
         # largest eigenvalues, so uncaptured directions have smaller eigenvalues
         # and larger inverses. The largest captured inverse is the best
@@ -99,7 +104,8 @@ class NystromPreconditioner(AbstractPreconditioner):
         structure = jax.ShapeDtypeStruct((w.shape[0],), w.dtype)
 
         def matvec(x: Float[Array, " n"]) -> Float[Array, " n"]:
-            return shift * x + w @ (scale * (w.T @ x))
+            coeffs = einsum(w, x, "n k, n -> k")
+            return shift * x + einsum(w, scale * coeffs, "n k, k -> n")
 
         return lx.FunctionLinearOperator(
             matvec, structure, lx.positive_semidefinite_tag

--- a/src/gaussx/_preconditioners/_nystrom.py
+++ b/src/gaussx/_preconditioners/_nystrom.py
@@ -1,0 +1,106 @@
+"""Randomized Nyström preconditioner."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from jaxtyping import Array, Float
+
+from gaussx._preconditioners._base import AbstractPreconditioner
+
+
+class NystromPreconditioner(AbstractPreconditioner):
+    r"""Low-rank approximate inverse from randomized operator probing.
+
+    Builds a rank-``k`` Nyström approximation of a symmetric positive
+    semidefinite operator ``A`` and uses it as an approximate inverse. Good when
+    ``A`` is available only through matvecs and a handful of probes captures its
+    dominant spectrum.
+
+    Algorithm (for PSD ``A``):
+
+    1. Draw a Gaussian probe matrix ``Omega in R^{n x k}`` and orthonormalise it
+       via QR to get ``Q``.
+    2. Form ``Y = A Q`` (``k`` matvecs) and the small matrix ``B = Q^T Y``.
+    3. Eigendecompose ``B = U S U^T`` and set ``W = Q U`` (orthonormal columns).
+    4. The approximate inverse is
+       ``M^{-1} x = a x + W ((s_inv - a) (W^T x))``,
+       where ``s_inv = 1 / |eig(B)|`` and the scalar fallback ``a`` keeps
+       directions outside the captured subspace near the inverse of the smallest
+       captured eigenvalue (so CG does not falsely converge in the
+       preconditioned norm).
+
+    Construct via :meth:`from_operator`.
+
+    Attributes:
+        basis: Orthonormal basis ``W``, shape ``(n, k)``.
+        scale: Per-direction extra scaling ``s_inv - a``, shape ``(k,)``.
+        shift: Scalar fallback ``a`` applied to the full space.
+    """
+
+    basis: Float[Array, "n k"]
+    scale: Float[Array, " k"]
+    shift: Float[Array, ""]
+
+    @classmethod
+    def from_operator(
+        cls,
+        operator: lx.AbstractLinearOperator,
+        rank: int = 50,
+        key: jax.Array | None = None,
+    ) -> NystromPreconditioner:
+        """Build a Nyström preconditioner by probing *operator*.
+
+        Args:
+            operator: A symmetric PSD operator ``A``.
+            rank: Number of probe vectors (approximation rank).
+            key: PRNG key for the probe matrix. Defaults to
+                ``jax.random.PRNGKey(0)``.
+
+        Returns:
+            A ready-to-use :class:`NystromPreconditioner`.
+        """
+        if key is None:
+            key = jax.random.PRNGKey(0)
+
+        n = operator.in_size()
+        k = min(rank, n)
+
+        omega = jax.random.normal(key, (n, k))
+        q, _ = jnp.linalg.qr(omega)
+
+        y = eqx.filter_vmap(operator.mv, in_axes=1, out_axes=1)(q)
+        b = q.T @ y
+        eigvals, u = jnp.linalg.eigh(b)
+
+        abs_eigvals = jnp.abs(eigvals)
+        eps = jnp.finfo(abs_eigvals.dtype).eps * n
+        s_inv = jnp.where(abs_eigvals > eps, 1.0 / abs_eigvals, 0.0)
+
+        w = q @ u
+        # Fallback for uncaptured directions: random probing captures the
+        # largest eigenvalues, so uncaptured directions have smaller eigenvalues
+        # and larger inverses. The largest captured inverse is the best
+        # available proxy and keeps the preconditioned spectrum near 1.
+        shift = jnp.max(s_inv)
+        scale = s_inv - shift
+        return cls(basis=w, scale=scale, shift=shift)
+
+    def as_operator(
+        self,
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> lx.AbstractLinearOperator:
+        """Return the rank-``k`` approximate inverse as a PSD operator."""
+        w = self.basis
+        scale = self.scale
+        shift = self.shift
+        structure = jax.ShapeDtypeStruct((w.shape[0],), w.dtype)
+
+        def matvec(x: Float[Array, " n"]) -> Float[Array, " n"]:
+            return shift * x + w @ (scale * (w.T @ x))
+
+        return lx.FunctionLinearOperator(
+            matvec, structure, lx.positive_semidefinite_tag
+        )

--- a/src/gaussx/_preconditioners/_operator.py
+++ b/src/gaussx/_preconditioners/_operator.py
@@ -1,0 +1,50 @@
+"""Adapter that turns an approximate inverse into a preconditioner.
+
+This is the slot through which PDE-specific approximate inverses enter gaussx:
+a spectral Helmholtz solve or a multigrid V-cycle (built in finitevolX /
+spectraldiffx) is wrapped here as a preconditioner and passed to a gaussx
+solver, without gaussx importing those packages.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import lineax as lx
+
+from gaussx._preconditioners._base import AbstractPreconditioner
+
+
+class OperatorPreconditioner(AbstractPreconditioner):
+    """Use an externally supplied approximate inverse as a preconditioner.
+
+    Args:
+        approx_inverse: The approximate inverse ``M^{-1}``, either as a lineax
+            operator or as a callable ``v -> M^{-1} v``.
+        in_structure: Input structure for the callable form. When ``None`` it is
+            taken from the system operator passed to :meth:`as_operator`.
+    """
+
+    approx_inverse: lx.AbstractLinearOperator | Callable
+    in_structure: object = None
+
+    def as_operator(
+        self,
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> lx.AbstractLinearOperator:
+        """Return the approximate inverse as a PSD lineax operator."""
+        ai = self.approx_inverse
+        if isinstance(ai, lx.AbstractLinearOperator):
+            if lx.is_positive_semidefinite(ai):
+                return ai
+            return lx.TaggedLinearOperator(ai, lx.positive_semidefinite_tag)
+
+        structure = self.in_structure
+        if structure is None:
+            if operator is None:
+                raise ValueError(
+                    "OperatorPreconditioner with a callable approximate inverse "
+                    "needs `in_structure` or a system operator to infer it."
+                )
+            structure = operator.out_structure()
+        return lx.FunctionLinearOperator(ai, structure, lx.positive_semidefinite_tag)

--- a/src/gaussx/_preconditioners/_partial_cholesky.py
+++ b/src/gaussx/_preconditioners/_partial_cholesky.py
@@ -1,0 +1,63 @@
+"""Pivoted partial-Cholesky preconditioner."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import lineax as lx
+import matfree.low_rank
+from jaxtyping import Array, Float
+
+from gaussx._preconditioners._base import AbstractPreconditioner
+
+
+class PartialCholeskyPreconditioner(AbstractPreconditioner):
+    """Preconditioner from a pivoted partial Cholesky factor.
+
+    Builds a rank-``k`` partial Cholesky factor ``L`` of the system operator via
+    matfree, then applies ``(s I + L L^T)^{-1}`` through the Woodbury identity.
+    For operators of the form ``K + sigma^2 I`` this dramatically reduces CG
+    iteration counts.
+
+    Args:
+        rank: Rank of the partial Cholesky. ``<= 0`` disables preconditioning
+            (:meth:`as_operator` returns ``None``).
+        shift: Diagonal shift ``s`` for the preconditioner, typically the noise
+            variance ``sigma^2``.
+    """
+
+    rank: int = 50
+    shift: float = 1.0
+
+    def as_operator(
+        self,
+        operator: lx.AbstractLinearOperator | None = None,
+    ) -> lx.AbstractLinearOperator | None:
+        """Build the Woodbury preconditioner operator from *operator*."""
+        if self.rank <= 0:
+            return None
+        if operator is None:
+            raise ValueError(
+                "PartialCholeskyPreconditioner.as_operator requires the system "
+                "operator to build its factor."
+            )
+
+        n = operator.in_size()
+        rank = min(self.rank, n)
+
+        def mat_el(i, j):
+            ej = jnp.zeros(n).at[j].set(1.0)
+            return operator.mv(ej)[i]
+
+        chol_fn = matfree.low_rank.cholesky_partial_pivot(mat_el, nrows=n, rank=rank)
+        factor, info = chol_fn()
+        precond_fn = matfree.low_rank.preconditioner(lambda: (factor, info))
+
+        def precond_matvec(v: Float[Array, " n"]) -> Float[Array, " n"]:
+            applied, _ = precond_fn(v, self.shift)
+            return applied
+
+        return lx.FunctionLinearOperator(
+            precond_matvec,
+            operator.out_structure(),
+            lx.positive_semidefinite_tag,
+        )

--- a/src/gaussx/_solve_frontend.py
+++ b/src/gaussx/_solve_frontend.py
@@ -1,0 +1,278 @@
+"""Front door for the unified solver layer.
+
+This module provides two things:
+
+* :func:`as_linear_operator` -- a thin adapter that wraps a raw ``matvec``
+  callable (and an optional shape) into a :class:`lineax.AbstractLinearOperator`
+  with the appropriate structural tags. This is the entry point used by
+  matrix-free callers (e.g. finite-volume / spectral PDE solvers) that hand
+  gaussx a bare ``v -> A @ v`` function rather than a built operator object.
+
+* :func:`linear_solve` -- a unified solve entry point that normalises its
+  operator argument (operator *or* ``(matvec, shape)``), handles the
+  negative-definite sign convention used by elliptic operators, selects a
+  sensible default :class:`AbstractSolveStrategy`, and optionally applies a
+  preconditioner.
+
+The design goal is that callers in other packages pre-transform their problem
+into an ``(operator, rhs)`` pair, call :func:`linear_solve`, and post-transform
+the result -- without gaussx ever needing to know about grids, boundary
+conditions, or transforms.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import lineax as lx
+from jaxtyping import Array, Float
+
+from gaussx._strategies._base import AbstractSolveStrategy
+from gaussx._strategies._cg import CGSolver
+from gaussx._strategies._minres import MINRESSolver
+from gaussx._tags import (
+    is_negative_semidefinite,
+    is_positive_semidefinite,
+    is_symmetric,
+)
+
+
+MatvecLike = Callable[[Float[Array, " n"]], Float[Array, " n"]]
+"""A raw matrix-vector product ``v -> A @ v``."""
+
+OperatorLike = lx.AbstractLinearOperator | tuple[MatvecLike, tuple[int, int]]
+"""Either a built operator or a ``(matvec, shape)`` pair."""
+
+PreconditionerLike = lx.AbstractLinearOperator | MatvecLike | object
+"""A preconditioner: a lineax operator, a callable applying ``M^{-1}``, or an
+object exposing ``.as_operator()`` (the Phase 1 ``AbstractPreconditioner``)."""
+
+
+def as_linear_operator(
+    matvec: MatvecLike,
+    *,
+    shape: tuple[int, int] | None = None,
+    in_structure: object | None = None,
+    dtype: object = float,
+    symmetric: bool = False,
+    positive_semidefinite: bool = False,
+    negative_definite: bool = False,
+) -> lx.AbstractLinearOperator:
+    """Wrap a raw ``matvec`` callable as a tagged lineax operator.
+
+    This is the matrix-free front door: callers that only have a
+    ``v -> A @ v`` function (rather than a structured operator object) use this
+    to obtain an operator that gaussx's solvers and primitives understand.
+
+    Args:
+        matvec: The matrix-vector product ``v -> A @ v``.
+        shape: Matrix shape ``(out, in)``. The operator's input structure is
+            inferred as a length-``in`` vector of ``dtype``. Ignored when
+            ``in_structure`` is given.
+        in_structure: An explicit input structure -- either a
+            ``jax.ShapeDtypeStruct``, an ``int`` (interpreted as a vector
+            length), or a PyTree thereof. Takes precedence over ``shape``.
+        dtype: Dtype used when building the input structure from ``shape``.
+        symmetric: Tag the operator symmetric (``A == A^T``).
+        positive_semidefinite: Tag the operator PSD (implies symmetric).
+        negative_definite: Tag the operator negative semidefinite (implies
+            symmetric). Use this for elliptic operators such as a discrete
+            Laplacian; :func:`linear_solve` will route the solve through the
+            equivalent positive-definite system.
+
+    Returns:
+        A :class:`lineax.FunctionLinearOperator` carrying the requested tags.
+
+    Raises:
+        ValueError: If neither ``shape`` nor ``in_structure`` is provided.
+    """
+    import jax
+
+    if in_structure is not None:
+        structure = _normalise_in_structure(in_structure, dtype)
+    elif shape is not None:
+        structure = jax.ShapeDtypeStruct((shape[1],), dtype)
+    else:
+        raise ValueError("Provide either `shape=(out, in)` or `in_structure`.")
+
+    tags: list[object] = []
+    if symmetric or positive_semidefinite or negative_definite:
+        tags.append(lx.symmetric_tag)
+    if positive_semidefinite:
+        tags.append(lx.positive_semidefinite_tag)
+    if negative_definite:
+        tags.append(lx.negative_semidefinite_tag)
+
+    return lx.FunctionLinearOperator(matvec, structure, tags=tuple(tags))
+
+
+def linear_solve(
+    operator: OperatorLike,
+    vector: Float[Array, " n"],
+    *,
+    solver: AbstractSolveStrategy | None = None,
+    preconditioner: PreconditionerLike | None = None,
+) -> Float[Array, " n"]:
+    """Solve ``A x = b`` through the unified front door.
+
+    Accepts either a built operator or a ``(matvec, shape)`` pair, handles the
+    negative-definite sign convention, picks a default solver when none is
+    given, and optionally applies a preconditioner.
+
+    Sign handling: an operator tagged *negative* semidefinite (and not PSD) is
+    solved via the equivalent positive-definite system ``(-A) x = -b``, so that
+    a CG-style solver can be used directly. This is the common case for elliptic
+    PDE operators (e.g. a discrete Laplacian), which finite-volume / spectral
+    callers hand over as negative-definite matvecs.
+
+    Default solver selection (when ``solver is None``):
+
+    * positive semidefinite operator -> :class:`CGSolver`
+    * symmetric (possibly indefinite) operator -> :class:`MINRESSolver`
+    * otherwise -> a :class:`ValueError` asking for an explicit solver
+
+    Args:
+        operator: The linear operator ``A``, or a ``(matvec, shape)`` pair.
+        vector: Right-hand side ``b``, shape ``(n,)``.
+        solver: Solve strategy to use. When ``None`` a default is selected from
+            the operator's structural tags.
+        preconditioner: Optional preconditioner. May be a lineax operator
+            applying ``M^{-1}``, a callable ``v -> M^{-1} v``, or an object with
+            an ``.as_operator()`` method (the Phase 1 preconditioner protocol).
+
+    Returns:
+        The solution ``x``, shape ``(n,)``.
+    """
+    op = _coerce_operator(operator, vector)
+
+    # Negative-definite -> solve the equivalent positive-definite system.
+    if is_negative_semidefinite(op) and not is_positive_semidefinite(op):
+        op = _negate(op)
+        vector = -vector
+
+    if solver is None:
+        solver = _default_solver(op)
+
+    if preconditioner is not None:
+        return _solve_preconditioned(op, vector, solver, preconditioner)
+
+    return solver.solve(op, vector)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise_in_structure(in_structure: object, dtype: object) -> object:
+    """Normalise an ``in_structure`` argument into a ShapeDtypeStruct PyTree."""
+    import jax
+
+    if isinstance(in_structure, int):
+        return jax.ShapeDtypeStruct((in_structure,), dtype)
+    if isinstance(in_structure, tuple) and all(
+        isinstance(d, int) for d in in_structure
+    ):
+        return jax.ShapeDtypeStruct(in_structure, dtype)
+    return in_structure
+
+
+def _coerce_operator(
+    operator: OperatorLike,
+    vector: Float[Array, " n"],
+) -> lx.AbstractLinearOperator:
+    """Normalise *operator* into a lineax operator.
+
+    A bare ``(matvec, shape)`` pair is wrapped with no structural assumptions;
+    callers wanting tags should build the operator via :func:`as_linear_operator`
+    and pass it directly.
+    """
+    if isinstance(operator, lx.AbstractLinearOperator):
+        return operator
+    if isinstance(operator, tuple) and len(operator) == 2:
+        matvec, shape = operator
+        return as_linear_operator(matvec, shape=shape, dtype=vector.dtype)
+    raise TypeError(
+        "operator must be a lineax AbstractLinearOperator or a "
+        "(matvec, shape) tuple; got "
+        f"{type(operator).__name__}."
+    )
+
+
+def _negate(operator: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
+    """Return ``-A`` as a symmetric PSD operator.
+
+    Negating a symmetric *negative*-semidefinite operator yields a symmetric
+    *positive*-semidefinite one, which CG can solve directly.
+    """
+    return lx.FunctionLinearOperator(
+        lambda v: -operator.mv(v),
+        operator.in_structure(),
+        tags=(lx.symmetric_tag, lx.positive_semidefinite_tag),
+    )
+
+
+def _default_solver(operator: lx.AbstractLinearOperator) -> AbstractSolveStrategy:
+    """Pick a default solve strategy from the operator's structural tags."""
+    if is_positive_semidefinite(operator):
+        return CGSolver()
+    if is_symmetric(operator):
+        return MINRESSolver()
+    raise ValueError(
+        "Could not infer a default solver for a non-symmetric operator. "
+        "Pass an explicit `solver=` or tag the operator via "
+        "`as_linear_operator(..., symmetric=/positive_semidefinite=)`."
+    )
+
+
+def _coerce_preconditioner(
+    preconditioner: PreconditionerLike,
+    operator: lx.AbstractLinearOperator,
+) -> lx.AbstractLinearOperator:
+    """Normalise a preconditioner into a lineax operator applying ``M^{-1}``."""
+    as_operator = getattr(preconditioner, "as_operator", None)
+    if callable(as_operator) and not isinstance(
+        preconditioner, lx.AbstractLinearOperator
+    ):
+        preconditioner = as_operator()
+    if isinstance(preconditioner, lx.AbstractLinearOperator):
+        # lineax CG requires the preconditioner to be tagged PSD.
+        if is_positive_semidefinite(preconditioner):
+            return preconditioner
+        return lx.TaggedLinearOperator(preconditioner, lx.positive_semidefinite_tag)
+    if callable(preconditioner):
+        return lx.FunctionLinearOperator(
+            preconditioner,
+            operator.out_structure(),
+            lx.positive_semidefinite_tag,
+        )
+    raise TypeError(
+        "preconditioner must be a lineax operator, a callable applying "
+        "M^{-1}, or an object with an `.as_operator()` method."
+    )
+
+
+def _solve_preconditioned(
+    operator: lx.AbstractLinearOperator,
+    vector: Float[Array, " n"],
+    solver: AbstractSolveStrategy,
+    preconditioner: PreconditionerLike,
+) -> Float[Array, " n"]:
+    """Solve with a preconditioner via lineax CG.
+
+    Preconditioning currently routes through lineax's CG with the
+    ``preconditioner`` option, reusing the tolerances of a :class:`CGSolver`
+    when one is supplied. Richer per-strategy preconditioner support arrives
+    with the Phase 1 preconditioner protocol.
+    """
+    precond_op = _coerce_preconditioner(preconditioner, operator)
+    if isinstance(solver, CGSolver):
+        cg = lx.CG(rtol=solver.rtol, atol=solver.atol, max_steps=solver.max_steps)
+    else:
+        cg = lx.CG(rtol=1e-5, atol=1e-5, max_steps=1000)
+    return lx.linear_solve(
+        operator,
+        vector,
+        cg,
+        options={"preconditioner": precond_op},
+    ).value

--- a/src/gaussx/_solve_frontend.py
+++ b/src/gaussx/_solve_frontend.py
@@ -22,11 +22,13 @@ conditions, or transforms.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Callable
 
 import lineax as lx
 from jaxtyping import Array, Float
 
+from gaussx._preconditioners import AbstractPreconditioner, OperatorPreconditioner
 from gaussx._strategies._base import AbstractSolveStrategy
 from gaussx._strategies._cg import CGSolver
 from gaussx._strategies._minres import MINRESSolver
@@ -136,9 +138,10 @@ def linear_solve(
         vector: Right-hand side ``b``, shape ``(n,)``.
         solver: Solve strategy to use. When ``None`` a default is selected from
             the operator's structural tags.
-        preconditioner: Optional preconditioner. May be a lineax operator
-            applying ``M^{-1}``, a callable ``v -> M^{-1} v``, or an object with
-            an ``.as_operator()`` method (the Phase 1 preconditioner protocol).
+        preconditioner: Optional preconditioner. May be an
+            :class:`AbstractPreconditioner`, a lineax operator applying
+            ``M^{-1}``, or a callable ``v -> M^{-1} v``. Preconditioning is
+            currently applied through :class:`CGSolver`.
 
     Returns:
         The solution ``x``, shape ``(n,)``.
@@ -154,7 +157,7 @@ def linear_solve(
         solver = _default_solver(op)
 
     if preconditioner is not None:
-        return _solve_preconditioned(op, vector, solver, preconditioner)
+        solver = _attach_preconditioner(solver, _as_preconditioner(preconditioner))
 
     return solver.solve(op, vector)
 
@@ -225,54 +228,39 @@ def _default_solver(operator: lx.AbstractLinearOperator) -> AbstractSolveStrateg
     )
 
 
-def _coerce_preconditioner(
+def _as_preconditioner(
     preconditioner: PreconditionerLike,
-    operator: lx.AbstractLinearOperator,
-) -> lx.AbstractLinearOperator:
-    """Normalise a preconditioner into a lineax operator applying ``M^{-1}``."""
-    as_operator = getattr(preconditioner, "as_operator", None)
-    if callable(as_operator) and not isinstance(
-        preconditioner, lx.AbstractLinearOperator
+) -> AbstractPreconditioner:
+    """Normalise *preconditioner* into an :class:`AbstractPreconditioner`.
+
+    A raw lineax operator or callable applying ``M^{-1}`` is wrapped in an
+    :class:`OperatorPreconditioner`; an existing preconditioner is returned
+    unchanged.
+    """
+    if isinstance(preconditioner, AbstractPreconditioner):
+        return preconditioner
+    if isinstance(preconditioner, lx.AbstractLinearOperator) or callable(
+        preconditioner
     ):
-        preconditioner = as_operator()
-    if isinstance(preconditioner, lx.AbstractLinearOperator):
-        # lineax CG requires the preconditioner to be tagged PSD.
-        if is_positive_semidefinite(preconditioner):
-            return preconditioner
-        return lx.TaggedLinearOperator(preconditioner, lx.positive_semidefinite_tag)
-    if callable(preconditioner):
-        return lx.FunctionLinearOperator(
-            preconditioner,
-            operator.out_structure(),
-            lx.positive_semidefinite_tag,
-        )
+        return OperatorPreconditioner(preconditioner)
     raise TypeError(
-        "preconditioner must be a lineax operator, a callable applying "
-        "M^{-1}, or an object with an `.as_operator()` method."
+        "preconditioner must be an AbstractPreconditioner, a lineax operator, "
+        "or a callable applying M^{-1}."
     )
 
 
-def _solve_preconditioned(
-    operator: lx.AbstractLinearOperator,
-    vector: Float[Array, " n"],
+def _attach_preconditioner(
     solver: AbstractSolveStrategy,
-    preconditioner: PreconditionerLike,
-) -> Float[Array, " n"]:
-    """Solve with a preconditioner via lineax CG.
+    preconditioner: AbstractPreconditioner,
+) -> AbstractSolveStrategy:
+    """Attach *preconditioner* to a CG-style solver.
 
-    Preconditioning currently routes through lineax's CG with the
-    ``preconditioner`` option, reusing the tolerances of a :class:`CGSolver`
-    when one is supplied. Richer per-strategy preconditioner support arrives
-    with the Phase 1 preconditioner protocol.
+    Preconditioning is currently supported through :class:`CGSolver`. A bare
+    :class:`CGSolver` gains the preconditioner; any other strategy raises.
     """
-    precond_op = _coerce_preconditioner(preconditioner, operator)
     if isinstance(solver, CGSolver):
-        cg = lx.CG(rtol=solver.rtol, atol=solver.atol, max_steps=solver.max_steps)
-    else:
-        cg = lx.CG(rtol=1e-5, atol=1e-5, max_steps=1000)
-    return lx.linear_solve(
-        operator,
-        vector,
-        cg,
-        options={"preconditioner": precond_op},
-    ).value
+        return dataclasses.replace(solver, preconditioner=preconditioner)
+    raise ValueError(
+        "Preconditioning is currently supported only with CGSolver; "
+        f"got {type(solver).__name__}. Pass `solver=CGSolver(...)`."
+    )

--- a/src/gaussx/_strategies/_cg.py
+++ b/src/gaussx/_strategies/_cg.py
@@ -6,6 +6,7 @@ import jax
 import lineax as lx
 from jaxtyping import Array, Float
 
+from gaussx._preconditioners import AbstractPreconditioner
 from gaussx._strategies._base import AbstractSolverStrategy
 from gaussx._strategies._slq_logdet import SLQLogdet
 
@@ -24,6 +25,8 @@ class CGSolver(AbstractSolverStrategy):
         max_steps: Maximum CG iterations.
         num_probes: Number of probe vectors for stochastic logdet.
         lanczos_order: Order of the Lanczos decomposition for SLQ.
+        preconditioner: Optional preconditioner. When set, its approximate
+            inverse is passed to lineax CG to accelerate convergence.
     """
 
     rtol: float = 1e-5
@@ -31,6 +34,7 @@ class CGSolver(AbstractSolverStrategy):
     max_steps: int = 1000
     num_probes: int = 20
     lanczos_order: int = 30
+    preconditioner: AbstractPreconditioner | None = None
 
     def solve(
         self,
@@ -47,7 +51,12 @@ class CGSolver(AbstractSolverStrategy):
             Solution ``x``, shape ``(n,)``.
         """
         solver = lx.CG(rtol=self.rtol, atol=self.atol, max_steps=self.max_steps)
-        return lx.linear_solve(operator, vector, solver).value
+        options: dict[str, lx.AbstractLinearOperator] = {}
+        if self.preconditioner is not None:
+            precond_op = self.preconditioner.as_operator(operator)
+            if precond_op is not None:
+                options["preconditioner"] = precond_op
+        return lx.linear_solve(operator, vector, solver, options=options).value
 
     def logdet(
         self,

--- a/src/gaussx/_strategies/_precond_cg.py
+++ b/src/gaussx/_strategies/_precond_cg.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import jax
-import jax.numpy as jnp
 import lineax as lx
-import matfree.low_rank
 from jaxtyping import Array, Float
 
+from gaussx._preconditioners import PartialCholeskyPreconditioner
 from gaussx._strategies._base import AbstractSolverStrategy
+from gaussx._strategies._cg import CGSolver
 from gaussx._strategies._slq_logdet import SLQLogdet
 
 
@@ -58,36 +58,15 @@ class PreconditionedCGSolver(AbstractSolverStrategy):
         Returns:
             The solution x.
         """
-        solver = lx.CG(rtol=self.rtol, atol=self.atol, max_steps=self.max_steps)
-        if self.preconditioner_rank <= 0:
-            return lx.linear_solve(operator, vector, solver).value
-
-        n = operator.in_size()
-        rank = min(self.preconditioner_rank, n)
-
-        def mat_el(i, j):
-            ej = jnp.zeros(n).at[j].set(1.0)
-            return operator.mv(ej)[i]
-
-        chol_fn = matfree.low_rank.cholesky_partial_pivot(mat_el, nrows=n, rank=rank)
-        L, info = chol_fn()
-        precond_fn = matfree.low_rank.preconditioner(lambda: (L, info))
-
-        def precond_matvec(v):
-            Mv_inv, _ = precond_fn(v, self.shift)
-            return Mv_inv
-
-        preconditioner = lx.FunctionLinearOperator(
-            precond_matvec,
-            operator.out_structure(),
-            lx.positive_semidefinite_tag,
+        preconditioner = PartialCholeskyPreconditioner(
+            rank=self.preconditioner_rank, shift=self.shift
         )
-        return lx.linear_solve(
-            operator,
-            vector,
-            solver,
-            options={"preconditioner": preconditioner},
-        ).value
+        return CGSolver(
+            rtol=self.rtol,
+            atol=self.atol,
+            max_steps=self.max_steps,
+            preconditioner=preconditioner,
+        ).solve(operator, vector)
 
     def logdet(
         self,

--- a/tests/linalg/test_tridiagonal.py
+++ b/tests/linalg/test_tridiagonal.py
@@ -1,0 +1,39 @@
+"""Tests for the tridiagonal solver."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from gaussx import solve_tridiagonal, solve_tridiagonal_batched
+from gaussx._testing import tree_allclose
+
+
+def _dense_tridiagonal(lower, diag, upper):
+    return jnp.diag(diag) + jnp.diag(lower, -1) + jnp.diag(upper, 1)
+
+
+def test_solve_tridiagonal_matches_dense(getkey):
+    n = 8
+    diag = jnp.abs(jr.normal(getkey(), (n,))) + 4.0  # diagonally dominant
+    lower = jr.normal(getkey(), (n - 1,))
+    upper = jr.normal(getkey(), (n - 1,))
+    rhs = jr.normal(getkey(), (n,))
+
+    x = solve_tridiagonal(lower, diag, upper, rhs)
+    mat = _dense_tridiagonal(lower, diag, upper)
+    assert tree_allclose(x, jnp.linalg.solve(mat, rhs), rtol=1e-5)
+
+
+def test_solve_tridiagonal_batched(getkey):
+    batch, n = 5, 6
+    diag = jnp.abs(jr.normal(getkey(), (batch, n))) + 4.0
+    lower = jr.normal(getkey(), (batch, n - 1))
+    upper = jr.normal(getkey(), (batch, n - 1))
+    rhs = jr.normal(getkey(), (batch, n))
+
+    x = solve_tridiagonal_batched(lower, diag, upper, rhs)
+    assert x.shape == (batch, n)
+    for k in range(batch):
+        mat = _dense_tridiagonal(lower[k], diag[k], upper[k])
+        assert tree_allclose(x[k], jnp.linalg.solve(mat, rhs[k]), rtol=1e-5)

--- a/tests/operators/test_capacitance.py
+++ b/tests/operators/test_capacitance.py
@@ -1,0 +1,59 @@
+"""Tests for the generic capacitance-matrix solver."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+
+from gaussx import CapacitanceSolver
+from gaussx._testing import random_pd_matrix, tree_allclose
+
+
+def test_capacitance_enforces_boundary_constraint(getkey):
+    """The solution is zero at the constrained (boundary) indices."""
+    n = 12
+    b_mat = random_pd_matrix(getkey(), n)
+    b_inv = jnp.linalg.inv(b_mat)
+    boundary = jnp.array([1, 4, 7])
+
+    solver = CapacitanceSolver(lambda f: b_inv @ f, boundary, n)
+    rhs = jr.normal(getkey(), (n,))
+    x = solver(rhs)
+
+    assert tree_allclose(x[boundary], jnp.zeros(boundary.shape[0]), atol=1e-6)
+
+
+def test_capacitance_residual_supported_on_boundary(getkey):
+    """``B x - f`` vanishes away from the constrained indices.
+
+    The capacitance method yields ``x = B^{-1}(f - sum_k alpha_k e_{b_k})``, so
+    the residual ``B x - f`` is a combination of point sources located only at
+    the constrained indices.
+    """
+    n = 16
+    b_mat = random_pd_matrix(getkey(), n)
+    b_inv = jnp.linalg.inv(b_mat)
+    boundary = jnp.array([2, 9, 13])
+
+    solver = CapacitanceSolver(lambda f: b_inv @ f, boundary, n)
+    rhs = jr.normal(getkey(), (n,))
+    x = solver(rhs)
+
+    residual = b_mat @ x - rhs
+    interior_mask = jnp.ones(n).at[boundary].set(0.0)
+    assert tree_allclose(residual * interior_mask, jnp.zeros(n), atol=1e-5)
+
+
+def test_capacitance_is_linear(getkey):
+    """The solver is a linear map of the right-hand side."""
+    n = 10
+    b_mat = random_pd_matrix(getkey(), n)
+    b_inv = jnp.linalg.inv(b_mat)
+    boundary = jnp.array([0, 5])
+    solver = CapacitanceSolver(lambda f: b_inv @ f, boundary, n)
+
+    f1 = jr.normal(getkey(), (n,))
+    f2 = jr.normal(getkey(), (n,))
+    combined = solver(2.0 * f1 + 3.0 * f2)
+    separate = 2.0 * solver(f1) + 3.0 * solver(f2)
+    assert tree_allclose(combined, separate, rtol=1e-5)

--- a/tests/strategies/test_preconditioners.py
+++ b/tests/strategies/test_preconditioners.py
@@ -1,0 +1,131 @@
+"""Tests for the preconditioner protocol and concrete preconditioners."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import pytest
+
+from gaussx import (
+    CGSolver,
+    JacobiPreconditioner,
+    NystromPreconditioner,
+    OperatorPreconditioner,
+    PartialCholeskyPreconditioner,
+    linear_solve,
+)
+from gaussx._testing import random_pd_matrix, tree_allclose
+
+
+def _psd_operator(key, n):
+    mat = random_pd_matrix(key, n)
+    return mat, lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+
+
+def test_jacobi_explicit_diagonal(getkey):
+    mat, op = _psd_operator(getkey(), 6)
+    pre = JacobiPreconditioner(diagonal=jnp.diag(mat))
+    minv = pre.as_operator(op)
+    assert lx.is_positive_semidefinite(minv)
+    v = jr.normal(getkey(), (6,))
+    assert tree_allclose(minv.mv(v), v / jnp.diag(mat), rtol=1e-5)
+
+
+def test_jacobi_extracts_diagonal_from_operator(getkey):
+    mat, op = _psd_operator(getkey(), 5)
+    pre = JacobiPreconditioner()  # no explicit diagonal
+    minv = pre.as_operator(op)
+    v = jr.normal(getkey(), (5,))
+    assert tree_allclose(minv.mv(v), v / jnp.diag(mat), rtol=1e-5)
+
+
+def test_jacobi_needs_diagonal_or_operator():
+    with pytest.raises(ValueError, match="diagonal"):
+        JacobiPreconditioner().as_operator(None)
+
+
+def test_solve_with_jacobi(getkey):
+    mat, op = _psd_operator(getkey(), 12)
+    b = jr.normal(getkey(), (12,))
+    x = linear_solve(
+        op,
+        b,
+        solver=CGSolver(rtol=1e-8, atol=1e-8),
+        preconditioner=JacobiPreconditioner(diagonal=jnp.diag(mat)),
+    )
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_nystrom_from_operator_solves(getkey):
+    mat, op = _psd_operator(getkey(), 40)
+    b = jr.normal(getkey(), (40,))
+    pre = NystromPreconditioner.from_operator(op, rank=20, key=getkey())
+    assert lx.is_positive_semidefinite(pre.as_operator(op))
+    x = linear_solve(op, b, solver=CGSolver(rtol=1e-8, atol=1e-8), preconditioner=pre)
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_nystrom_reduces_iterations(getkey):
+    """On an ill-conditioned SPD system, Nyström should cut CG iterations."""
+    n = 60
+    key = getkey()
+    q, _ = jnp.linalg.qr(jr.normal(key, (n, n)))
+    # Geometrically spread spectrum -> ill-conditioned.
+    eigs = jnp.logspace(0, 4, n)
+    mat = (q * eigs) @ q.T
+    op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+    b = jr.normal(getkey(), (n,))
+
+    def cg_steps(preconditioner):
+        solver = lx.CG(rtol=1e-8, atol=1e-8, max_steps=2000)
+        options = {}
+        if preconditioner is not None:
+            options["preconditioner"] = preconditioner.as_operator(op)
+        sol = lx.linear_solve(op, b, solver, options=options)
+        return sol.stats["num_steps"]
+
+    plain = cg_steps(None)
+    pre = NystromPreconditioner.from_operator(op, rank=40, key=getkey())
+    preconditioned = cg_steps(pre)
+    assert preconditioned < plain
+
+
+def test_partial_cholesky_disabled_returns_none(getkey):
+    _, op = _psd_operator(getkey(), 5)
+    pre = PartialCholeskyPreconditioner(rank=0)
+    assert pre.as_operator(op) is None
+
+
+def test_operator_preconditioner_callable(getkey):
+    mat, op = _psd_operator(getkey(), 15)
+    b = jr.normal(getkey(), (15,))
+    inv_diag = 1.0 / jnp.diag(mat)
+    pre = OperatorPreconditioner(lambda v: inv_diag * v)
+    x = linear_solve(op, b, solver=CGSolver(rtol=1e-8, atol=1e-8), preconditioner=pre)
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_operator_preconditioner_operator_tags_psd(getkey):
+    """An untagged operator approximate-inverse is tagged PSD for lineax CG."""
+    mat, op = _psd_operator(getkey(), 10)
+    untagged = lx.DiagonalLinearOperator(1.0 / jnp.diag(mat))
+    pre = OperatorPreconditioner(untagged)
+    assert lx.is_positive_semidefinite(pre.as_operator(op))
+
+
+def test_preconditioner_non_cg_solver_raises(getkey):
+    """Preconditioning with a non-CG solver is rejected clearly."""
+    from gaussx import MINRESSolver
+
+    a = jr.normal(getkey(), (8, 8))
+    sym = 0.5 * (a + a.T)
+    op = lx.MatrixLinearOperator(sym, lx.symmetric_tag)
+    b = jr.normal(getkey(), (8,))
+    with pytest.raises(ValueError, match="only with CGSolver"):
+        linear_solve(
+            op,
+            b,
+            solver=MINRESSolver(),
+            preconditioner=JacobiPreconditioner(diagonal=jnp.diag(sym)),
+        )

--- a/tests/strategies/test_solve_frontend.py
+++ b/tests/strategies/test_solve_frontend.py
@@ -1,0 +1,126 @@
+"""Tests for the unified solve front door.
+
+Covers ``as_linear_operator`` and ``linear_solve``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import pytest
+
+from gaussx import as_linear_operator, linear_solve
+from gaussx._strategies import CGSolver, MINRESSolver
+from gaussx._testing import random_pd_matrix, tree_allclose
+
+
+def test_as_linear_operator_matches_matrix(getkey):
+    """A wrapped matvec reproduces the underlying matrix action."""
+    mat = random_pd_matrix(getkey(), 6)
+    op = as_linear_operator(lambda v: mat @ v, shape=(6, 6), positive_semidefinite=True)
+    v = jr.normal(getkey(), (6,))
+    assert tree_allclose(op.mv(v), mat @ v, rtol=1e-5)
+    assert lx.is_positive_semidefinite(op)
+    assert lx.is_symmetric(op)
+
+
+def test_as_linear_operator_requires_shape():
+    with pytest.raises(ValueError, match="shape"):
+        as_linear_operator(lambda v: v)
+
+
+def test_in_structure_int_and_tuple(getkey):
+    """`in_structure` accepts an int or a shape tuple."""
+    mat = random_pd_matrix(getkey(), 4)
+    op_int = as_linear_operator(
+        lambda v: mat @ v, in_structure=4, positive_semidefinite=True
+    )
+    op_tuple = as_linear_operator(
+        lambda v: mat @ v, in_structure=(4,), positive_semidefinite=True
+    )
+    v = jr.normal(getkey(), (4,))
+    assert tree_allclose(op_int.mv(v), op_tuple.mv(v), rtol=1e-6)
+
+
+def test_linear_solve_psd_operator(getkey):
+    """PSD operator solves via the default CG path."""
+    mat = random_pd_matrix(getkey(), 8)
+    op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+    b = jr.normal(getkey(), (8,))
+    x = linear_solve(op, b, solver=CGSolver(rtol=1e-8, atol=1e-8))
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_linear_solve_matvec_tuple(getkey):
+    """A bare `(matvec, shape)` pair is coerced and solved.
+
+    The tuple path carries no structural tags, so a solver that works from the
+    raw matvec (MINRES) is supplied explicitly.
+    """
+    mat = random_pd_matrix(getkey(), 7)
+    b = jr.normal(getkey(), (7,))
+    x = linear_solve(
+        (lambda v: mat @ v, (7, 7)), b, solver=MINRESSolver(rtol=1e-10, atol=1e-10)
+    )
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_linear_solve_negative_definite(getkey):
+    """A negative-definite operator is solved via the negated PSD system.
+
+    This mirrors how elliptic (Laplacian-like) operators are handed over by
+    finite-volume / spectral callers.
+    """
+    pd = random_pd_matrix(getkey(), 10)
+    neg = -pd  # symmetric negative definite
+    op = as_linear_operator(lambda v: neg @ v, shape=(10, 10), negative_definite=True)
+    b = jr.normal(getkey(), (10,))
+    x = linear_solve(op, b, solver=CGSolver(rtol=1e-8, atol=1e-8))
+    assert tree_allclose(x, jnp.linalg.solve(neg, b), rtol=1e-4)
+
+
+def test_default_solver_symmetric_indefinite(getkey):
+    """A symmetric indefinite operator defaults to MINRES."""
+    a = jr.normal(getkey(), (12, 12))
+    sym = 0.5 * (a + a.T)  # symmetric, generally indefinite
+    op = as_linear_operator(lambda v: sym @ v, shape=(12, 12), symmetric=True)
+    b = jr.normal(getkey(), (12,))
+    x = linear_solve(op, b)  # no solver -> default MINRES
+    assert tree_allclose(sym @ x, b, rtol=1e-3, atol=1e-4)
+
+
+def test_default_solver_nonsymmetric_raises(getkey):
+    """An untagged (non-symmetric) operator has no safe default solver."""
+    a = jr.normal(getkey(), (5, 5))
+    op = as_linear_operator(lambda v: a @ v, shape=(5, 5))
+    b = jr.normal(getkey(), (5,))
+    with pytest.raises(ValueError, match="non-symmetric"):
+        linear_solve(op, b)
+
+
+def test_preconditioner_callable(getkey):
+    """A callable Jacobi preconditioner is accepted and yields the right solve."""
+    mat = random_pd_matrix(getkey(), 30)
+    op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+    b = jr.normal(getkey(), (30,))
+    inv_diag = 1.0 / jnp.diag(mat)
+    x = linear_solve(
+        op,
+        b,
+        solver=CGSolver(rtol=1e-8, atol=1e-8),
+        preconditioner=lambda v: inv_diag * v,
+    )
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)
+
+
+def test_preconditioner_operator(getkey):
+    """A lineax operator preconditioner is accepted."""
+    mat = random_pd_matrix(getkey(), 20)
+    op = lx.MatrixLinearOperator(mat, lx.positive_semidefinite_tag)
+    b = jr.normal(getkey(), (20,))
+    precond = lx.DiagonalLinearOperator(1.0 / jnp.diag(mat))
+    x = linear_solve(
+        op, b, solver=CGSolver(rtol=1e-8, atol=1e-8), preconditioner=precond
+    )
+    assert tree_allclose(x, jnp.linalg.solve(mat, b), rtol=1e-4)


### PR DESCRIPTION
## Unified solvers in gaussx (all gaussx-side phases)

This makes **gaussx the shared raw-solver + preconditioner substrate** for
`finitevolX` and `spectraldiffx`. Those packages keep their PDE-specific bits
(grids, boundary conditions, masks, spectral transforms, multigrid) and call
gaussx with an `(operator, rhs)` pair, getting a solution back.

**Scope boundary (intentional):** gaussx gains *no* grid/BC/transform/mask
concepts. PDE-specific approximate inverses (spectral, multigrid) enter only as
passed-in callables/operators, so the dependency direction stays acyclic:
`finitevolX → spectraldiffx → gaussx`.

This PR completes **Phases 0–3** (the entire gaussx side of the plan). The
follow-up wrapper work lands in the other two repos.

📄 **Design doc:** published in the docs site under **Design → Unified Solvers**
(`docs/design/unified-solvers.md`) — motivation, the SPDE/GP↔PDE math, target
state, API, and the cross-repo execution phases.

---

### Phase 0 — unified front door (`gaussx._solve_frontend`)
- **`as_linear_operator(matvec, *, shape | in_structure, symmetric=, positive_semidefinite=, negative_definite=)`** — wrap a raw `v -> A @ v` as a tagged `lineax.FunctionLinearOperator`.
- **`linear_solve(operator_or_matvec, b, *, solver=None, preconditioner=None)`** — accepts an operator or `(matvec, shape)`; routes **negative-definite** operators through the equivalent PD system `(-A) x = -b` (the elliptic/Laplacian case); selects a default strategy from tags (PSD → CG, symmetric → MINRES); attaches a preconditioner.

### Phase 1 — preconditioner layer (`gaussx._preconditioners`)
- **`AbstractPreconditioner`** — protocol with `as_operator(operator)` returning a PSD approximate inverse (or `None` to disable).
- **`JacobiPreconditioner`** — `diag(1/diag(A))`, extracts the diagonal from the operator when not given.
- **`NystromPreconditioner`** — randomized low-rank approximate inverse via `from_operator`, with the scalar fallback that prevents false convergence in the preconditioned norm.
- **`PartialCholeskyPreconditioner`** — pivoted partial Cholesky (matfree), factored out of `PreconditionedCGSolver`.
- **`OperatorPreconditioner`** — adapter wrapping an externally supplied approximate inverse (callable/operator). **This is the slot** through which spectral & multigrid inverses (built in the PDE packages) enter, dodging the dependency cycle.
- `CGSolver` gains an optional `preconditioner`; **`PreconditionedCGSolver` now delegates** to `PartialCholeskyPreconditioner` + `CGSolver` (behaviour-preserving — existing `test_precond_cg` suite still green).

### Phase 2 — capacitance operator (`gaussx.CapacitanceSolver`)
- Sherman–Morrison / Woodbury correction around a **passed-in base solve**, enforcing homogeneous constraints at supplied flat indices. Owns only the generic linear algebra; mask/boundary extraction stays with the caller.

### Phase 3 — tridiagonal (`gaussx.solve_tridiagonal` / `solve_tridiagonal_batched`)
- Thin Thomas-algorithm wrappers over `lineax.TridiagonalLinearOperator`, with a batched `vmap` convenience.

---

### Tests & checks
New tests (all passing): `tests/strategies/test_solve_frontend.py`,
`tests/strategies/test_preconditioners.py` (protocol, each concrete
preconditioner, a CG iteration-count reduction check, the non-CG guard),
`tests/operators/test_capacitance.py` (boundary constraint, residual support,
linearity), `tests/linalg/test_tridiagonal.py` (dense parity, batched). Full
`tests/strategies/ tests/operators/ tests/linalg/ tests/test_import.py` green;
repo-wide `ruff check .` / `ruff format --check .` clean; `ty` typecheck passes;
docs build includes the new design page.

### Follow-up PRs (other repos)
- **spectraldiffx** — `build_capacitance_solver` extracts boundary indices + builds the base spectral solve, then delegates to `gaussx.CapacitanceSolver`.
- **finitevolX** — `solve_cg` → `gaussx.linear_solve`; Nyström → `gaussx.NystromPreconditioner`; spectral/multigrid → `gaussx.OperatorPreconditioner`; tridiagonal → `gaussx.solve_tridiagonal`.

https://claude.ai/code/session_018Hda43B2KgcXVMqdFGaeM1