### PR TITLE
docs(api): themed API reference with geonnax-style structure; warning-free build

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -1,0 +1,66 @@
+# Distributions & Exponential Family
+
+Layer 2: Gaussian distributions over structured covariance operators, the sugar
+operations that probabilistic code actually calls, and the exponential-family
+(natural-parameter) view used by variational and EP-style inference.
+
+## Multivariate normal distributions
+
+NumPyro-compatible distributions whose covariance (or precision) is a lineax
+operator, so `sample` / `log_prob` inherit every structured fast path.
+`MultivariateNormalPrecision` carries $\Lambda = \Sigma^{-1}$ directly — the
+natural home for natural-parameter guides, where materializing $\Sigma$ would
+be wasted work. Both require `numpyro` to be installed.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [MultivariateNormal, MultivariateNormalPrecision]
+
+## Gaussian sugar ops
+
+$$
+\log \mathcal{N}(x \mid \mu, \Sigma)
+= -\tfrac12 (x-\mu)^\top \Sigma^{-1} (x-\mu)
+  - \tfrac12 \log|\Sigma| - \tfrac{N}{2}\log 2\pi
+$$
+
+evaluated through structured `solve` + `logdet`, plus entropy, quadratic
+forms, KL divergences, conditioning, and the numerically stable Joseph-form
+covariance update.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [gaussian_log_prob, gaussian_entropy, quadratic_form, kl_standard_normal, dist_kl_divergence, conditional, joseph_update, add_jitter, project]
+
+## Exponential family
+
+The Gaussian in natural form: $\eta_1 = \Lambda\mu$, $\eta_2 = -\tfrac12
+\Lambda$. Conversions between mean/covariance, natural, and expectation
+parameterizations — multivariate (operator-aware) and univariate (per-site
+diagonal) — plus the log-partition, Fisher information, and sufficient
+statistics that natural-gradient and EP updates are built from.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members:
+        - GaussianExpFam
+        - to_natural
+        - to_expectation
+        - mean_cov_to_natural
+        - natural_to_mean_cov
+        - meanvar_to_natural
+        - natural_to_meanvar
+        - meanvar_to_expectation
+        - expectation_to_meanvar
+        - expectation_to_natural
+        - natural_to_expectation
+        - log_partition
+        - fisher_info
+        - sufficient_stats
+        - kl_divergence

--- a/docs/api/gp.md
+++ b/docs/api/gp.md
@@ -1,0 +1,81 @@
+# Gaussian Processes
+
+Layer 3 recipes for GP inference: conditioning, whitening, prediction caches,
+pathwise (Matheron) sampling, variational bounds, and cross-validation — all
+expressed over covariance *operators* so structured kernels keep their fast
+paths end to end. The modelling shell (kernels with hyperparameter priors,
+NumPyro sites) lives downstream; gaussx owns the math.
+
+## Conditioning & prediction
+
+The standard posterior
+
+$$
+\mu_* = K_{*f}\,K^{-1}(y - \mu), \qquad
+\Sigma_{**} = K_{**} - K_{*f}\,K^{-1}K_{f*}
+$$
+
+plus a precomputed-cache variant for repeated test-time queries and a
+Kronecker-structured path for separable kernels on grids.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [base_conditional, build_prediction_cache, PredictionCache, predict_mean, predict_variance, conditional_interpolate, kronecker_posterior_predictive, kronecker_mll]
+
+## Pathwise sampling
+
+Matheron's rule turns joint prior draws $(a, b)$ into posterior draws:
+$a + \mathrm{Cov}(a,b)\,\mathrm{Cov}(b,b)^{-1}(\beta - b)$.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [matheron_update]
+
+## Whitening
+
+The whitened parameterization $u = Lv$, $v \sim \mathcal{N}(0, I)$ that keeps
+sparse-variational optimization well-conditioned, and the whitened SVGP
+predictive that consumes it.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [unwhiten, unwhiten_covariance, whiten_covariance, whitened_svgp_predict, svgp_variance_adjustment]
+
+## Variational bounds & KL
+
+ELBOs for Gaussian and Monte-Carlo variational families, the collapsed
+(Titsias) sparse bound, and the Gaussian-to-Gaussian KL term.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [variational_elbo_gaussian, variational_elbo_mc, collapsed_elbo, gauss_kl]
+
+## Cross-validation & diagnostics
+
+LOVE-style cached predictive variances and closed-form leave-one-out
+cross-validation from a single factorization.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [love_cache, love_variance, LOVECache, leave_one_out_cv, LOOResult]
+
+## Multi-output projections
+
+The orthogonal instantaneous linear mixing model (OILMM): project multi-output
+observations into independent latent processes and back.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [oilmm_project, oilmm_back_project]

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,53 @@
+# API Reference
+
+gaussx is structured linear algebra, Gaussian distributions, and exponential-family
+primitives for JAX, built on [lineax](https://github.com/patrick-kidger/lineax),
+[Equinox](https://github.com/patrick-kidger/equinox), and
+[matfree](https://github.com/pnkraemer/matfree). The reference is organised by the
+package's layered architecture rather than dumped as one flat page:
+
+| Section | Layer | What's inside |
+|---------|-------|---------------|
+| [Primitives](primitives.md) | 0 | Pure functions with structural dispatch — `solve`, `logdet`, `cholesky`, `trace`, `diag`, `sqrt`, `inv`, `eig`, `svd`, root decompositions |
+| [Operators & Tags](operators.md) | 1 | `Kronecker`, `BlockDiag`, `LowRankUpdate`, `Toeplitz`, block-tridiagonal and kernel operators, plus the structural tags that drive dispatch |
+| [Solvers & Preconditioners](solvers.md) | 1.5 | Solver strategy objects (`DenseSolver`, `CGSolver`, `BBMMSolver`, SLQ logdets), the `linear_solve` front door, and preconditioners |
+| [Linear-Algebra Utilities](linalg.md) | — | `safe_cholesky`, `symmetrize`, Woodbury and Schur identities, matrix-RHS solves, tridiagonal solves |
+| [Distributions & Exponential Family](distributions.md) | 2 | `MultivariateNormal` / `MultivariateNormalPrecision`, Gaussian sugar ops, KL divergences, natural-parameter conversions |
+| [Gaussian Processes](gp.md) | 3 | Conditioning, whitening, prediction caches, Matheron updates, ELBOs, LOVE / LOO, OILMM projections |
+| [Kernels & Approximations](kernels.md) | 3 | Nyström and RFF operators, EigenPro preconditioning, HSIC / MMD, grid + interpolation helpers |
+| [Quadrature & Moment Matching](quadrature.md) | 3 | Integrators (Gauss-Hermite, unscented, Taylor, MC), likelihoods, kernel expectations, uncertain-input GP prediction |
+| [State-Space Models & Kalman](ssm.md) | 3 | SDE kernels, Kalman filter / RTS smoother (sequential, parallel, infinite-horizon), SpInGP, CVI sites |
+| [Bayesian Inference & Ensembles](inference.md) | 3 | Bayesian linear regression, Newton / natural-gradient updates, ensemble Kalman primitives (localization, inflation, ETKF) |
+
+## Conventions
+
+A few patterns hold across the whole package:
+
+- **Operators are lineax operators.** Every structured matrix extends
+  [`lineax.AbstractLinearOperator`](https://docs.kidger.site/lineax/api/operators/)
+  and is an immutable `equinox.Module` pytree — safe under `jit` / `grad` / `vmap`.
+  Dense matrices enter the system as `lx.MatrixLinearOperator(A, tags)`.
+
+- **Tags drive dispatch.** Primitives inspect operator *structure* (Kronecker,
+  block-diagonal, low-rank, …) and *properties*
+  (`lineax.positive_semidefinite_tag`, symmetric, triangular) to pick the cheapest
+  algorithm. Tag your operators — an untagged dense PSD matrix falls back to LU
+  where a tagged one gets Cholesky.
+
+- **`solver=None` means structural dispatch.** Functions that accept an optional
+  `solver:`[`AbstractSolverStrategy`](solvers.md) use the structure-aware default
+  when it is `None`; pass `CGSolver()`, `BBMMSolver()`, or a `ComposedSolver` to
+  override the numerical path without touching the math.
+
+- **Lazy over dense.** Primitives like `inv`, `sqrt`, and `cholesky` return
+  *operators*, not arrays, wherever structure allows; nothing is materialized until
+  `.as_matrix()` is called. When a structured path has to densify, a
+  `DenseFallbackWarning` is emitted.
+
+- **Pure functions.** Outside the operator classes everything is a pure function:
+  arrays and operators in, arrays and operators out. PRNG keys are explicit
+  arguments for every stochastic routine.
+
+Every public class and function carries a Google-style docstring with shapes in
+[jaxtyping](https://docs.kidger.site/jaxtyping/) notation; tensor contraction and
+reshaping inside the package go through [einx](https://github.com/fferflo/einx).

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -1,0 +1,60 @@
+# Bayesian Inference & Ensembles
+
+Layer 3 recipes for conjugate updates, second-order variational steps, and
+ensemble data assimilation. All covariances are operators, so the updates
+inherit structured solves; all stochastic routines take explicit PRNG keys.
+
+## Bayesian linear regression
+
+Closed-form Gaussian posterior updates — full covariance or diagonal-only —
+plus the marginal likelihood and expected log-likelihood that score them.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [blr_full_update, blr_diag_update, log_marginal_likelihood, gaussian_expected_log_lik]
+
+## Newton & natural-gradient updates
+
+Second-order variational steps: Newton's method on the variational objective,
+Gauss-Newton curvature (exact diagonal or Hutchinson-estimated), damped
+natural-gradient steps, and the PSD projection that keeps Riemannian updates
+on the manifold.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [newton_update, damped_natural_update, gauss_newton_precision, ggn_diagonal, hutchinson_hessian_diag, riemannian_psd_correction, cavity_distribution, trace_correction]
+
+## Ensemble covariances & Kalman gain
+
+Bessel-corrected empirical (cross-)covariances from ensemble members and the
+ensemble Kalman gain built from them.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [ensemble_covariance, ensemble_cross_covariance, ensemble_kalman_gain, etkf_transform]
+
+## Localization & inflation
+
+The standard fixes for small-ensemble rank deficiency: Schur-product
+localization with a taper (Gaspari-Cohn by default) and multiplicative /
+RTPP / RTPS inflation.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [localization_matrix, localized_kalman_gain, gaspari_cohn, inflate_multiplicative, inflate_rtpp, inflate_rtps]
+
+## Distances
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [euclidean_distance, haversine_distance]

--- a/docs/api/kernels.md
+++ b/docs/api/kernels.md
@@ -1,0 +1,48 @@
+# Kernels & Approximations
+
+Low-rank kernel approximations, spectral preconditioning for kernel SGD,
+kernel two-sample / independence statistics, and the grid helpers behind
+interpolation-based (KISS-GP style) operators.
+
+## Low-rank kernel operators
+
+Nyström ($K \approx K_{nm} K_{mm}^{-1} K_{mn}$) and random-Fourier-feature
+approximations, returned as [`LowRankUpdate`](operators.md) operators so solves
+and logdets go through Woodbury automatically.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [nystrom_operator, rff_operator]
+
+## EigenPro preconditioning
+
+Spectral preconditioning for kernel stochastic gradient descent: damp the top
+eigendirections of the kernel operator so the step size is governed by the
+residual spectrum (Ma & Belkin, 2017).
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [eigenpro_preconditioner, eigenpro_step_size, eigenpro_correction, EigenProPreconditioner]
+
+## Kernel statistics
+
+Centering, the Hilbert-Schmidt independence criterion, and maximum mean
+discrepancy.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [center_kernel, centering_operator, hsic, mmd_squared]
+
+## Grids & interpolation
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [create_grid, grid_data, cubic_interpolation_weights]

--- a/docs/api/linalg.md
+++ b/docs/api/linalg.md
@@ -1,0 +1,51 @@
+# Linear-Algebra Utilities
+
+Numerically careful building blocks shared by the higher layers: robust
+factorizations, classical matrix identities in operator form, and batched /
+matrix-RHS solve helpers.
+
+## Robust factorization & hygiene
+
+`safe_cholesky` retries with geometrically growing diagonal jitter inside a
+`jax.lax.while_loop` (JIT-compatible) when a matrix is not numerically
+positive-definite; `symmetrize` removes the floating-point asymmetry that
+accumulates in covariance updates.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [safe_cholesky, symmetrize]
+
+## Matrix identities
+
+Woodbury, Schur complements, and conditional (Schur-complement) variances —
+the identities behind every Gaussian conditioning step, exposed directly so
+recipes never re-derive them.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [woodbury_solve, schur_complement, conditional_variance, diag_conditional_variance, cov_transform, sandwich, trace_product, diag_inv]
+
+## Matrix-RHS & batched solves
+
+Solve $AX = B$ for matrix right-hand sides with one factorization
+(`solve_matrix`), per-column or per-row structured dispatch
+(`solve_columns` / `solve_rows`), or $O(n)$ Thomas-algorithm tridiagonal
+solves.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [solve_matrix, solve_columns, solve_rows, solve_tridiagonal, solve_tridiagonal_batched, batched_kernel_matvec, batched_kernel_rmatvec]
+
+## Stable kernel arithmetic & Lyapunov
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [stable_squared_distances, stable_rbf_kernel, discrete_lyapunov_solve]

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -1,0 +1,105 @@
+# Operators & Tags
+
+Layer 1: structured linear operators extending
+[`lineax.AbstractLinearOperator`](https://docs.kidger.site/lineax/api/operators/).
+All are immutable `equinox.Module` pytrees, so they compose freely with `jit`,
+`grad`, and `vmap`. The [primitives](primitives.md) dispatch on these types: a
+`solve` against a `Kronecker` factorizes per Kronecker factor, a `logdet` of a
+`BlockDiag` sums per block, a `LowRankUpdate` solve applies Woodbury.
+
+## Structured products & sums
+
+The Kronecker product $A_1 \otimes A_2 \otimes \cdots$ gives $O(\sum_i n_i^3)$
+solves on a $\prod_i n_i$ grid; the Kronecker *sum* $A \otimes I + I \otimes B$
+diagonalises in the joint eigenbasis with eigenvalues $\lambda_i + \mu_j$.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [Kronecker, BlockDiag, KroneckerSum, KroneckerSumSqrt, SumKronecker]
+
+## Low-rank updates
+
+$L + U\,\mathrm{diag}(d)\,V^\top$ with Woodbury-efficient solves and
+matrix-determinant-lemma logdets. The factories build the common special cases
+directly from arrays.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [LowRankUpdate, SVDLowRankUpdate, low_rank_plus_diag, low_rank_plus_identity, svd_low_rank_plus_diag]
+
+## Banded & Toeplitz
+
+Block-tridiagonal operators solve in $O(N d^3)$ via block-banded Cholesky — the
+precision structure of Markovian (state-space) GPs. Symmetric Toeplitz
+operators get $O(n \log n)$ matvecs and sampling via FFT circulant embedding.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [BlockTriDiag, LowerBlockTriDiag, UpperBlockTriDiag, Toeplitz, ToeplitzCholesky]
+
+## Kernel operators
+
+Kernel matrices as operators — dense (`KernelOperator`), matrix-free
+(`ImplicitKernelOperator`, rows generated on the fly per matvec), rectangular
+cross-kernels, and grid-interpolated (KISS-GP style) variants.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [KernelOperator, ImplicitKernelOperator, ImplicitCrossKernelOperator, implicit_cross_kernel, InterpolatedOperator, MaskedOperator]
+
+## Lazy algebra & sampling
+
+Sum / scale / compose operators without materializing, sample
+$\varepsilon \sim \mathcal{N}(0, A)$ for the structured families, and solve
+bordered systems through the capacitance (Schur-complement) form.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [SumOperator, ScaledOperator, ProductOperator, kronecker_sum_sample, sumkronecker_sample, toeplitz_sample, CapacitanceSolver]
+
+## Structural tags & predicates
+
+Tags mark structure and properties on operators; the `is_*` predicates are what
+the primitives consult when choosing an algorithm. The property tags
+(`positive_semidefinite_tag`, `symmetric_tag`, the triangular tags, …) are
+re-exported from lineax so user code only needs one import.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members:
+        - is_kronecker
+        - is_kronecker_sum
+        - is_block_diagonal
+        - is_block_tridiagonal
+        - is_low_rank
+        - is_diagonal
+        - is_symmetric
+        - is_positive_semidefinite
+        - is_negative_semidefinite
+        - is_lower_triangular
+        - is_upper_triangular
+        - kronecker_tag
+        - kronecker_sum_tag
+        - block_diagonal_tag
+        - block_tridiagonal_tag
+        - low_rank_tag
+        - diagonal_tag
+        - symmetric_tag
+        - positive_semidefinite_tag
+        - negative_semidefinite_tag
+        - lower_triangular_tag
+        - upper_triangular_tag
+        - tridiagonal_tag
+        - unit_diagonal_tag

--- a/docs/api/primitives.md
+++ b/docs/api/primitives.md
@@ -1,0 +1,66 @@
+# Primitives
+
+Layer 0: pure functions over `lineax.AbstractLinearOperator` with **structural
+dispatch** — each primitive inspects the operator (diagonal, Kronecker,
+block-diagonal, low-rank, block-tridiagonal, …) and routes to the cheapest exact
+algorithm, falling back to a dense computation (with a
+[`DenseFallbackWarning`](#gaussx.DenseFallbackWarning)) only when no structured
+path exists.
+
+## Solve, logdet & Cholesky
+
+The workhorses behind Gaussian densities: $A^{-1}b$, $\log|A|$, and $A = LL^\top$.
+`cholesky` returns a *lazy* lower-triangular operator that preserves structure
+(the Cholesky of a `Kronecker` is a `Kronecker` of Cholesky factors);
+`cholesky_logdet` turns an existing factor into $\log|A| = 2\sum_i \log L_{ii}$
+for free.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [solve, logdet, cholesky, cholesky_logdet]
+
+## Trace & diagonal
+
+Exact where structure allows; stochastic (Hutchinson / XTrace probing) for
+matrix-free operators. `trace_and_diag` shares one probe pass between both
+estimates.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [trace, diag, trace_and_diag]
+
+## Inverse, square root & spectral decompositions
+
+`inv` and `sqrt` return lazy operators that route their matvecs through
+structured solves / Lanczos; `eig`, `eigvals`, and `svd` take an optional `rank`
+for partial (Krylov) decompositions.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [inv, sqrt, eig, eigvals, svd, frobenius_norm, submatrix]
+
+## Root decompositions
+
+Tall-factor approximations $RR^\top \approx A$ (and $R^- (R^-)^\top \approx
+A^{-1}$) via Cholesky, pivoted Cholesky, Lanczos, or truncated SVD — the
+building block for low-rank posterior sampling and BBMM-style solvers.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [root_decomposition, root_inv_decomposition, RootDecomposition]
+
+## Support types
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [SumKroneckerSqrt, DenseFallbackWarning]

--- a/docs/api/quadrature.md
+++ b/docs/api/quadrature.md
@@ -1,0 +1,65 @@
+# Quadrature & Moment Matching
+
+Gaussian integration: $\mathbb{E}_{x \sim \mathcal{N}(\mu, \Sigma)}[f(x)]$ via
+deterministic rules (Gauss-Hermite, unscented / cubature, Taylor) or Monte
+Carlo, behind one `AbstractIntegrator` interface. Everything that needs an
+expectation — expected log-likelihoods, EP tilted moments, uncertain-input GP
+predictions — takes an integrator argument, so swapping the rule never touches
+the model.
+
+## State & integrators
+
+`GaussianState` pairs a mean with a covariance *operator*; integrators
+propagate functions of it.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [GaussianState, PropagationResult, AbstractIntegrator, GaussHermiteIntegrator, UnscentedIntegrator, TaylorIntegrator, MonteCarloIntegrator, AssumedDensityFilter]
+
+## Quadrature rules
+
+The raw point sets behind the integrators, for when a recipe needs direct
+control.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [gauss_hermite_points, cubature_points, sigma_points]
+
+## Likelihoods
+
+Observation models with quadrature-friendly `log_prob` surfaces, shared by the
+expectation helpers and the SSM / CVI recipes.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [AbstractLikelihood, GaussianLikelihood, HeteroscedasticGaussianLikelihood, BernoulliLikelihood, PoissonLikelihood, SoftmaxLikelihood, StudentTLikelihood]
+
+## Expectations & EP moments
+
+Expected log-likelihoods (the ELL term of every ELBO), generic mean / gradient /
+cost expectations, and the tilted-moment matching at the heart of expectation
+propagation.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [elbo, expected_log_likelihood, log_likelihood_expectation, mean_expectation, gradient_expectation, cost_expectation, ep_tilted_moments]
+
+## Kernel expectations & uncertain-input GPs
+
+The $\Psi$-statistics $\Psi_0 = \mathbb{E}[k(x,x)]$, $\Psi_1 = \mathbb{E}[k(x,
+X)]$, $\Psi_2 = \mathbb{E}[k(x,\cdot)k(x,\cdot)^\top]$ and the GP / SVGP / VGP /
+BGPLVM predictive equations for inputs that are themselves Gaussian.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [kernel_expectations, compute_psi_statistics, AnalyticalPsiStatistics, uncertain_gp_predict, uncertain_gp_predict_mc, uncertain_svgp_predict, uncertain_vgp_predict, uncertain_bgplvm_predict]

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,3 +1,0 @@
-# API Reference
-
-::: gaussx

--- a/docs/api/solvers.md
+++ b/docs/api/solvers.md
@@ -1,0 +1,66 @@
+# Solvers & Preconditioners
+
+Layer 1.5: strategy objects that encapsulate *how* a solve or logdet is
+computed, decoupled from *what* is being solved. Everything that accepts a
+`solver=` keyword anywhere in gaussx takes one of these; `None` falls back to
+structural dispatch on the operator.
+
+A strategy bundles a `solve` and a `logdet` algorithm. Mix and match with
+[`ComposedSolver`](#gaussx.ComposedSolver) — e.g. CG for the solve, stochastic
+Lanczos quadrature for the logdet — which is the standard recipe for large
+kernel matrices.
+
+## The front door
+
+`linear_solve` is the high-level entry point: it accepts a lineax operator *or*
+a bare `(matvec, shape)` pair, normalises negative-definite systems, picks a
+sensible iterative solver from the operator's tags, and threads a
+preconditioner through. `as_linear_operator` wraps a raw matvec callable into a
+tagged `FunctionLinearOperator` for matrix-free workflows.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [linear_solve, as_linear_operator]
+
+## Abstract interfaces
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [AbstractSolveStrategy, AbstractLogdetStrategy, AbstractSolverStrategy]
+
+## Direct & iterative solvers
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [DenseSolver, AutoSolver, CGSolver, PreconditionedCGSolver, MINRESSolver, LSMRSolver, BBMMSolver, ComposedSolver]
+
+## Logdet strategies
+
+Dense eigendecomposition for exactness; stochastic Lanczos quadrature (SLQ) for
+$O(n^2 \cdot \text{rank})$ estimates on large PSD (or symmetric-indefinite)
+operators.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [DenseLogdet, SLQLogdet, IndefiniteSLQLogdet]
+
+## Preconditioners
+
+Approximate inverses $M^{-1} \approx A^{-1}$ that accelerate the iterative
+solvers above. Pass them via the `preconditioner=` argument of
+[`linear_solve`](#gaussx.linear_solve), [`CGSolver`](#gaussx.CGSolver), or
+[`PreconditionedCGSolver`](#gaussx.PreconditionedCGSolver).
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [AbstractPreconditioner, JacobiPreconditioner, OperatorPreconditioner, NystromPreconditioner, PartialCholeskyPreconditioner]

--- a/docs/api/ssm.md
+++ b/docs/api/ssm.md
@@ -1,0 +1,64 @@
+# State-Space Models & Kalman
+
+Layer 3 recipes for linear-Gaussian state-space models. Stationary 1-D GP
+kernels with rational spectral densities admit exact SDE representations
+
+$$
+\dot{x}(t) = F\,x(t) + L\,w(t), \qquad f(t) = H\,x(t),
+$$
+
+turning $O(N^3)$ GP inference into $O(N d^3)$ Kalman filtering. This page
+covers the SDE kernel zoo, the filters and smoothers (sequential, parallel
+associative-scan, square-root, and steady-state), and the natural-parameter /
+site machinery for non-conjugate likelihoods.
+
+## SDE kernels
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [SDEKernel, SDEParams, ConstantSDE, MaternSDE, PeriodicSDE, QuasiPeriodicSDE, CosineSDE, ProductSDE, SumSDE, sde_autocovariance]
+
+## Kalman filtering & smoothing
+
+The forward filter and RTS smoother, their $O(\log N)$ parallel
+(associative-scan) counterparts, and the steady-state (infinite-horizon)
+variants built on the discrete algebraic Riccati equation.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [EmissionModel, FilterState, kalman_filter, rts_smoother, kalman_gain, parallel_kalman_filter, parallel_rts_smoother, infinite_horizon_filter, infinite_horizon_smoother, InfiniteHorizonState, dare, DAREResult, pairwise_marginals]
+
+## SpInGP
+
+State-space (sparse-in-time) GP inference: marginal likelihood and posterior
+through the SSM representation.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [spingp_log_likelihood, spingp_posterior]
+
+## Sites & natural parameters
+
+Conjugate-computation VI (CVI) site updates and the conversions between SSM
+moment, expectation, and natural parameterizations used by non-conjugate
+temporal inference.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [GaussianSites, cvi_update_sites, sites_to_precision, cavity_from_marginal, site_natural_from_tilted, site_mean_var_from_natural, expectations_to_ssm, naturals_to_ssm, ssm_to_expectations, ssm_to_naturals]
+
+## Process noise
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [process_noise_covariance]

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,5 +84,5 @@ kernel_op = gaussx.ImplicitKernelOperator(
 
 ## Links
 
-- [API Reference](api/reference.md)
+- [API Reference](api/index.md)
 - [GitHub](https://github.com/jejjohnson/gaussx)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,18 @@ plugins:
           paths: [src]
           options:
             docstring_style: google
+            docstring_section_style: table
             show_source: true
             show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            heading_level: 3
+            show_signature_annotations: true
+            signature_crossrefs: true
+            merge_init_into_class: false
+            filters: ["!^_"]
   - mkdocs-jupyter:
       execute: false
       ignore_h1_titles: true
@@ -76,7 +86,19 @@ nav:
       - Whitened SVGP & BLR: notebooks/whitened_svgp.ipynb
       - GP with Uncertain Inputs: notebooks/uncertain_gp_inputs.ipynb
       - Matrix-Free GP: notebooks/implicit_kernel.ipynb
-  - API Reference: api/reference.md
+  - API Reference:
+      - Overview: api/index.md
+      - Primitives: api/primitives.md
+      - Operators & Tags: api/operators.md
+      - Solvers & Preconditioners: api/solvers.md
+      - Linear-Algebra Utilities: api/linalg.md
+      - Distributions & Exponential Family: api/distributions.md
+      - Gaussian Processes: api/gp.md
+      - Kernels & Approximations: api/kernels.md
+      - Quadrature & Moment Matching: api/quadrature.md
+      - State-Space Models & Kalman: api/ssm.md
+      - Bayesian Inference & Ensembles: api/inference.md
+  - Changelog: CHANGELOG.md
 
 markdown_extensions:
   - admonition

--- a/src/gaussx/_distributions/_conditional.py
+++ b/src/gaussx/_distributions/_conditional.py
@@ -23,14 +23,16 @@ def conditional(
 ) -> tuple[Float[Array, " R"], lx.AbstractLinearOperator]:
     r"""Compute ``p(x_A | x_B = b)`` from a joint Gaussian ``p(x_A, x_B)``.
 
-    Given a joint distribution :math:`\mathcal{N}(\mu, \Sigma)` and
+    Given a joint distribution $\mathcal{N}(\mu, \Sigma)$ and
     observed indices *B* with values *b*, returns the conditional
     distribution over the remaining indices *A*:
 
-    .. math::
-
-        \mu_{A|B} &= \mu_A + \Sigma_{AB} \Sigma_{BB}^{-1} (b - \mu_B) \\
-        \Sigma_{A|B} &= \Sigma_{AA} - \Sigma_{AB} \Sigma_{BB}^{-1} \Sigma_{BA}
+    $$
+    \begin{aligned}
+    \mu_{A|B} &= \mu_A + \Sigma_{AB} \Sigma_{BB}^{-1} (b - \mu_B) \\
+    \Sigma_{A|B} &= \Sigma_{AA} - \Sigma_{AB} \Sigma_{BB}^{-1} \Sigma_{BA}
+    \end{aligned}
+    $$
 
     Args:
         loc: Mean vector of the joint distribution, shape ``(N,)``.

--- a/src/gaussx/_distributions/_gaussian.py
+++ b/src/gaussx/_distributions/_gaussian.py
@@ -61,7 +61,7 @@ def gaussian_log_prob(
 ) -> Float[Array, ""]:
     """Multivariate normal log-probability.
 
-    Computes::
+    Computes:
 
         log N(value | loc, Sigma)
         = -0.5 * (N log(2 pi) + log|Sigma| + (value - loc)^T Sigma^{-1} (value - loc))
@@ -89,7 +89,7 @@ def gaussian_entropy(
 ) -> Float[Array, ""]:
     """Entropy of a multivariate normal ``N(mu, Sigma)``.
 
-    Computes::
+    Computes:
 
         H = 0.5 * (N * (1 + log(2 pi)) + log|Sigma|)
 
@@ -116,12 +116,12 @@ def kl_standard_normal(
 ) -> Float[Array, ""]:
     """KL divergence ``KL(N(m, S) || N(0, I))``.
 
-    Special case of :func:`~gaussx._distributions._kl.dist_kl_divergence`
+    Special case of `dist_kl_divergence`
     with ``q_loc = 0`` and ``q_cov = I``.  The identity prior means no
     matrix inversion is required, making this more efficient than calling
     the general form directly.
 
-    Computes::
+    Computes:
 
         KL = 0.5 * (tr(S) + m^T m - N - log|S|)
 
@@ -137,7 +137,7 @@ def kl_standard_normal(
         Scalar KL divergence.
 
     See Also:
-        :func:`~gaussx._distributions._kl.dist_kl_divergence`: General KL
+        `dist_kl_divergence`: General KL
         between two multivariate normals with arbitrary lineax covariance
         operators.
     """

--- a/src/gaussx/_distributions/_joseph.py
+++ b/src/gaussx/_distributions/_joseph.py
@@ -14,7 +14,7 @@ def joseph_update(
 ) -> Float[Array, "N N"]:
     r"""Numerically stable Joseph-form covariance update.
 
-    Computes the updated covariance after a Kalman measurement update::
+    Computes the updated covariance after a Kalman measurement update:
 
         P_update = (I - K H) P_pred (I - K H)^T + K R K^T
 

--- a/src/gaussx/_distributions/_kl.py
+++ b/src/gaussx/_distributions/_kl.py
@@ -24,21 +24,21 @@ def dist_kl_divergence(
     The specialised variants below all compute the same quantity but with
     different parameterisations suited to their use cases:
 
-    - :func:`~gaussx._distributions._gaussian.kl_standard_normal` —
+    - `kl_standard_normal` —
       special case ``KL(N(m, S) || N(0, I))``; avoids matrix inversion.
-    - :func:`~gaussx._gp._gauss_kl.gauss_kl` — Cholesky-parameterised form
+    - `gauss_kl` — Cholesky-parameterised form
       for GP/SVGP models; supports multi-output and diagonal ``q_sqrt``.
-    - :func:`~gaussx._expfam._gaussian.kl_divergence` — Bregman-divergence
+    - `kl_divergence` — Bregman-divergence
       form operating on natural parameters for the exponential family.
 
-    .. math::
-
-        KL(p \| q) = \frac{1}{2}\bigl(
-            \operatorname{tr}(\Sigma_q^{-1} \Sigma_p)
-            + (\mu_q - \mu_p)^T \Sigma_q^{-1} (\mu_q - \mu_p)
-            - N
-            + \log|\Sigma_q| - \log|\Sigma_p|
-        \bigr)
+    $$
+    KL(p \| q) = \frac{1}{2}\bigl(
+        \operatorname{tr}(\Sigma_q^{-1} \Sigma_p)
+        + (\mu_q - \mu_p)^T \Sigma_q^{-1} (\mu_q - \mu_p)
+        - N
+        + \log|\Sigma_q| - \log|\Sigma_p|
+    \bigr)
+    $$
 
     Exploits structured operators for the trace and logdet terms.
 

--- a/src/gaussx/_distributions/_mvn.py
+++ b/src/gaussx/_distributions/_mvn.py
@@ -42,7 +42,7 @@ class MultivariateNormal(dist.Distribution):
             to ``AutoSolver()``.
         validate_args: Whether to validate input arguments.
 
-    Example::
+    Examples:
 
         >>> import jax.numpy as jnp
         >>> import lineax as lx

--- a/src/gaussx/_distributions/_mvn_prec.py
+++ b/src/gaussx/_distributions/_mvn_prec.py
@@ -38,7 +38,7 @@ class MultivariateNormalPrecision(dist.Distribution):
             to ``AutoSolver()``.
         validate_args: Whether to validate input arguments.
 
-    Example::
+    Examples:
 
         >>> import jax.numpy as jnp
         >>> import lineax as lx

--- a/src/gaussx/_einx.py
+++ b/src/gaussx/_einx.py
@@ -19,7 +19,7 @@ from jaxtyping import Array
 def rearrange(tensor: Array, pattern: str, **axes: int) -> Array:
     """Reorder/reshape ``tensor`` according to an einx pattern.
 
-    einops-compatible wrapper around :func:`einx.id`.
+    einops-compatible wrapper around `einx.id`.
 
     Args:
         tensor: Input array.
@@ -35,7 +35,7 @@ def rearrange(tensor: Array, pattern: str, **axes: int) -> Array:
 def repeat(tensor: Array, pattern: str, **axes: int) -> Array:
     """Broadcast/repeat ``tensor`` along new axes via an einx pattern.
 
-    einops-compatible wrapper around :func:`einx.id`.
+    einops-compatible wrapper around `einx.id`.
 
     Args:
         tensor: Input array.
@@ -71,7 +71,7 @@ def einsum(*operands: Any) -> Array:
     """Contract tensors via an einx pattern (``einops.einsum``-compatible).
 
     The trailing positional argument is the pattern; all preceding arguments
-    are the input tensors. Wraps :func:`einx.dot`.
+    are the input tensors. Wraps `einx.dot`.
 
     Args:
         *operands: Input tensors followed by the einx pattern string, e.g.

--- a/src/gaussx/_expfam/_gaussian.py
+++ b/src/gaussx/_expfam/_gaussian.py
@@ -18,9 +18,9 @@ from gaussx._primitives._solve import solve
 class GaussianExpFam(eqx.Module):
     r"""Gaussian in natural (exponential family) parameters.
 
-    .. math::
-
-        q(x \mid \eta) = h(x) \exp(\eta^T T(x) - A(\eta))
+    $$
+    q(x \mid \eta) = h(x) \exp(\eta^T T(x) - A(\eta))
+    $$
 
     where:
 
@@ -107,10 +107,10 @@ def to_natural(
 def log_partition(expfam: GaussianExpFam) -> Float[Array, ""]:
     r"""Log-partition function ``A(eta)``.
 
-    .. math::
-
-        A(\eta) = -\frac{1}{4} \eta_1^T \eta_2^{-1} \eta_1
-                  - \frac{1}{2} \log|-2\eta_2|
+    $$
+    A(\eta) = -\frac{1}{4} \eta_1^T \eta_2^{-1} \eta_1
+              - \frac{1}{2} \log|-2\eta_2|
+    $$
 
     Args:
         expfam: Gaussian in natural form.
@@ -180,20 +180,20 @@ def kl_divergence(
     Exponential-family expression of the KL divergence in terms of the
     log-partition ``A`` and the natural parameters of ``q`` and ``p``.
     Mathematically equivalent to
-    :func:`~gaussx._distributions._kl.dist_kl_divergence`.
+    `dist_kl_divergence`.
 
     The current implementation evaluates the Bregman form by routing
-    through :func:`to_expectation` for the natural-gradient term
+    through `to_expectation` for the natural-gradient term
     ``(eta_p - eta_q)^T nabla A(eta_q)``. The second-moment contraction
     splits into a quadratic form (operator matvecs) plus
-    :func:`gaussx.trace_product`, so structured ``eta2`` / ``Sigma_q``
+    `gaussx.trace_product`, so structured ``eta2`` / ``Sigma_q``
     operators are never materialized. The benefit relative to
-    :func:`dist_kl_divergence` is keeping the gradient flowing in
+    `dist_kl_divergence` is keeping the gradient flowing in
     natural-parameter space (suitable inside a natural-gradient loop).
 
-    .. math::
-
-        KL(q || p) = A(eta_p) - A(eta_q) - (eta_p - eta_q)^T nabla A(eta_q)
+    $$
+    KL(q || p) = A(eta_p) - A(eta_q) - (eta_p - eta_q)^T nabla A(eta_q)
+    $$
 
     Args:
         q: First Gaussian (the "true" distribution).
@@ -203,7 +203,7 @@ def kl_divergence(
         Scalar KL divergence.
 
     See Also:
-        :func:`~gaussx._distributions._kl.dist_kl_divergence`: General KL
+        `dist_kl_divergence`: General KL
         in mean/covariance form with lineax operators.
     """
     A_p = log_partition(p)

--- a/src/gaussx/_expfam/_natural.py
+++ b/src/gaussx/_expfam/_natural.py
@@ -5,20 +5,20 @@ conversions in the exponential-family sense. Three parameterizations are
 supported:
 
 - **Operator-based mean/covariance**: ``(mu, Sigma)`` where ``Sigma`` is a
-  :class:`lineax.AbstractLinearOperator`. Conversions exploit operator
+  `lineax.AbstractLinearOperator`. Conversions exploit operator
   structure via structural dispatch (e.g. diagonal, Kronecker). See
-  :func:`natural_to_mean_cov` and :func:`mean_cov_to_natural`.
+  `natural_to_mean_cov` and `mean_cov_to_natural`.
 
 - **Dense mean/variance (Cholesky)**: ``(mu, S_sqrt)`` where
   ``Sigma = S_sqrt @ S_sqrt^T``. All six conversion directions between
   mean/variance, natural, and expectation parameterizations operate on plain
-  JAX arrays. See :func:`meanvar_to_natural`, :func:`natural_to_meanvar`,
-  :func:`meanvar_to_expectation`, :func:`expectation_to_meanvar`,
-  :func:`natural_to_expectation`, and :func:`expectation_to_natural`.
+  JAX arrays. See `meanvar_to_natural`, `natural_to_meanvar`,
+  `meanvar_to_expectation`, `expectation_to_meanvar`,
+  `natural_to_expectation`, and `expectation_to_natural`.
 
 For **block-tridiagonal** (SSM / Gauss-Markov) parameterizations see
-:mod:`gaussx._ssm._ssm_natural`. For **per-site** (scalar/diagonal EP)
-parameterizations see :mod:`gaussx._ssm._site_natural`.
+`gaussx._ssm._ssm_natural`. For **per-site** (scalar/diagonal EP)
+parameterizations see `gaussx._ssm._site_natural`.
 """
 
 from __future__ import annotations
@@ -57,10 +57,10 @@ def natural_to_mean_cov(
 
     Operator structure (diagonal, Kronecker, …) is exploited via
     structural dispatch. For dense-array inputs see
-    :func:`natural_to_meanvar`.
+    `natural_to_meanvar`.
 
     For block-tridiagonal (SSM) inputs see
-    :func:`gaussx._ssm._ssm_natural.naturals_to_ssm`.
+    `gaussx._ssm._ssm_natural.naturals_to_ssm`.
 
     Args:
         eta1: Natural location parameter, shape ``(N,)``.
@@ -93,10 +93,10 @@ def mean_cov_to_natural(
 
     Operator structure (diagonal, Kronecker, …) is exploited via
     structural dispatch. For dense-array inputs see
-    :func:`meanvar_to_natural`.
+    `meanvar_to_natural`.
 
     For block-tridiagonal (SSM) inputs see
-    :func:`gaussx._ssm._ssm_natural.ssm_to_naturals`.
+    `gaussx._ssm._ssm_natural.ssm_to_naturals`.
 
     Args:
         mu: Mean vector, shape ``(N,)``.

--- a/src/gaussx/_gp/_base_conditional.py
+++ b/src/gaussx/_gp/_base_conditional.py
@@ -33,11 +33,11 @@ def base_conditional(
     - Inducing function values ``f`` (or whitened values if ``white=True``)
     - Optional variational posterior ``q(u) = N(f, q_sqrt q_sqrt^T)``
 
-    The conditional mean is::
+    The conditional mean is:
 
         mu = K_nm K_mm^{-1} f   (or  K_nm L_mm^{-T} f  if white)
 
-    The conditional covariance is::
+    The conditional covariance is:
 
         Sigma = K_nn - K_nm K_mm^{-1} K_mn + K_nm K_mm^{-1} S K_mm^{-1} K_mn
 

--- a/src/gaussx/_gp/_collapsed_elbo.py
+++ b/src/gaussx/_gp/_collapsed_elbo.py
@@ -25,7 +25,7 @@ def collapsed_elbo(
     """Collapsed ELBO (Titsias bound) for sparse GP regression.
 
     Computes the variational lower bound on the log marginal likelihood
-    using the matrix determinant lemma for O(NM² + M³) cost::
+    using the matrix determinant lemma for O(NM² + M³) cost:
 
         ELBO = log 𝒩(y | 0, Q_ff + σ²I) − ½σ⁻² tr(K_ff − Q_ff)
 

--- a/src/gaussx/_gp/_elbo.py
+++ b/src/gaussx/_gp/_elbo.py
@@ -19,12 +19,12 @@ def variational_elbo_gaussian(
 ) -> Float[Array, ""]:
     """Titsias collapsed ELBO for Gaussian likelihoods.
 
-    Computes::
+    Computes:
 
         ELBO = E_q[log p(y|f)] - KL(q||p)
 
     where the expected log-likelihood under a Gaussian variational
-    distribution with diagonal variance has the closed form::
+    distribution with diagonal variance has the closed form:
 
         E_q[log N(y|f, sigma^2 I)]
             = -0.5 * N * log(2 pi sigma^2)
@@ -54,7 +54,7 @@ def variational_elbo_mc(
 ) -> Float[Array, ""]:
     """Monte Carlo ELBO for non-conjugate likelihoods.
 
-    Computes::
+    Computes:
 
         ELBO = (1/S) sum_s log p(y|f_s) - KL(q||p)
 

--- a/src/gaussx/_gp/_gauss_kl.py
+++ b/src/gaussx/_gp/_gauss_kl.py
@@ -23,11 +23,11 @@ def gauss_kl(
     r"""KL divergence ``KL[q(u) || p(u)]`` between Gaussian distributions.
 
     Cholesky-parameterised variant of
-    :func:`~gaussx._distributions._kl.dist_kl_divergence` designed for
+    `dist_kl_divergence` designed for
     GP/SVGP models.  The Cholesky representation avoids explicit covariance
     matrix construction and supports both full and diagonal ``q_sqrt``.
     For lineax-operator covariances, use
-    :func:`~gaussx._distributions._kl.dist_kl_divergence` instead.
+    `dist_kl_divergence` instead.
 
     Computes the KL divergence where:
 
@@ -55,7 +55,7 @@ def gauss_kl(
         Scalar KL divergence summed over all ``R`` output dimensions.
 
     See Also:
-        :func:`~gaussx._distributions._kl.dist_kl_divergence`: General KL
+        `dist_kl_divergence`: General KL
         between two multivariate normals with lineax covariance operators.
     """
     del solver  # cholesky does not accept a solver; parameter reserved for future use

--- a/src/gaussx/_gp/_interpolation.py
+++ b/src/gaussx/_gp/_interpolation.py
@@ -25,13 +25,13 @@ def conditional_interpolate(
 ) -> tuple[Float[Array, " d"], Float[Array, "d d"]]:
     r"""Interpolated marginal at time ``t`` given posteriors at ``t^-`` and ``t^+``.
 
-    For an SDE-discretized state-space model::
+    For an SDE-discretized state-space model:
 
         x_t     | x_{t^-} \sim N(A_{fwd} x_{t^-}, Q_{fwd})
         x_{t^+} | x_t     \sim N(A_{bwd} x_t,     Q_{bwd})
 
     computes ``p(x_t | x_{t^-}, x_{t^+})`` using information fusion
-    of the forward and backward predictions::
+    of the forward and backward predictions:
 
         \Lambda_{fwd} = (A_{fwd} P_{prev} A_{fwd}^T + Q_{fwd})^{-1}
         \Lambda_{bwd} = A_{bwd}^T (P_{next} + Q_{bwd})^{-1} A_{bwd}

--- a/src/gaussx/_gp/_kronecker_gp.py
+++ b/src/gaussx/_gp/_kronecker_gp.py
@@ -58,7 +58,7 @@ def kronecker_mll(
     r"""Exact marginal log-likelihood for a Kronecker-structured GP.
 
     For a GP with covariance ``K = K_1 \otimes K_2 \otimes \ldots + sigma^2 I``,
-    computes the log marginal likelihood via per-factor eigendecomposition::
+    computes the log marginal likelihood via per-factor eigendecomposition:
 
         log p(y) = -0.5 * (y^T (K + sigma^2 I)^{-1} y
                            + log|K + sigma^2 I|
@@ -116,7 +116,7 @@ def kronecker_posterior_predictive(
     r"""Posterior mean and variance for a Kronecker GP at test points.
 
     Uses the eigendecomposition trick: projects cross-covariances onto
-    the eigenbasis and weights by inverse eigenvalues::
+    the eigenbasis and weights by inverse eigenvalues:
 
         mu_* = K_{*f} (K_{ff} + sigma^2 I)^{-1} y
         var_* = k_{**} - K_{*f} (K_{ff} + sigma^2 I)^{-1} K_{f*}

--- a/src/gaussx/_gp/_loo.py
+++ b/src/gaussx/_gp/_loo.py
@@ -41,7 +41,7 @@ def leave_one_out_cv(
     Computes leave-one-out predictive means, variances, and
     log-likelihood without refitting the model N times.
 
-    Math::
+    Math:
 
         alpha = K_y^{-1} y
         mu_LOO_i   = y_i - alpha_i / [K_y^{-1}]_{ii}
@@ -57,7 +57,7 @@ def leave_one_out_cv(
         solver: Optional solve strategy for computing K_y^{-1} y
             and for the ``diag_inv`` computation. When ``None``,
             falls back to structural dispatch.
-        diag_inv_method: Method passed to :func:`diag_inv`. Defaults to
+        diag_inv_method: Method passed to `diag_inv`. Defaults to
             ``"solve"`` so the LOO variances remain deterministic.
         diag_inv_num_probes: Number of Hutchinson probes when
             ``diag_inv_method="hutchinson"``.
@@ -65,7 +65,7 @@ def leave_one_out_cv(
             ``diag_inv_method="hutchinson"``.
 
     Returns:
-        A :class:`LOOResult` containing the LOO log-likelihood,
+        A `LOOResult` containing the LOO log-likelihood,
         predictive means, and predictive variances.
     """
     alpha = dispatch_solve(operator, y, solver)

--- a/src/gaussx/_gp/_love.py
+++ b/src/gaussx/_gp/_love.py
@@ -48,7 +48,7 @@ def love_cache(
             ``jax.random.PRNGKey(0)``.
 
     Returns:
-        A :class:`LOVECache` object.
+        A `LOVECache` object.
     """
     inverse_root = root_inv_decomposition(
         K_op,
@@ -70,17 +70,17 @@ def love_variance(
     r"""Fast predictive variance using a LOVE cache.
 
     Computes ``k_*^T K^{-1} k_*`` in ``O(Nk)`` via the cached Lanczos
-    factorization::
+    factorization:
 
         k_*^T K^{-1} k_* \approx k_*^T Q \Lambda^{-1} Q^T k_*
                               = \sum_i (q_i^T k_*)^2 / \lambda_i
 
-    The predictive variance for a GP is then::
+    The predictive variance for a GP is then:
 
         var_* = k(x_*, x_*) - love\_variance(cache, k_*)
 
     Args:
-        cache: A :class:`LOVECache` from :func:`love_cache`.
+        cache: A `LOVECache` from `love_cache`.
         K_star_row: Cross-covariance vector ``k(X_{train}, x_*)``,
             shape ``(N,)``.
 

--- a/src/gaussx/_gp/_matheron.py
+++ b/src/gaussx/_gp/_matheron.py
@@ -26,9 +26,9 @@ def matheron_update(
     Given joint prior draws ``(a, b)`` and an observed conditioning value
     ``β``, Matheron's rule samples from ``a | b = β`` by applying
 
-    .. math::
-
-        a + \operatorname{Cov}(a, b)\operatorname{Cov}(b, b)^{-1}(β - b).
+    $$
+    a + \operatorname{Cov}(a, b)\operatorname{Cov}(b, b)^{-1}(β - b).
+    $$
 
     This helper keeps both covariance arguments as lineax operators, so the
     conditioning solve uses the existing GaussX structural dispatch and the
@@ -45,7 +45,7 @@ def matheron_update(
         conditioning_covariance: Conditioning covariance operator
             ``Cov(b, b)``, shape ``(M, M)``.
         solver: Optional solver strategy for the conditioning solve
-            (e.g. :class:`gaussx.CGSolver`, :class:`gaussx.BBMMSolver`).
+            (e.g. `gaussx.CGSolver`, `gaussx.BBMMSolver`).
             When ``None``, routes through structural dispatch on
             ``conditioning_covariance``.
 

--- a/src/gaussx/_gp/_oilmm.py
+++ b/src/gaussx/_gp/_oilmm.py
@@ -14,7 +14,7 @@ def oilmm_project(
     """Project multi-output data to independent latent GPs via OILMM.
 
     Given an orthogonal mixing matrix W ∈ ℝᴾˣᴸ with WᵀW = I_L, projects
-    P-output observations to L independent latent channels::
+    P-output observations to L independent latent channels:
 
         Y_latent    = Y W              (N, L)
         σ²_latent   = (W ⊙ W)ᵀ σ²     (L,)
@@ -42,7 +42,7 @@ def oilmm_back_project(
 ) -> tuple[Float[Array, "N P"], Float[Array, "N P"]]:
     """Back-project latent GP predictions to the observation space.
 
-    Reconstructs observation-space predictions via::
+    Reconstructs observation-space predictions via:
 
         y_means = f_means Wᵀ              (N, P)
         y_vars  = f_vars (W ⊙ W)ᵀ        (N, P)

--- a/src/gaussx/_gp/_prediction_cache.py
+++ b/src/gaussx/_gp/_prediction_cache.py
@@ -40,10 +40,10 @@ def build_prediction_cache(
         operator: Training covariance operator ``K_y``, shape ``(N, N)``.
         y: Training targets, shape ``(N,)``.
         solver: Optional solve strategy. When ``None``, falls back
-            to structural-dispatch :func:`gaussx.solve`.
+            to structural-dispatch `gaussx.solve`.
 
     Returns:
-        A :class:`PredictionCache` holding the solved weights.
+        A `PredictionCache` holding the solved weights.
     """
     alpha = dispatch_solve(operator, y, solver)
     return PredictionCache(alpha=alpha)
@@ -56,7 +56,7 @@ def predict_mean(
     """Predictive mean: ``mu* = K_*f @ alpha``.
 
     Args:
-        cache: Prediction cache from :func:`build_prediction_cache`.
+        cache: Prediction cache from `build_prediction_cache`.
         K_cross: Cross-covariance matrix, shape ``(Nt, N)``.
 
     Returns:
@@ -82,7 +82,7 @@ def predict_variance(
         K_test_diag: Prior variance at test points, shape ``(Nt,)``.
         operator: Training covariance operator ``K_y``, shape ``(N, N)``.
         solver: Optional solve strategy. When ``None``, falls back
-            to structural-dispatch :func:`gaussx.solve`.
+            to structural-dispatch `gaussx.solve`.
 
     Returns:
         Predictive variance, shape ``(Nt,)``.

--- a/src/gaussx/_gp/_svgp.py
+++ b/src/gaussx/_gp/_svgp.py
@@ -20,7 +20,7 @@ def whitened_svgp_predict(
     r"""Whitened SVGP prediction: mean and variance at test points.
 
     Computes the predictive mean and variance for a sparse variational
-    GP using the whitened parameterization::
+    GP using the whitened parameterization:
 
         L_{zz} = cholesky(K_{zz})
         A = L_{zz}^{-1} K_{zx}           (triangular solve)

--- a/src/gaussx/_gp/_svgp_variance.py
+++ b/src/gaussx/_gp/_svgp_variance.py
@@ -15,7 +15,7 @@ def svgp_variance_adjustment(
     r"""Compute the SVGP variance adjustment operator.
 
     Builds the operator ``Q = K_{zz}^{-1} S_u K_{zz}^{-1} - K_{zz}^{-1}``
-    which appears in every sparse GP predictive variance computation::
+    which appears in every sparse GP predictive variance computation:
 
         Var[f_*] = k_{**} - k_{*z} (K_{zz}^{-1} - Q) k_{z*}
 

--- a/src/gaussx/_gp/_unwhiten.py
+++ b/src/gaussx/_gp/_unwhiten.py
@@ -30,7 +30,7 @@ def unwhiten_covariance(
 ) -> lx.MatrixLinearOperator:
     """Unwhiten variational covariance: S = L S̃ Lᵀ.
 
-    Delegates to :func:`~gaussx.cov_transform`.
+    Delegates to `cov_transform`.
 
     Args:
         L: Cholesky factor, shape ``(M, M)``.

--- a/src/gaussx/_inference/_blr.py
+++ b/src/gaussx/_inference/_blr.py
@@ -24,7 +24,7 @@ def blr_diag_update(
 ) -> tuple[Float[Array, " d"], Float[Array, " d"]]:
     r"""Diagonal natural parameter BLR update step.
 
-    Computes the damped update for diagonal variational parameters::
+    Computes the damped update for diagonal variational parameters:
 
         \mu = nat1 / (-2 \cdot nat2)
         eta2_{target} = -\tfrac{1}{2}(-hessian\_diag) = 0.5 \cdot hessian\_diag
@@ -71,7 +71,7 @@ def blr_full_update(
 ) -> tuple[Float[Array, " d"], Float[Array, "d d"]]:
     r"""Full-rank natural parameter BLR update step.
 
-    Computes the damped update for full-rank variational parameters::
+    Computes the damped update for full-rank variational parameters:
 
         nat2_{new} = (1 - lr) \cdot nat2 + lr \cdot (-\tfrac{1}{2}(-H))
         \mu = solve(-2 \cdot nat2, nat1)

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -34,7 +34,7 @@ def ensemble_covariance(
         bessel: If True, apply the ``1 / (J - 1)`` Bessel correction
             used throughout the ensemble Kalman filter literature. This
             lower-level helper defaults to False for backwards compatibility;
-            :func:`ensemble_kalman_gain` defaults to True for the EnKF
+            `ensemble_kalman_gain` defaults to True for the EnKF
             convention.
 
     Returns:
@@ -70,7 +70,7 @@ def ensemble_cross_covariance(
         particles_G: Second ensemble, shape ``(J, M)``.
         bessel: If True, apply the ``1 / (J - 1)`` Bessel correction
             used by ensemble Kalman filter recipes. This lower-level helper
-            defaults to False for backwards compatibility; :func:`ensemble_kalman_gain`
+            defaults to False for backwards compatibility; `ensemble_kalman_gain`
             defaults to True for the EnKF convention.
 
     Returns:
@@ -148,20 +148,22 @@ def gaspari_cohn(r: Float[Array, "*shape"], c: float) -> Float[Array, "*shape"]:
     The standard positive-definite, approximately-Gaussian localization
     function. With ``z = 2 |r| / c`` it is the piecewise-rational
 
-    .. math::
-
-        \rho = \begin{cases}
-          -\tfrac14 z^5 + \tfrac12 z^4 + \tfrac58 z^3 - \tfrac53 z^2 + 1
-            & 0 \le z \le 1 \\
-          \tfrac1{12} z^5 - \tfrac12 z^4 + \tfrac58 z^3 + \tfrac53 z^2
-            - 5 z + 4 - \tfrac{2}{3 z}
-            & 1 < z \le 2 \\
-          0 & z > 2.
-        \end{cases}
+    $$
+    \begin{aligned}
+    \rho = \begin{cases}
+      -\tfrac14 z^5 + \tfrac12 z^4 + \tfrac58 z^3 - \tfrac53 z^2 + 1
+        & 0 \le z \le 1 \\
+      \tfrac1{12} z^5 - \tfrac12 z^4 + \tfrac58 z^3 + \tfrac53 z^2
+        - 5 z + 4 - \tfrac{2}{3 z}
+        & 1 < z \le 2 \\
+      0 & z > 2.
+    \end{cases}
+    \end{aligned}
+    $$
 
     so ``rho(0) = 1`` and ``rho = 0`` for ``|r| >= c`` (``c`` is the
     compact-support radius, **not** a Gaussian length scale). The taper is
-    only :math:`C^1` at the knots ``z = 1, 2``.
+    only $C^1$ at the knots ``z = 1, 2``.
 
     Differentiability: the ``2 / (3 z)`` term in the middle branch is guarded
     with a safe denominator so reverse-mode gradients are finite at ``r = 0``
@@ -198,8 +200,8 @@ def euclidean_distance(
 ) -> Float[Array, "Na Nb"]:
     """Pairwise Euclidean distances ``||a_i - b_j||``.
 
-    A default ``metric`` for :func:`localization_matrix`. Builds on
-    :func:`stable_squared_distances` and takes a gradient-safe square root so
+    A default ``metric`` for `localization_matrix`. Builds on
+    `stable_squared_distances` and takes a gradient-safe square root so
     zero distances (e.g. the diagonal of a self-distance matrix) do not produce
     ``NaN`` gradients.
 
@@ -227,7 +229,7 @@ def haversine_distance(
 ) -> Float[Array, "Na Nb"]:
     """Pairwise great-circle (haversine) distances on a sphere.
 
-    A ``metric`` for :func:`localization_matrix` on geophysical grids.
+    A ``metric`` for `localization_matrix` on geophysical grids.
     Coordinates are ``(latitude, longitude)`` in **radians**.
 
     Args:
@@ -263,15 +265,15 @@ def localization_matrix(
     """Pairwise Gaspari-Cohn taper ``rho(dist(a_i, b_j); c)``.
 
     Use this to build the ``rho_xy`` (state-obs) and ``rho_yy`` (obs-obs)
-    localization matrices consumed by :func:`localized_kalman_gain`.
+    localization matrices consumed by `localized_kalman_gain`.
 
     Args:
         coords_a: First set of points, shape ``(Na, D)``.
         coords_b: Second set of points, shape ``(Nb, D)``.
         c: Gaspari-Cohn compact-support radius.
         metric: Pairwise distance function returning an ``(Na, Nb)`` matrix.
-            Defaults to :func:`euclidean_distance`; pass
-            :func:`haversine_distance` for spherical coordinates.
+            Defaults to `euclidean_distance`; pass
+            `haversine_distance` for spherical coordinates.
 
     Returns:
         Localization matrix of shape ``(Na, Nb)`` with entries in ``[0, 1]``.
@@ -293,9 +295,9 @@ def localized_kalman_gain(
 
     Computes
 
-    .. math::
-
-        K = (\rho_{xy} \circ P_{xy})\,(\rho_{yy} \circ P_{yy} + R)^{-1},
+    $$
+    K = (\rho_{xy} \circ P_{xy})\,(\rho_{yy} \circ P_{yy} + R)^{-1},
+    $$
 
     where ``P_xy`` is the state-observation cross-covariance and ``P_yy`` the
     observation-space ensemble covariance. Tapering kills spurious long-range
@@ -303,7 +305,7 @@ def localized_kalman_gain(
     product theorem keeps ``rho_yy . P_yy`` PSD, so the innovation covariance
     stays invertible.
 
-    This is the localized counterpart of :func:`ensemble_kalman_gain`. Unlike
+    This is the localized counterpart of `ensemble_kalman_gain`. Unlike
     that routine, the Hadamard product destroys the low-rank structure, so the
     innovation covariance is materialized densely and the solve is
     ``O(N M + M^3)``. Recover the unlocalized gain as the ``c -> inf`` limit
@@ -437,18 +439,18 @@ def etkf_transform(
     With raw observation perturbations ``Y = H X'^f`` (columns are members) and
     ``d = y - H x_bar^f``,
 
-    .. math::
-
-        \tilde{A}^{-1} = \tfrac{J-1}{\lambda} I + Y^T R^{-1} Y, \qquad
-        \bar{w} = \tilde{A}\, Y^T R^{-1} d, \qquad
-        W = \big((J-1)\,\tilde{A}\big)^{1/2},
+    $$
+    \tilde{A}^{-1} = \tfrac{J-1}{\lambda} I + Y^T R^{-1} Y, \qquad
+    \bar{w} = \tilde{A}\, Y^T R^{-1} d, \qquad
+    W = \big((J-1)\,\tilde{A}\big)^{1/2},
+    $$
 
     where ``lambda`` is the (multiplicative) ``inflation`` and ``W`` is the
     **symmetric** square root. The analysis ensemble is reconstructed as
 
-    .. math::
-
-        \bar{x}^a = \bar{x}^f + X'^f \bar{w}, \qquad X'^a = X'^f\, W.
+    $$
+    \bar{x}^a = \bar{x}^f + X'^f \bar{w}, \qquad X'^a = X'^f\, W.
+    $$
 
     The symmetric (eigendecomposition) square root -- not a Cholesky factor --
     is required: because the observation perturbations are zero-mean, ``1`` is

--- a/src/gaussx/_inference/_inference.py
+++ b/src/gaussx/_inference/_inference.py
@@ -22,11 +22,11 @@ def log_marginal_likelihood(
 ) -> Float[Array, ""]:
     """GP log marginal likelihood.
 
-    Computes::
+    Computes:
 
         log p(y) = -0.5 * (y-mu)^T K^{-1} (y-mu) - 0.5 * log|K| - N/2 * log(2pi)
 
-    Delegates to :func:`gaussx.gaussian_log_prob`.
+    Delegates to `gaussx.gaussian_log_prob`.
 
     Args:
         loc: Prior mean, shape ``(N,)``.
@@ -51,7 +51,7 @@ def gaussian_expected_log_lik(
 ) -> Float[Array, ""]:
     r"""Expected log-likelihood ``E_q[log N(y | f, R)]``.
 
-    Computes::
+    Computes:
 
         E_q[log N(y|f,R)] = log N(y | q_mu, R) - 0.5 * tr(R^{-1} q_cov)
 
@@ -92,7 +92,7 @@ def trace_correction(
 ) -> Float[Array, ""]:
     """Trace term in Titsias collapsed ELBO.
 
-    Computes::
+    Computes:
 
         tr(K_xx) - tr(K_xz^T K_zz^{-1} K_xz)
 
@@ -131,7 +131,7 @@ def cavity_distribution(
 ) -> tuple[Float[Array, " N"], lx.AbstractLinearOperator]:
     """Compute EP cavity distribution by removing a site.
 
-    Computes::
+    Computes:
 
         cav_prec = post_prec - power * site_nat2
         cav_cov  = inv(cav_prec)
@@ -165,7 +165,7 @@ def newton_update(
 ) -> tuple[Float[Array, " N"], Float[Array, "N N"]]:
     """Convert a Newton step to natural pseudo-likelihood parameters.
 
-    Computes::
+    Computes:
 
         nat1 = jacobian - hessian @ mean
         nat2 = -hessian
@@ -192,7 +192,7 @@ def process_noise_covariance(
 ) -> Float[Array, "N N"]:
     """Compute process noise from stationary covariance.
 
-    Computes::
+    Computes:
 
         Q = Pinf - A @ Pinf @ A^T
 

--- a/src/gaussx/_inference/_natural_gradient.py
+++ b/src/gaussx/_inference/_natural_gradient.py
@@ -22,7 +22,7 @@ def damped_natural_update(
 
     The universal primitive for iterative approximate inference
     (EP, VI, Newton, PL). Every method reduces to computing target
-    natural parameters and applying this damped update::
+    natural parameters and applying this damped update:
 
         nat1_{new} = (1 - lr) \cdot nat1_{old} + lr \cdot nat1_{target}
         nat2_{new} = (1 - lr) \cdot nat2_{old} + lr \cdot nat2_{target}
@@ -68,7 +68,7 @@ def riemannian_psd_correction(
     r"""Riemannian gradient correction for PSD precision updates.
 
     Ensures the corrected Hessian remains negative semi-definite,
-    stabilizing Newton/EP/VI when the raw Hessian is indefinite::
+    stabilizing Newton/EP/VI when the raw Hessian is indefinite:
 
         G = site\_precision + hessian
         H_{psd} = hessian - 0.5 \cdot lr \cdot G \cdot S \cdot G
@@ -98,7 +98,7 @@ def gauss_newton_precision(
     Hessian approximation is ``-J_r^T J_r`` which gives precision
     ``\Lambda = J^T J`` (always PSD).
 
-    When ``D_{obs} < D_{latent}``, returns a :class:`~gaussx.LowRankUpdate`
+    When ``D_{obs} < D_{latent}``, returns a `LowRankUpdate`
     to enable efficient Woodbury-based solves downstream.
 
     Args:

--- a/src/gaussx/_kernels/_eigenpro.py
+++ b/src/gaussx/_kernels/_eigenpro.py
@@ -27,7 +27,7 @@ class EigenProPreconditioner(eqx.Module):
     Stores the top eigenspace of ``K_mm / m`` on a subsample and the
     corresponding EigenPro correction weights.
 
-    Args:
+    Attributes:
         V: Top eigenvectors of ``K_mm / m``, shape ``(m, k)``.
         D: Correction weights, shape ``(k,)``.
         subsample_indices: Indices used for the subsample, shape ``(m,)``.

--- a/src/gaussx/_kernels/_grid.py
+++ b/src/gaussx/_kernels/_grid.py
@@ -44,7 +44,7 @@ def grid_data(grid: list[Float[Array, " n"]]) -> Float[Array, "G D"]:
 def _cubic_weights_1d(t: Float[Array, " B"]) -> Float[Array, "B four"]:
     """Cubic convolution interpolation weights (Keys, 1981).
 
-    For fractional position t ∈ [0, 1], the four weights are::
+    For fractional position t ∈ [0, 1], the four weights are:
 
         w₋₁ = −½t³ + t² − ½t
         w₀  = 3/2 t³ − 5/2 t² + 1

--- a/src/gaussx/_kernels/_kernel_approx.py
+++ b/src/gaussx/_kernels/_kernel_approx.py
@@ -17,7 +17,7 @@ def nystrom_operator(
     r"""Nystrom low-rank kernel approximation.
 
     Approximates ``K_{XX} \approx K_{XZ} K_{ZZ}^{-1} K_{ZX}`` as a
-    :class:`~gaussx.LowRankUpdate` with zero base::
+    `LowRankUpdate` with zero base:
 
         K_{XX} \approx U D U^T
 
@@ -30,7 +30,7 @@ def nystrom_operator(
         K_ZZ_op: Inducing-point covariance operator, shape ``(M, M)``.
 
     Returns:
-        :class:`~gaussx.LowRankUpdate` operator of shape ``(N, N)``.
+        `LowRankUpdate` operator of shape ``(N, N)``.
     """
 
     L = cholesky(K_ZZ_op)
@@ -62,11 +62,11 @@ def rff_operator(
 ) -> LowRankUpdate:
     r"""Random Fourier Features kernel approximation.
 
-    Approximates ``K_{XX} \approx \Phi \Phi^T`` where::
+    Approximates ``K_{XX} \approx \Phi \Phi^T`` where:
 
         \Phi_{i,j} = \sqrt{2/D_{rff}} \cos(X_i \cdot \omega_j + b_j)
 
-    Returns a :class:`~gaussx.LowRankUpdate` that never materializes
+    Returns a `LowRankUpdate` that never materializes
     the ``N x N`` matrix.
 
     Args:
@@ -77,7 +77,7 @@ def rff_operator(
             Sample uniformly from ``[0, 2*pi]``.
 
     Returns:
-        :class:`~gaussx.LowRankUpdate` operator of shape ``(N, N)``.
+        `LowRankUpdate` operator of shape ``(N, N)``.
     """
     D_rff = omega.shape[0]
     N = X.shape[0]
@@ -97,14 +97,14 @@ def rff_operator(
 def centering_operator(n: int) -> LowRankUpdate:
     r"""Centering matrix ``H = I - (1/n) \mathbf{1}\mathbf{1}^T``.
 
-    Returns as a :class:`~gaussx.LowRankUpdate` so the structure is
+    Returns as a `LowRankUpdate` so the structure is
     preserved for downstream operations like ``H K H``.
 
     Args:
         n: Dimension of the centering matrix.
 
     Returns:
-        :class:`~gaussx.LowRankUpdate` operator of shape ``(n, n)``.
+        `LowRankUpdate` operator of shape ``(n, n)``.
     """
     base = lx.DiagonalLinearOperator(jnp.ones(n))
     ones = jnp.ones((n, 1))
@@ -143,7 +143,7 @@ def hsic(
 ) -> Float[Array, ""]:
     r"""Biased HSIC estimator.
 
-    Computes the Hilbert-Schmidt Independence Criterion::
+    Computes the Hilbert-Schmidt Independence Criterion:
 
         HSIC = (1/n^2) \mathrm{tr}(K_f H K_q H)
 
@@ -171,7 +171,7 @@ def mmd_squared(
 ) -> Float[Array, ""]:
     r"""Biased squared Maximum Mean Discrepancy.
 
-    Computes::
+    Computes:
 
         MMD^2 = mean(K_{xx}) + mean(K_{yy}) - 2 \cdot mean(K_{xy})
 

--- a/src/gaussx/_linalg/_diag_inv.py
+++ b/src/gaussx/_linalg/_diag_inv.py
@@ -65,7 +65,7 @@ def diag_inv(
 def _diag_inv_cholesky(operator: lx.AbstractLinearOperator) -> Float[Array, " N"]:
     """Exact diagonal of A⁻¹ via Cholesky factorisation.
 
-    Uses :func:`safe_cholesky` for robustness on ill-conditioned
+    Uses `safe_cholesky` for robustness on ill-conditioned
     matrices, then computes L⁻¹ via triangular solve against the
     identity and returns ``sum_j (L⁻¹)_{j,i}²`` for each column i.
     """

--- a/src/gaussx/_linalg/_linalg.py
+++ b/src/gaussx/_linalg/_linalg.py
@@ -43,7 +43,7 @@ def cov_transform(
 
     Exploits structure where it can:
 
-    - **Operator-valued** ``J``: routes through :func:`sandwich`, which
+    - **Operator-valued** ``J``: routes through `sandwich`, which
       preserves matched ``Kronecker`` / ``BlockDiag`` structure and
       avoids materialising ``Sigma`` when either ``J`` or ``cov_operator``
       is diagonal.
@@ -62,8 +62,8 @@ def cov_transform(
     Returns:
         Transformed covariance operator, shape ``(M, M)``. For
         operator-valued ``J`` the structural class of the return type
-        follows :func:`sandwich`; otherwise it is a
-        :class:`lineax.MatrixLinearOperator`.
+        follows `sandwich`; otherwise it is a
+        `lineax.MatrixLinearOperator`.
     """
     if isinstance(J, lx.AbstractLinearOperator):
         return sandwich(J, cov_operator)
@@ -93,7 +93,7 @@ def sandwich(
     Returns:
         Transformed covariance operator with shape ``(M, M)``.
 
-    Example:
+    Examples:
         ```python
         A = gaussx.Kronecker(A1, A2)
         P = gaussx.Kronecker(P1, P2)
@@ -190,9 +190,9 @@ def trace_product(
     - **Both diagonal**: ``sum(diag(A) * diag(B))``.
     - **Diagonal × general** (or vice versa): contract the diagonal with
       the diagonal of the other operator (no full materialization).
-    - **Matched** :class:`gaussx.BlockDiag` (same block sizes): sum of
+    - **Matched** `gaussx.BlockDiag` (same block sizes): sum of
       per-block ``trace_product``.
-    - **Matched** :class:`gaussx.Kronecker` (same factor structure):
+    - **Matched** `gaussx.Kronecker` (same factor structure):
       ``prod_i tr(A_i @ B_i)``.
     - Otherwise falls back to ``sum(A * B^T)`` on the materialized
       matrices — the same O(N²) cost the previous implementation paid.
@@ -269,9 +269,9 @@ def diag_conditional_variance(
 ) -> Float[Array, " N"]:
     """Diagonal of Schur complement: ``diag(K_XX - A K_ZX)``.
 
-    Thin wrapper around :func:`gaussx.conditional_variance` (defined in
-    :func:`gaussx._linalg._schur.conditional_variance`) without a
-    variational covariance.  Use :func:`gaussx.conditional_variance`
+    Thin wrapper around `gaussx.conditional_variance` (defined in
+    `gaussx._linalg._schur.conditional_variance`) without a
+    variational covariance.  Use `gaussx.conditional_variance`
     directly when a variational correction ``S_u`` is also needed.
 
     Args:
@@ -327,18 +327,18 @@ def solve_matrix(
     """Solve ``A X = B`` with a single factorization on the matrix RHS.
 
     When ``solver`` is ``None`` and ``A`` is positive semidefinite, this
-    factors ``A = L L^T`` once via :func:`gaussx.cholesky` and then uses
+    factors ``A = L L^T`` once via `gaussx.cholesky` and then uses
     a single ``cho_solve`` on the full matrix RHS — avoiding the
-    per-column re-factorization incurred by :func:`solve_columns`.
+    per-column re-factorization incurred by `solve_columns`.
 
     For non-PSD operators (or when a custom ``solver`` is supplied),
-    falls back to :func:`solve_columns`.
+    falls back to `solve_columns`.
 
     Args:
         operator: Linear operator A, shape ``(N, N)``.
         matrix: Right-hand side B, shape ``(N, K)``.
         solver: Optional solver strategy. When provided, dispatch is
-            delegated column-by-column via :func:`solve_columns`.
+            delegated column-by-column via `solve_columns`.
 
     Returns:
         Solution X = A⁻¹ B, shape ``(N, K)``.

--- a/src/gaussx/_linalg/_lyapunov.py
+++ b/src/gaussx/_linalg/_lyapunov.py
@@ -20,11 +20,11 @@ def discrete_lyapunov_solve(
 
     Uses the eigendecomposition ``G = V Λ V^{-1}`` so that
 
-    .. math::
-
-        \tilde{P} - \Lambda \tilde{P} \Lambda^T
-            = V^{-1} Q V^{-T}, \quad
-        \tilde{P}_{ij} = \frac{(V^{-1} Q V^{-T})_{ij}}{1 - \lambda_i \lambda_j},
+    $$
+    \tilde{P} - \Lambda \tilde{P} \Lambda^T
+        = V^{-1} Q V^{-T}, \quad
+    \tilde{P}_{ij} = \frac{(V^{-1} Q V^{-T})_{ij}}{1 - \lambda_i \lambda_j},
+    $$
 
     and then ``P = V \tilde{P} V^T``. This avoids materializing the
     ``(N², N²)`` Kronecker matrix the vectorized formulation requires.
@@ -38,7 +38,7 @@ def discrete_lyapunov_solve(
     The standard sufficient condition — ``G`` is stable
     (spectral radius < 1) — guarantees this.
 
-    .. warning::
+    !!! warning
 
         This implementation assumes ``G`` is **diagonalizable**. For
         defective ``G`` (e.g., a Jordan block with eigenvalue magnitude

--- a/src/gaussx/_linalg/_mixed_precision.py
+++ b/src/gaussx/_linalg/_mixed_precision.py
@@ -68,7 +68,7 @@ def stable_rbf_kernel(
     r"""RBF (squared exponential) kernel with mixed-precision stability.
 
     Computes ``variance * exp(-0.5 * ||x - z||^2 / lengthscale^2)``
-    using :func:`stable_squared_distances` for the distance computation.
+    using `stable_squared_distances` for the distance computation.
 
     Args:
         X: First set of points, shape ``(N, D)``.

--- a/src/gaussx/_linalg/_safe_cholesky.py
+++ b/src/gaussx/_linalg/_safe_cholesky.py
@@ -25,7 +25,7 @@ def safe_cholesky(
 ) -> Float[Array, "N N"]:
     """Cholesky decomposition with adaptive jitter for near-singular matrices.
 
-    The first attempt routes through :func:`gaussx._primitives.cholesky`, so
+    The first attempt routes through `gaussx._primitives.cholesky`, so
     structured operators (``DiagonalLinearOperator``, ``BlockDiag``,
     ``Kronecker``, ``BlockTriDiag``) keep their structure on the happy path.
     If the result contains NaNs (the matrix is not numerically

--- a/src/gaussx/_linalg/_schur.py
+++ b/src/gaussx/_linalg/_schur.py
@@ -58,7 +58,7 @@ def conditional_variance(
     """Predictive variance: Schur complement diagonal plus optional variational
     correction.
 
-    Computes the diagonal of the conditional covariance::
+    Computes the diagonal of the conditional covariance:
 
         diag(K_XX - A_X K_XZ^T) + diag(A_X S_u A_X^T)
 
@@ -85,9 +85,9 @@ def conditional_variance(
         ``base_diag`` was the *Schur* diagonal already, ``A_X`` was the
         projection, and ``S_u`` was the variational covariance) is
         still accepted: it is detected when the second positional
-        argument is a :class:`lineax.AbstractLinearOperator` (the old
+        argument is a `lineax.AbstractLinearOperator` (the old
         ``S_u`` slot type). Such calls emit a
-        :class:`DeprecationWarning` and compute
+        `DeprecationWarning` and compute
         ``base_diag + diag(A_X S_u A_X^T)`` without the
         Schur subtraction.
     """

--- a/src/gaussx/_linalg/_tridiagonal.py
+++ b/src/gaussx/_linalg/_tridiagonal.py
@@ -15,7 +15,7 @@ def solve_tridiagonal(
 ) -> Float[Array, " n"]:
     """Solve a tridiagonal system ``A x = d``.
 
-    Thin wrapper over :class:`lineax.TridiagonalLinearOperator`, which delegates
+    Thin wrapper over `lineax.TridiagonalLinearOperator`, which delegates
     to ``jax.lax.linalg.tridiagonal_solve`` (LAPACK / cuSPARSE).
 
     Args:
@@ -39,7 +39,7 @@ def solve_tridiagonal_batched(
 ) -> Float[Array, "*batch n"]:
     """Solve independent tridiagonal systems over leading batch dimensions.
 
-    Applies :func:`solve_tridiagonal` vmapped over all leading dimensions.
+    Applies `solve_tridiagonal` vmapped over all leading dimensions.
 
     Args:
         lower: Sub-diagonals, shape ``(*batch, n - 1)``.

--- a/src/gaussx/_linalg/_woodbury.py
+++ b/src/gaussx/_linalg/_woodbury.py
@@ -19,7 +19,7 @@ def woodbury_solve(
     Convenience function for cases where the user has the components
     but doesn't want to construct a ``LowRankUpdate`` operator.
 
-    Uses the identity::
+    Uses the identity:
 
         (L + U D U^T)^{-1} b = L^{-1}b - L^{-1}U C^{-1} U^T L^{-1}b
 

--- a/src/gaussx/_operators/_block_tridiag.py
+++ b/src/gaussx/_operators/_block_tridiag.py
@@ -15,7 +15,7 @@ from gaussx._operators._block_diag import _to_frozenset
 class BlockTriDiag(lx.AbstractLinearOperator):
     r"""Symmetric block-tridiagonal operator.
 
-    Represents the structure::
+    Represents the structure:
 
         [D_1  A_1^T              ]
         [A_1  D_2   A_2^T        ]
@@ -165,7 +165,7 @@ class BlockTriDiag(lx.AbstractLinearOperator):
 class LowerBlockTriDiag(lx.AbstractLinearOperator):
     """Lower triangular block-bidiagonal Cholesky factor.
 
-    Represents::
+    Represents:
 
         [L_1              ]
         [B_1  L_2          ]
@@ -246,7 +246,7 @@ class LowerBlockTriDiag(lx.AbstractLinearOperator):
 class UpperBlockTriDiag(lx.AbstractLinearOperator):
     """Upper triangular block-bidiagonal (transpose of LowerBlockTriDiag).
 
-    Represents::
+    Represents:
 
         [U_1  C_1            ]
         [     U_2  C_2        ]

--- a/src/gaussx/_operators/_implicit_cross_kernel.py
+++ b/src/gaussx/_operators/_implicit_cross_kernel.py
@@ -138,7 +138,7 @@ class ImplicitCrossKernelOperator(lx.AbstractLinearOperator):
     ``N x M`` kernel matrix, using a batched scan that keeps peak memory
     at ``O(batch\_size \times M)`` per step.
 
-    Forward matvec (``mv``)::
+    Forward matvec (``mv``):
 
         y_i = \sum_j k(x_i, z_j) \cdot v_j
 
@@ -302,7 +302,7 @@ class ImplicitCrossKernelOperator(lx.AbstractLinearOperator):
 
 
 class _TransposedCrossKernelOperator(lx.AbstractLinearOperator):
-    """Adjoint of :class:`ImplicitCrossKernelOperator`.
+    """Adjoint of `ImplicitCrossKernelOperator`.
 
     Computes ``K^T u`` by scanning over batches of ``X_data`` and
     accumulating ``K_batch^T @ u_batch`` into an ``(M,)`` vector.
@@ -438,7 +438,7 @@ def implicit_cross_kernel(
 ) -> ImplicitCrossKernelOperator:
     """Create a matrix-free rectangular cross-kernel operator.
 
-    Convenience wrapper around :class:`ImplicitCrossKernelOperator`.
+    Convenience wrapper around `ImplicitCrossKernelOperator`.
 
     Args:
         kernel_fn: Kernel function ``k(x, z) -> scalar`` or

--- a/src/gaussx/_operators/_implicit_kernel.py
+++ b/src/gaussx/_operators/_implicit_kernel.py
@@ -91,7 +91,7 @@ class ImplicitKernelOperator(lx.AbstractLinearOperator):
 
     Computes the kernel matvec without materializing the ``N x N`` kernel
     matrix, using ``O(N)`` memory instead of ``O(N^2)``.  Each element of
-    the output is computed as::
+    the output is computed as:
 
         y_i = \sum_j k(x_i, x_j) v_j + sigma^2 v_i
 

--- a/src/gaussx/_operators/_kronecker_sum.py
+++ b/src/gaussx/_operators/_kronecker_sum.py
@@ -106,12 +106,12 @@ class KroneckerSum(lx.AbstractLinearOperator):
         ``self == Q @ diag(eigenvalues) @ Q.T``. Diagonal factors get a
         structural shortcut; other operators are materialized and
         decomposed via ``jnp.linalg.eigh``. We deliberately avoid
-        routing untagged factors through :func:`gaussx.eig` because
+        routing untagged factors through `gaussx.eig` because
         that primitive falls back to ``jnp.linalg.eig`` for untagged
         operators and would return general (non-orthonormal)
         eigenvectors — breaking the ``Q.T == Q^{-1}`` contract for the
         common case of numerically symmetric matrices wrapped as plain
-        :class:`lineax.MatrixLinearOperator`.
+        `lineax.MatrixLinearOperator`.
 
         Returns:
             Tuple ``(eigenvalues, Q)`` where ``Q = Q_A ⊗ Q_B`` and the
@@ -132,7 +132,7 @@ class KroneckerSumSqrt(lx.AbstractLinearOperator):
 
     Represents the symmetric matrix ``S`` with ``S @ S = A \oplus B``
     (where ``\oplus`` is the Kronecker sum ``A ⊗ I + I ⊗ B``). The square
-    root is never materialized: :meth:`mv` and :meth:`solve` apply ``S`` and
+    root is never materialized: `mv` and `solve` apply ``S`` and
     ``S^{-1}`` matrix-free using the per-factor eigendecompositions, so the
     cost is governed by the factor sizes rather than the full ``n_a · n_b``
     dimension.
@@ -259,7 +259,7 @@ def kronecker_sum_sample(
     """Sample from ``𝒩(0, A ⊕ B)`` using per-factor eigendecompositions.
 
     Draws zero-mean samples with covariance ``A ⊕ B`` by applying the
-    matrix-free :class:`KroneckerSumSqrt` to standard normal noise, avoiding
+    matrix-free `KroneckerSumSqrt` to standard normal noise, avoiding
     materialization of the full ``(n_a · n_b, n_a · n_b)`` covariance.
 
     Args:

--- a/src/gaussx/_operators/_low_rank_update.py
+++ b/src/gaussx/_operators/_low_rank_update.py
@@ -265,7 +265,7 @@ def _safe_query(query, operator: lx.AbstractLinearOperator) -> bool:
 
 
 class SVDLowRankUpdate(LowRankUpdate):
-    """Deprecated subclass of :class:`LowRankUpdate` with ``orthonormal=True``.
+    """Deprecated subclass of `LowRankUpdate` with ``orthonormal=True``.
 
     Preserves the pre-consolidation public API for one release:
 
@@ -273,14 +273,14 @@ class SVDLowRankUpdate(LowRankUpdate):
       ones (via the parent ``LowRankUpdate``) if omitted, and ``V``
       defaults to ``U`` so calls like ``SVDLowRankUpdate(base, U, S)``
       and ``SVDLowRankUpdate(base, U)`` continue to work.
-    - Inherits from :class:`LowRankUpdate` so ``isinstance`` /
+    - Inherits from `LowRankUpdate` so ``isinstance`` /
       ``issubclass`` checks and ``singledispatch`` registrations keyed
       on this class keep working.
     - Forces ``orthonormal=True`` and emits a
-      :class:`DeprecationWarning` on construction.
+      `DeprecationWarning` on construction.
 
     New code should construct ``LowRankUpdate(base, U, S, V,
-    orthonormal=True)`` (or use :func:`svd_low_rank_plus_diag`)
+    orthonormal=True)`` (or use `svd_low_rank_plus_diag`)
     directly. Will be removed in a future release.
     """
 

--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -21,7 +21,7 @@ class SumKronecker(lx.AbstractLinearOperator):
 
     Matvec is computed as the sum of the Kronecker matvecs.
 
-    For solve and logdet, call :meth:`eigendecompose` which uses a
+    For solve and logdet, call `eigendecompose` which uses a
     joint eigendecomposition of the second Kronecker pair (requires
     ``A_2, B_2`` to be symmetric).  The eigendecomposition forms a
     dense ``(n_c n_d) x (n_c n_d)`` matrix internally, so it is
@@ -110,7 +110,7 @@ class SumKronecker(lx.AbstractLinearOperator):
         ``B_2 = Q_D \Lambda_D Q_D^T``, then transforms the first pair
         into the eigenbasis and diagonalizes the result.
 
-        .. note::
+        !!! note
 
             This forms a dense ``(n_c n_d) x (n_c n_d)`` matrix
             internally and is O((n_c n_d)^3).  Intended for moderate

--- a/src/gaussx/_operators/_svd_low_rank_update.py
+++ b/src/gaussx/_operators/_svd_low_rank_update.py
@@ -16,12 +16,12 @@ from gaussx._operators._low_rank_update import (
 class SVDLowRankUpdate(LowRankUpdate):
     """SVD-parameterized low-rank update ``L + U diag(S) Vᵀ``.
 
-    Like :class:`LowRankUpdate` but assumes orthonormality of *U* and
+    Like `LowRankUpdate` but assumes orthonormality of *U* and
     *V* for cheaper solves and log-determinants. Typical sources are
     truncated SVD (Nyström approximation) or ensemble methods.
 
     Inherits ``mv``, ``as_matrix``, ``rank``, ``in_structure``, and
-    ``out_structure`` from :class:`LowRankUpdate`. The singular values
+    ``out_structure`` from `LowRankUpdate`. The singular values
     are stored in the inherited ``d`` field.
 
     Args:

--- a/src/gaussx/_preconditioners/_base.py
+++ b/src/gaussx/_preconditioners/_base.py
@@ -2,16 +2,16 @@
 
 A preconditioner supplies an approximate inverse ``M^{-1} ~= A^{-1}`` used to
 accelerate iterative solves. In gaussx a preconditioner is an
-:class:`equinox.Module` that knows how to produce a *positive-semidefinite*
+`equinox.Module` that knows how to produce a *positive-semidefinite*
 lineax operator applying ``M^{-1}``.
 
-The single abstract method, :meth:`as_operator`, takes the *system* operator
+The single abstract method, `as_operator`, takes the *system* operator
 ``A`` as an argument. Static preconditioners (e.g. Jacobi, or an externally
 supplied approximate inverse) ignore it; data-dependent ones (e.g.
 partial-Cholesky) use it to build their factor lazily at solve time. This is
 the slot through which PDE-specific approximate inverses (spectral solves,
 multigrid V-cycles) enter gaussx -- they are wrapped by
-:class:`OperatorPreconditioner` and passed in, so gaussx never needs to import
+`OperatorPreconditioner` and passed in, so gaussx never needs to import
 the packages that build them.
 """
 
@@ -27,7 +27,7 @@ from jaxtyping import Array, Float
 class AbstractPreconditioner(eqx.Module):
     """Protocol for preconditioners producing an approximate inverse.
 
-    Subclasses implement :meth:`as_operator`, returning a PSD lineax operator
+    Subclasses implement `as_operator`, returning a PSD lineax operator
     that applies ``M^{-1}`` (or ``None`` to disable preconditioning).
     """
 

--- a/src/gaussx/_preconditioners/_jacobi.py
+++ b/src/gaussx/_preconditioners/_jacobi.py
@@ -18,7 +18,7 @@ class JacobiPreconditioner(AbstractPreconditioner):
 
     Attributes:
         diagonal: The diagonal of ``A``. When ``None``, it is extracted from the
-            operator passed to :meth:`as_operator` via :func:`gaussx.diag`.
+            operator passed to `as_operator` via `gaussx.diag`.
     """
 
     diagonal: Float[Array, " n"] | None = None

--- a/src/gaussx/_preconditioners/_jacobi.py
+++ b/src/gaussx/_preconditioners/_jacobi.py
@@ -16,7 +16,7 @@ class JacobiPreconditioner(AbstractPreconditioner):
     the corresponding diagonal entry of ``A``. Effective when ``A`` is
     diagonally dominant.
 
-    Args:
+    Attributes:
         diagonal: The diagonal of ``A``. When ``None``, it is extracted from the
             operator passed to :meth:`as_operator` via :func:`gaussx.diag`.
     """

--- a/src/gaussx/_preconditioners/_nystrom.py
+++ b/src/gaussx/_preconditioners/_nystrom.py
@@ -34,7 +34,7 @@ class NystromPreconditioner(AbstractPreconditioner):
        captured eigenvalue (so CG does not falsely converge in the
        preconditioned norm).
 
-    Construct via :meth:`from_operator`.
+    Construct via `from_operator`.
 
     Attributes:
         basis: Orthonormal basis ``W``, shape ``(n, k)``.
@@ -62,7 +62,7 @@ class NystromPreconditioner(AbstractPreconditioner):
                 ``jax.random.PRNGKey(0)``.
 
         Returns:
-            A ready-to-use :class:`NystromPreconditioner`.
+            A ready-to-use `NystromPreconditioner`.
         """
         if key is None:
             key = jax.random.PRNGKey(0)

--- a/src/gaussx/_preconditioners/_operator.py
+++ b/src/gaussx/_preconditioners/_operator.py
@@ -22,7 +22,7 @@ class OperatorPreconditioner(AbstractPreconditioner):
         approx_inverse: The approximate inverse ``M^{-1}``, either as a lineax
             operator or as a callable ``v -> M^{-1} v``.
         in_structure: Input structure for the callable form. When ``None`` it is
-            taken from the system operator passed to :meth:`as_operator`.
+            taken from the system operator passed to `as_operator`.
     """
 
     approx_inverse: lx.AbstractLinearOperator | Callable

--- a/src/gaussx/_preconditioners/_operator.py
+++ b/src/gaussx/_preconditioners/_operator.py
@@ -18,7 +18,7 @@ from gaussx._preconditioners._base import AbstractPreconditioner
 class OperatorPreconditioner(AbstractPreconditioner):
     """Use an externally supplied approximate inverse as a preconditioner.
 
-    Args:
+    Attributes:
         approx_inverse: The approximate inverse ``M^{-1}``, either as a lineax
             operator or as a callable ``v -> M^{-1} v``.
         in_structure: Input structure for the callable form. When ``None`` it is

--- a/src/gaussx/_preconditioners/_partial_cholesky.py
+++ b/src/gaussx/_preconditioners/_partial_cholesky.py
@@ -20,7 +20,7 @@ class PartialCholeskyPreconditioner(AbstractPreconditioner):
 
     Attributes:
         rank: Rank of the partial Cholesky. ``<= 0`` disables preconditioning
-            (:meth:`as_operator` returns ``None``).
+            (`as_operator` returns ``None``).
         shift: Diagonal shift ``s`` for the preconditioner, typically the noise
             variance ``sigma^2``.
     """

--- a/src/gaussx/_preconditioners/_partial_cholesky.py
+++ b/src/gaussx/_preconditioners/_partial_cholesky.py
@@ -18,7 +18,7 @@ class PartialCholeskyPreconditioner(AbstractPreconditioner):
     For operators of the form ``K + sigma^2 I`` this dramatically reduces CG
     iteration counts.
 
-    Args:
+    Attributes:
         rank: Rank of the partial Cholesky. ``<= 0`` disables preconditioning
             (:meth:`as_operator` returns ``None``).
         shift: Diagonal shift ``s`` for the preconditioner, typically the noise

--- a/src/gaussx/_primitives/_root.py
+++ b/src/gaussx/_primitives/_root.py
@@ -58,7 +58,7 @@ def root_decomposition(
         key: PRNG key for random-start methods.
 
     Returns:
-        A :class:`RootDecomposition` with root shape ``(N, k)``.
+        A `RootDecomposition` with root shape ``(N, k)``.
     """
     _n, rank = _validate_square_rank(operator, rank, method=method)
     if isinstance(operator, lx.DiagonalLinearOperator):
@@ -92,7 +92,7 @@ def root_inv_decomposition(
         key: PRNG key for random-start methods.
 
     Returns:
-        A :class:`RootDecomposition` with inverse-root shape ``(N, k)``.
+        A `RootDecomposition` with inverse-root shape ``(N, k)``.
     """
     n, rank = _validate_square_rank(operator, rank, method=method)
     if isinstance(operator, lx.DiagonalLinearOperator):

--- a/src/gaussx/_primitives/_sqrt.py
+++ b/src/gaussx/_primitives/_sqrt.py
@@ -34,7 +34,7 @@ def sqrt(
         operator: A PSD linear operator.
         lanczos_order: Order of Lanczos iteration for matrix-free
             sqrt. If ``None``, uses dense eigendecomposition for most
-            operators, *except* :class:`SumKronecker` — where ``None``
+            operators, *except* `SumKronecker` — where ``None``
             falls back to a Lanczos sqrt with the module default order
             (no closed-form sqrt exists for the sum-of-Kronecker
             structure). Pass an explicit ``lanczos_order`` to override
@@ -154,8 +154,8 @@ class SqrtOperator(lx.AbstractLinearOperator):
 class SumKroneckerSqrt(SqrtOperator):
     """Lazy Lanczos square-root operator for ``SumKronecker`` covariances.
 
-    Specialization of :class:`SqrtOperator` that narrows ``original`` to a
-    :class:`SumKronecker` operator. :meth:`mv` computes ``sqrt(A) v`` via
+    Specialization of `SqrtOperator` that narrows ``original`` to a
+    `SumKronecker` operator. `mv` computes ``sqrt(A) v`` via
     matfree's Lanczos matrix-function product without materializing the full
     square root.
 

--- a/src/gaussx/_primitives/_submatrix.py
+++ b/src/gaussx/_primitives/_submatrix.py
@@ -24,10 +24,10 @@ def submatrix(
 
     Currently dispatches on:
 
-    - :class:`lineax.DiagonalLinearOperator`
-    - :class:`lineax.TaggedLinearOperator` (delegates to the wrapped operator)
-    - :class:`gaussx.BlockDiag`
-    - :class:`gaussx.Kronecker`
+    - `lineax.DiagonalLinearOperator`
+    - `lineax.TaggedLinearOperator` (delegates to the wrapped operator)
+    - `gaussx.BlockDiag`
+    - `gaussx.Kronecker`
 
     Falls back to ``operator.as_matrix()[ix_(row_idx, col_idx)]`` for
     other operators.

--- a/src/gaussx/_quadrature/_adf.py
+++ b/src/gaussx/_quadrature/_adf.py
@@ -26,7 +26,7 @@ class AssumedDensityFilter(AbstractIntegrator):
     ``argmin_q KL(p(y) || q(y))`` within the Gaussian family.
 
     Adds adaptive regularization and optional diagnostics for detecting
-    non-Gaussianity::
+    non-Gaussianity:
 
         eps = eps_base * trace(Sigma_y) / n_dim
 

--- a/src/gaussx/_quadrature/_adf.py
+++ b/src/gaussx/_quadrature/_adf.py
@@ -30,7 +30,7 @@ class AssumedDensityFilter(AbstractIntegrator):
 
         eps = eps_base * trace(Sigma_y) / n_dim
 
-    Args:
+    Attributes:
         n_samples: Number of Monte Carlo samples. Default ``5000``.
         regularization: Base regularization. Default ``1e-6``.
         adaptive_regularization: Scale regularization by output

--- a/src/gaussx/_quadrature/_expectations.py
+++ b/src/gaussx/_quadrature/_expectations.py
@@ -38,7 +38,7 @@ def gradient_expectation(
 ) -> Float[Array, " N"]:
     r"""Compute ``E[nabla f(x)]`` via Stein's lemma.
 
-    Uses the identity::
+    Uses the identity:
 
         E[nabla f(x)] = Sigma^{-1} Cov[x, f(x)]
 
@@ -135,7 +135,7 @@ def elbo(
 ) -> Float[Array, ""]:
     r"""Evidence lower bound (ELBO).
 
-    Computes::
+    Computes:
 
         ELBO = E_q[log p(y | f)] - KL(q || p)
 

--- a/src/gaussx/_quadrature/_gauss_hermite.py
+++ b/src/gaussx/_quadrature/_gauss_hermite.py
@@ -18,7 +18,7 @@ class GaussHermiteIntegrator(AbstractIntegrator):
     r"""Gauss-Hermite quadrature integrator.
 
     Approximates Gaussian expectations using tensor-product Gauss-Hermite
-    quadrature::
+    quadrature:
 
         E[g(f)] \approx \sum_i w_i \cdot g(\mu + L z_i)
 

--- a/src/gaussx/_quadrature/_gauss_hermite.py
+++ b/src/gaussx/_quadrature/_gauss_hermite.py
@@ -28,7 +28,7 @@ class GaussHermiteIntegrator(AbstractIntegrator):
     Exact for polynomials up to degree ``2 * order - 1``.
     Complexity: ``O(order^dim)``, practical for ``dim <= ~5``.
 
-    Args:
+    Attributes:
         order: Number of quadrature points per dimension. Default ``20``.
     """
 

--- a/src/gaussx/_quadrature/_gp_predict.py
+++ b/src/gaussx/_quadrature/_gp_predict.py
@@ -23,7 +23,7 @@ def kernel_expectations(
 ) -> tuple[Float[Array, ""], Float[Array, " N_train"], Float[Array, "N_train N_train"]]:
     r"""Compute kernel expectations Psi_0, Psi_1, Psi_2 for uncertain inputs.
 
-    These are the core quantities for GP inference with uncertain inputs::
+    These are the core quantities for GP inference with uncertain inputs:
 
         Psi_0 = E[k(x, x)]                      scalar
         Psi_1_i = E[k(x, x_i)]                  (N_train,)
@@ -80,7 +80,7 @@ def uncertain_gp_predict(
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     r"""Predictive mean and variance for GP with uncertain inputs.
 
-    Uses kernel expectations::
+    Uses kernel expectations:
 
         mu_pred = Psi_1 @ alpha
         var_pred = Psi_0 - tr(K_inv @ Psi_2) + alpha^T @ Psi_2 @ alpha - mu_pred^2
@@ -122,16 +122,16 @@ def uncertain_svgp_predict(
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     r"""Predictive mean and variance for SVGP with uncertain inputs.
 
-    Uses kernel expectations with inducing points::
+    Uses kernel expectations with inducing points:
 
         mu_pred = Psi_1 @ alpha
         var_pred = Psi_0 + tr(Q @ Psi_2) + alpha^T @ Psi_2 @ alpha - mu_pred^2
 
     where ``Q = K_{zz}^{-1} S K_{zz}^{-1} - K_{zz}^{-1}`` is the variance
-    adjustment operator (see :func:`gaussx.svgp_variance_adjustment`).
+    adjustment operator (see `gaussx.svgp_variance_adjustment`).
     The exact uncertain GP trace correction is recovered by setting
     ``Q = -K_{zz}^{-1}``; if ``Z`` equals the training inputs, this matches
-    :func:`gaussx.uncertain_gp_predict`.
+    `gaussx.uncertain_gp_predict`.
 
     Args:
         kernel_fn: Kernel function ``k(x, x') -> scalar``.
@@ -171,7 +171,7 @@ def uncertain_vgp_predict(
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     r"""Predictive mean and variance for dense VGP with uncertain inputs.
 
-    Uses kernel expectations with training points::
+    Uses kernel expectations with training points:
 
         mu_pred = Psi_1 @ alpha
         var_pred = Psi_0 + tr(Q @ Psi_2) + alpha^T @ Psi_2 @ alpha - mu_pred^2
@@ -219,15 +219,15 @@ def uncertain_bgplvm_predict(
     r"""Multi-output uncertain GP prediction for BGPLVM.
 
     Maps a latent variable ``z ~ N(mu, Sigma)`` to high-dimensional
-    reconstruction ``y`` using per-output GP weights::
+    reconstruction ``y`` using per-output GP weights:
 
         mu_pred_d = Psi_1 @ alpha_d
         var_pred_d = Psi_0 - tr(K_inv @ Psi_2)
                    + alpha_d^T @ Psi_2 @ alpha_d - mu_pred_d^2
 
     This intentionally uses the exact GP trace term for every output dimension.
-    Unlike :func:`gaussx.uncertain_vgp_predict` and
-    :func:`gaussx.uncertain_svgp_predict`, there is no separate variational
+    Unlike `gaussx.uncertain_vgp_predict` and
+    `gaussx.uncertain_svgp_predict`, there is no separate variational
     covariance correction operator.
 
     Args:
@@ -271,7 +271,7 @@ def uncertain_gp_predict_mc(
     r"""Monte Carlo GP prediction with uncertain inputs.
 
     Alternative to analytic kernel expectations when Psi integrals are
-    intractable. Uses law of total variance::
+    intractable. Uses law of total variance:
 
         mu = mean(particle_means)
         var = var(particle_means) + mean(particle_vars)

--- a/src/gaussx/_quadrature/_likelihood.py
+++ b/src/gaussx/_quadrature/_likelihood.py
@@ -64,7 +64,7 @@ class AbstractLikelihood(eqx.Module):
 class GaussianLikelihood(AbstractLikelihood):
     r"""Gaussian likelihood ``log N(y | f, noise_var * I)``.
 
-    Supports closed-form expected log-likelihood::
+    Supports closed-form expected log-likelihood:
 
         E_q[log N(y | f, \sigma^2 I)]
             = log N(y | q_\mu, \sigma^2 I)
@@ -102,12 +102,12 @@ class GaussianLikelihood(AbstractLikelihood):
     ) -> Float[Array, ""]:
         r"""Closed-form ``E_q[log N(y | f, \sigma^2 I)]``.
 
-        Uses::
+        Uses:
 
             E_q[log N(y|f,R)] = log N(y | q_mu, R) - 0.5 tr(R^{-1} q_cov)
 
         where ``R = noise_var * I``. Delegates the log-density term to
-        :func:`gaussx.gaussian_log_prob` (which exploits the diagonal
+        `gaussx.gaussian_log_prob` (which exploits the diagonal
         noise structure) and computes the trace correction directly via
         the structural ``trace(q_cov) / noise_var`` shortcut, so
         Kronecker/BlockDiag-structured ``q_cov`` keeps its O(n)

--- a/src/gaussx/_quadrature/_likelihood.py
+++ b/src/gaussx/_quadrature/_likelihood.py
@@ -70,7 +70,7 @@ class GaussianLikelihood(AbstractLikelihood):
             = log N(y | q_\mu, \sigma^2 I)
               - 0.5 / \sigma^2 \cdot tr(q_{cov})
 
-    Args:
+    Attributes:
         y: Observed targets, shape ``(N,)``.
         noise_var: Observation noise variance (scalar).
     """

--- a/src/gaussx/_quadrature/_likelihoods.py
+++ b/src/gaussx/_quadrature/_likelihoods.py
@@ -14,7 +14,7 @@ from gaussx._quadrature._likelihood import AbstractLikelihood
 class BernoulliLikelihood(AbstractLikelihood):
     r"""Bernoulli likelihood with logit link.
 
-    Args:
+    Attributes:
         y: Binary observations, shape ``(N,)``.
     """
 
@@ -30,7 +30,7 @@ class BernoulliLikelihood(AbstractLikelihood):
 class PoissonLikelihood(AbstractLikelihood):
     r"""Poisson likelihood with log link.
 
-    Args:
+    Attributes:
         y: Count observations, shape ``(N,)``.
     """
 
@@ -44,7 +44,7 @@ class PoissonLikelihood(AbstractLikelihood):
 class StudentTLikelihood(AbstractLikelihood):
     r"""Student-t likelihood for robust regression.
 
-    Args:
+    Attributes:
         y: Observations, shape ``(N,)``.
         df: Degrees of freedom (> 0).
         scale: Scale parameter (> 0).
@@ -98,7 +98,7 @@ class SoftmaxLikelihood(AbstractLikelihood):
 class HeteroscedasticGaussianLikelihood(AbstractLikelihood):
     r"""Heteroscedastic Gaussian likelihood with input-dependent noise.
 
-    Args:
+    Attributes:
         y: Observations, shape ``(N,)``.
     """
 

--- a/src/gaussx/_quadrature/_monte_carlo.py
+++ b/src/gaussx/_quadrature/_monte_carlo.py
@@ -29,7 +29,7 @@ class MonteCarloIntegrator(AbstractIntegrator):
         Sigma_y = cov(y_i) + regularization * I
         cross_cov = cov(x_i, y_i)
 
-    Args:
+    Attributes:
         n_samples: Number of Monte Carlo samples. Default ``1000``.
         regularization: Diagonal jitter for numerical stability.
         key: PRNG key. If ``None``, uses ``jax.random.key(0)``.

--- a/src/gaussx/_quadrature/_monte_carlo.py
+++ b/src/gaussx/_quadrature/_monte_carlo.py
@@ -21,7 +21,7 @@ class MonteCarloIntegrator(AbstractIntegrator):
 
     Propagates uncertainty by drawing samples from the input Gaussian,
     evaluating the function at each sample, and computing empirical
-    output moments::
+    output moments:
 
         x_i ~ N(mu, Sigma)       (n_samples points)
         y_i = f(x_i)

--- a/src/gaussx/_quadrature/_psi_statistics.py
+++ b/src/gaussx/_quadrature/_psi_statistics.py
@@ -53,9 +53,9 @@ def compute_psi_statistics(
 ) -> tuple[Float[Array, ""], Float[Array, " M"], Float[Array, "M M"]]:
     """Compute Ψ statistics, dispatching to analytical or numerical.
 
-    If ``kernel`` implements :class:`AnalyticalPsiStatistics`, uses
+    If ``kernel`` implements `AnalyticalPsiStatistics`, uses
     the closed-form methods. Otherwise, falls back to numerical
-    integration via the provided integrator::
+    integration via the provided integrator:
 
         Ψ₀   = E[k(x, x)]                   scalar
         Ψ₁ᵢ  = E[k(x, xᵢ)]                 (M,)
@@ -63,7 +63,7 @@ def compute_psi_statistics(
 
     Args:
         kernel: Kernel object, optionally implementing
-            :class:`AnalyticalPsiStatistics`.
+            `AnalyticalPsiStatistics`.
         state: Input Gaussian distribution x ~ 𝒩(μ, Σ).
         X_train: Training/inducing points, shape ``(M, D)``.
         integrator: Numerical integrator for fallback. Required if

--- a/src/gaussx/_quadrature/_taylor.py
+++ b/src/gaussx/_quadrature/_taylor.py
@@ -18,13 +18,13 @@ from gaussx._quadrature._types import GaussianState, PropagationResult
 class TaylorIntegrator(AbstractIntegrator):
     r"""1st or 2nd order Taylor expansion for uncertainty propagation.
 
-    **1st order (EKF)**::
+    **1st order (EKF)**:
 
         mu_y = f(mu_x)
         Sigma_y = J @ Sigma_x @ J^T
         cross_cov = Sigma_x @ J^T
 
-    **2nd order**::
+    **2nd order**:
 
         mu_y_i += 0.5 * tr(H_i @ Sigma_x)
         Sigma_y += correction from Hessians

--- a/src/gaussx/_quadrature/_taylor.py
+++ b/src/gaussx/_quadrature/_taylor.py
@@ -29,7 +29,7 @@ class TaylorIntegrator(AbstractIntegrator):
         mu_y_i += 0.5 * tr(H_i @ Sigma_x)
         Sigma_y += correction from Hessians
 
-    Args:
+    Attributes:
         order: Taylor expansion order (1 or 2). Default 1.
         correct_variance: If True and order=2, apply 2nd-order covariance
             correction using 4th Gaussian moments. Default True to preserve

--- a/src/gaussx/_quadrature/_unscented.py
+++ b/src/gaussx/_quadrature/_unscented.py
@@ -18,7 +18,7 @@ class UnscentedIntegrator(AbstractIntegrator):
     r"""Unscented transform: deterministic sigma points.
 
     Generates ``2N+1`` sigma points around the mean, propagates them
-    through the nonlinear function, and reconstructs output moments::
+    through the nonlinear function, and reconstructs output moments:
 
         chi_i = mu + sqrt((N + lambda) * Sigma) @ xi_i
         y_i = f(chi_i)

--- a/src/gaussx/_quadrature/_unscented.py
+++ b/src/gaussx/_quadrature/_unscented.py
@@ -28,7 +28,7 @@ class UnscentedIntegrator(AbstractIntegrator):
 
     where ``lambda = alpha^2 * (N + kappa) - N``.
 
-    Args:
+    Attributes:
         alpha: Spread parameter. Default ``1e-3``.
         beta: Prior knowledge parameter (2.0 optimal for Gaussian).
         kappa: Secondary scaling. Default ``0.0``.

--- a/src/gaussx/_solve_frontend.py
+++ b/src/gaussx/_solve_frontend.py
@@ -2,20 +2,20 @@
 
 This module provides two things:
 
-* :func:`as_linear_operator` -- a thin adapter that wraps a raw ``matvec``
-  callable (and an optional shape) into a :class:`lineax.AbstractLinearOperator`
+* `as_linear_operator` -- a thin adapter that wraps a raw ``matvec``
+  callable (and an optional shape) into a `lineax.AbstractLinearOperator`
   with the appropriate structural tags. This is the entry point used by
   matrix-free callers (e.g. finite-volume / spectral PDE solvers) that hand
   gaussx a bare ``v -> A @ v`` function rather than a built operator object.
 
-* :func:`linear_solve` -- a unified solve entry point that normalises its
+* `linear_solve` -- a unified solve entry point that normalises its
   operator argument (operator *or* ``(matvec, shape)``), handles the
   negative-definite sign convention used by elliptic operators, selects a
-  sensible default :class:`AbstractSolveStrategy`, and optionally applies a
+  sensible default `AbstractSolveStrategy`, and optionally applies a
   preconditioner.
 
 The design goal is that callers in other packages pre-transform their problem
-into an ``(operator, rhs)`` pair, call :func:`linear_solve`, and post-transform
+into an ``(operator, rhs)`` pair, call `linear_solve`, and post-transform
 the result -- without gaussx ever needing to know about grids, boundary
 conditions, or transforms.
 """
@@ -79,11 +79,11 @@ def as_linear_operator(
         positive_semidefinite: Tag the operator PSD (implies symmetric).
         negative_definite: Tag the operator negative semidefinite (implies
             symmetric). Use this for elliptic operators such as a discrete
-            Laplacian; :func:`linear_solve` will route the solve through the
+            Laplacian; `linear_solve` will route the solve through the
             equivalent positive-definite system.
 
     Returns:
-        A :class:`lineax.FunctionLinearOperator` carrying the requested tags.
+        A `lineax.FunctionLinearOperator` carrying the requested tags.
 
     Raises:
         ValueError: If neither ``shape`` nor ``in_structure`` is provided.
@@ -129,9 +129,9 @@ def linear_solve(
 
     Default solver selection (when ``solver is None``):
 
-    * positive semidefinite operator -> :class:`CGSolver`
-    * symmetric (possibly indefinite) operator -> :class:`MINRESSolver`
-    * otherwise -> a :class:`ValueError` asking for an explicit solver
+    * positive semidefinite operator -> `CGSolver`
+    * symmetric (possibly indefinite) operator -> `MINRESSolver`
+    * otherwise -> a `ValueError` asking for an explicit solver
 
     Args:
         operator: The linear operator ``A``, or a ``(matvec, shape)`` pair.
@@ -139,9 +139,9 @@ def linear_solve(
         solver: Solve strategy to use. When ``None`` a default is selected from
             the operator's structural tags.
         preconditioner: Optional preconditioner. May be an
-            :class:`AbstractPreconditioner`, a lineax operator applying
+            `AbstractPreconditioner`, a lineax operator applying
             ``M^{-1}``, or a callable ``v -> M^{-1} v``. Preconditioning is
-            currently applied through :class:`CGSolver`.
+            currently applied through `CGSolver`.
 
     Returns:
         The solution ``x``, shape ``(n,)``.
@@ -187,7 +187,7 @@ def _coerce_operator(
     """Normalise *operator* into a lineax operator.
 
     A bare ``(matvec, shape)`` pair is wrapped with no structural assumptions;
-    callers wanting tags should build the operator via :func:`as_linear_operator`
+    callers wanting tags should build the operator via `as_linear_operator`
     and pass it directly.
     """
     if isinstance(operator, lx.AbstractLinearOperator):
@@ -231,10 +231,10 @@ def _default_solver(operator: lx.AbstractLinearOperator) -> AbstractSolveStrateg
 def _as_preconditioner(
     preconditioner: PreconditionerLike,
 ) -> AbstractPreconditioner:
-    """Normalise *preconditioner* into an :class:`AbstractPreconditioner`.
+    """Normalise *preconditioner* into an `AbstractPreconditioner`.
 
     A raw lineax operator or callable applying ``M^{-1}`` is wrapped in an
-    :class:`OperatorPreconditioner`; an existing preconditioner is returned
+    `OperatorPreconditioner`; an existing preconditioner is returned
     unchanged.
     """
     if isinstance(preconditioner, AbstractPreconditioner):
@@ -255,8 +255,8 @@ def _attach_preconditioner(
 ) -> AbstractSolveStrategy:
     """Attach *preconditioner* to a CG-style solver.
 
-    Preconditioning is currently supported through :class:`CGSolver`. A bare
-    :class:`CGSolver` gains the preconditioner; any other strategy raises.
+    Preconditioning is currently supported through `CGSolver`. A bare
+    `CGSolver` gains the preconditioner; any other strategy raises.
     """
     if isinstance(solver, CGSolver):
         return dataclasses.replace(solver, preconditioner=preconditioner)

--- a/src/gaussx/_ssm/_autocovariance.py
+++ b/src/gaussx/_ssm/_autocovariance.py
@@ -16,7 +16,7 @@ def sde_autocovariance(
 ) -> Float[Array, " *batch"]:
     r"""Compute the stationary autocovariance of an SDE kernel.
 
-    Evaluates::
+    Evaluates:
 
         K(\tau) = H \, \exp(F |\tau|) \, P_\infty \, H^T
 

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -78,7 +78,7 @@ class ProductSDE(SDEKernel):
             kernels (Matérn-3/2, periodic) this is ≤ 32, so the
             materialization is bounded and cheap. A future refactor
             could expose a parallel ``sde_operators()`` method that
-            returns :class:`gaussx.Kronecker` operators for downstream
+            returns `gaussx.Kronecker` operators for downstream
             filters that can exploit the structure (issue #153).
         """
         p1 = self.kernel1.sde_params()
@@ -104,9 +104,9 @@ class ProductSDE(SDEKernel):
         For a product kernel ``F = F_1 \oplus F_2 = F_1 \otimes I + I \otimes F_2``,
         the factors ``F_1 \otimes I`` and ``I \otimes F_2`` commute, so
 
-        .. math::
-
-            \exp(F \, dt) = \exp(F_1 \, dt) \otimes \exp(F_2 \, dt).
+        $$
+        \exp(F \, dt) = \exp(F_1 \, dt) \otimes \exp(F_2 \, dt).
+        $$
 
         This computes two ``expm`` calls of size ``d_1`` and ``d_2``
         each, plus one Kronecker product, instead of one ``expm`` of
@@ -123,7 +123,7 @@ class ProductSDE(SDEKernel):
             dt: Time step (scalar, positive).
 
         Returns:
-            Tuple ``(A, Q)`` matching :meth:`SDEKernel.discretise`.
+            Tuple ``(A, Q)`` matching `SDEKernel.discretise`.
         """
         p1 = self.kernel1.sde_params()
         p2 = self.kernel2.sde_params()

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -14,7 +14,7 @@ from gaussx._ssm._sde_kernel import SDEKernel, SDEParams
 class SumSDE(SDEKernel):
     """Sum of SDE kernels via block-diagonal composition.
 
-    Args:
+    Attributes:
         kernels: Tuple of component SDE kernels.
     """
 
@@ -54,7 +54,7 @@ class SumSDE(SDEKernel):
 class ProductSDE(SDEKernel):
     """Product of two SDE kernels via Kronecker composition.
 
-    Args:
+    Attributes:
         kernel1: First component kernel.
         kernel2: Second component kernel.
     """
@@ -143,7 +143,7 @@ class ProductSDE(SDEKernel):
 class QuasiPeriodicSDE(ProductSDE):
     """Quasi-periodic kernel: product of Matern and Periodic SDE.
 
-    Args:
+    Attributes:
         kernel1: Modulating kernel (typically Matern).
         kernel2: Periodic kernel.
     """

--- a/src/gaussx/_ssm/_constant.py
+++ b/src/gaussx/_ssm/_constant.py
@@ -11,11 +11,11 @@ from gaussx._ssm._sde_kernel import SDEKernel, SDEParams
 class ConstantSDE(SDEKernel):
     r"""State-space representation of a constant kernel.
 
-    Models :math:`k(\tau) = \sigma^2` — a degenerate kernel with zero
+    Models $k(\tau) = \sigma^2$ — a degenerate kernel with zero
     dynamics and zero diffusion. State dimension is 1.
 
     Attributes:
-        variance: Signal variance :math:`\sigma^2`.
+        variance: Signal variance $\sigma^2$.
     """
 
     variance: Float[Array, ""]

--- a/src/gaussx/_ssm/_constant.py
+++ b/src/gaussx/_ssm/_constant.py
@@ -14,7 +14,7 @@ class ConstantSDE(SDEKernel):
     Models :math:`k(\tau) = \sigma^2` — a degenerate kernel with zero
     dynamics and zero diffusion. State dimension is 1.
 
-    Args:
+    Attributes:
         variance: Signal variance :math:`\sigma^2`.
     """
 

--- a/src/gaussx/_ssm/_cvi.py
+++ b/src/gaussx/_ssm/_cvi.py
@@ -14,7 +14,7 @@ class GaussianSites(eqx.Module):
 
     Stores per-timestep natural parameters for ``N`` Gaussian sites,
     following the ``\eta_2 = -\tfrac{1}{2}\Lambda`` convention
-    (consistent with :func:`gaussx.mean_cov_to_natural`).
+    (consistent with `gaussx.mean_cov_to_natural`).
 
     Attributes:
         nat1: Natural location parameters, shape ``(N, d)``.
@@ -34,7 +34,7 @@ def cvi_update_sites(
 ) -> GaussianSites:
     r"""Natural gradient update for CVI sites.
 
-    Performs a damped update in natural parameter space::
+    Performs a damped update in natural parameter space:
 
         \theta \leftarrow (1 - \rho) \theta + \rho \nabla
 
@@ -45,7 +45,7 @@ def cvi_update_sites(
         rho: Step size / damping factor in ``[0, 1]``.
 
     Returns:
-        Updated :class:`GaussianSites`.
+        Updated `GaussianSites`.
     """
     new_nat1 = (1.0 - rho) * sites.nat1 + rho * grad_nat1
     new_nat2 = (1.0 - rho) * sites.nat2 + rho * grad_nat2
@@ -55,10 +55,10 @@ def cvi_update_sites(
 def sites_to_precision(sites: GaussianSites) -> BlockTriDiag:
     r"""Convert Gaussian sites to a block-tridiagonal precision.
 
-    Returns a block-diagonal :class:`~gaussx.BlockTriDiag` (zero
+    Returns a block-diagonal `BlockTriDiag` (zero
     sub-diagonals) representing the precision contribution of the
     sites. This can be added to a prior precision via ``.add()``
-    or ``+`` to form the posterior precision::
+    or ``+`` to form the posterior precision:
 
         \Lambda_{post} = \Lambda_{prior} + \Lambda_{sites}
 
@@ -69,7 +69,7 @@ def sites_to_precision(sites: GaussianSites) -> BlockTriDiag:
         sites: Gaussian sites with ``nat2`` in eta2 convention.
 
     Returns:
-        Block-diagonal :class:`~gaussx.BlockTriDiag` precision.
+        Block-diagonal `BlockTriDiag` precision.
     """
     N, d = sites.nat1.shape
     diag_blocks = -2.0 * sites.nat2  # (N, d, d)

--- a/src/gaussx/_ssm/_dare.py
+++ b/src/gaussx/_ssm/_dare.py
@@ -46,7 +46,7 @@ def dare(
 ) -> DAREResult:
     """Discrete Algebraic Riccati Equation solver.
 
-    Iterates the Kalman predict-update equations until convergence::
+    Iterates the Kalman predict-update equations until convergence:
 
         Predict:  P⁻ = A P Aᵀ + Q
         Update:   S = H P⁻ Hᵀ + R
@@ -66,11 +66,11 @@ def dare(
         solver: Optional solver strategy for structured linear algebra.
             When ``None``, falls back to structural dispatch.
         woodbury_innovation: When ``True``, build ``S = H P⁻ Hᵀ + R``
-            as a :class:`gaussx.LowRankUpdate` so structured ``R`` uses
+            as a `gaussx.LowRankUpdate` so structured ``R`` uses
             Woodbury solves.
 
     Returns:
-        A :class:`DAREResult` containing the steady-state covariance,
+        A `DAREResult` containing the steady-state covariance,
         Kalman gain, and convergence flag.
     """
     A_op = _as_operator(A)

--- a/src/gaussx/_ssm/_infinite_horizon_kalman.py
+++ b/src/gaussx/_ssm/_infinite_horizon_kalman.py
@@ -62,14 +62,14 @@ def infinite_horizon_filter(
 
     Uses the DARE solution for a constant Kalman gain K∞, avoiding
     per-step Riccati updates.  For dense matrices, the per-step cost is
-    O(N² + MN + M²) instead of O(N³) for the standard Kalman filter::
+    O(N² + MN + M²) instead of O(N³) for the standard Kalman filter:
 
         Predict:  x⁻ₜ = A xₜ₋₁
         Update:   vₜ  = yₜ − H x⁻ₜ
                   xₜ  = x⁻ₜ + K∞ vₜ
 
     All four operator/array arguments accept either a raw JAX array or
-    a :class:`lineax.AbstractLinearOperator`. Operator inputs preserve
+    a `lineax.AbstractLinearOperator`. Operator inputs preserve
     their structural matvec inside the per-step scan; the sandwiches
     materialise once outside the scan.
 
@@ -89,7 +89,7 @@ def infinite_horizon_filter(
         solver: Optional solver strategy for structured linear algebra.
             When ``None``, falls back to structural dispatch.
         woodbury_innovation: When ``True``, build the steady-state
-            innovation covariance as :class:`gaussx.LowRankUpdate` so
+            innovation covariance as `gaussx.LowRankUpdate` so
             structured ``R`` can use Woodbury solves/log-determinants.
 
     Returns:
@@ -185,7 +185,7 @@ def infinite_horizon_smoother(
 
     Precomputes the steady-state smoother gain G∞ = P∞ Aᵀ P⁻pred⁻¹,
     then runs a backward scan with fixed G∞.  The steady-state smoothed
-    covariance is the solution of the discrete Lyapunov equation::
+    covariance is the solution of the discrete Lyapunov equation:
 
         P_smooth = P∞ + G∞ (P_smooth − P⁻pred) G∞ᵀ
 
@@ -218,7 +218,7 @@ def infinite_horizon_smoother(
     # Solve discrete Lyapunov equation:
     # P_smooth = P∞ + G∞ (P_smooth − P⁻pred) G∞ᵀ
     # ⟺ P_smooth − G∞ P_smooth G∞ᵀ = P∞ − G∞ P⁻pred G∞ᵀ
-    # Routed through :func:`discrete_lyapunov_solve` which uses a
+    # Routed through `discrete_lyapunov_solve` which uses a
     # per-factor eigendecomposition of ``G∞`` instead of materializing
     # the ``(N², N²)`` Kronecker matrix ``I − G∞ ⊗ G∞``.
     rhs = P_inf - G_inf @ P_pred_inf @ G_inf.T  # (N, N)

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -55,7 +55,7 @@ def kalman_filter(
     r"""Kalman filter forward pass via ``jax.lax.scan``.
 
     Implements the predict-update cycle for a (possibly time-varying)
-    linear-Gaussian state-space model::
+    linear-Gaussian state-space model:
 
         x_t = A_t @ x_{t-1} + q_t,   q_t ~ N(0, Q_t)
         y_t = H_t @ x_t + r_t,        r_t ~ N(0, R_t)
@@ -63,7 +63,7 @@ def kalman_filter(
     **Time-invariant inputs** (single ``(N, N)`` / ``(M, N)`` etc.) are
     automatically broadcast along the time axis. **Time-varying inputs**
     are passed as ``(T, …)`` stacks (e.g. from
-    :meth:`~gaussx.SDEKernel.discretise_sequence`).
+    `discretise_sequence`).
 
     **Operator inputs** (lineax ``BlockDiag`` / ``Kronecker`` /
     ``DiagonalLinearOperator`` / ``MaskedOperator`` / etc.) are accepted
@@ -76,7 +76,7 @@ def kalman_filter(
 
     Args:
         transition: State transition matrix ``A``. Shape ``(N, N)``,
-            ``(T, N, N)``, or :class:`lineax.AbstractLinearOperator`.
+            ``(T, N, N)``, or `lineax.AbstractLinearOperator`.
         obs_model: Observation matrix ``H``. Shape ``(M, N)``,
             ``(T, M, N)``, or operator.
         process_noise: Process noise covariance ``Q``. Shape ``(N, N)``,
@@ -95,7 +95,7 @@ def kalman_filter(
             structural dispatch.
         woodbury_innovation: When ``True``, build the innovation
             covariance ``S = H P Hᵀ + R`` as a
-            :class:`gaussx.LowRankUpdate` so structured ``R`` can use
+            `gaussx.LowRankUpdate` so structured ``R`` can use
             Woodbury solves/log-determinants. Defaults to ``False`` to
             preserve the dense innovation path.
 
@@ -221,17 +221,17 @@ def rts_smoother(
     """Rauch-Tung-Striebel backward smoother.
 
     Accepts the same time-invariant / time-varying / operator forms for
-    ``transition`` and ``process_noise`` as :func:`kalman_filter`. When
+    ``transition`` and ``process_noise`` as `kalman_filter`. When
     a step was masked off in the filter (``mask[t] == 0``), the
     smoother formula degenerates harmlessly because filtered ==
     predicted at that step.
 
     Args:
-        filter_state: Output of :func:`kalman_filter`.
+        filter_state: Output of `kalman_filter`.
         transition: State transition matrix or operator.
         process_noise: Process noise covariance or operator. (Not
             currently used by the standard RTS recurrence — kept for
-            API symmetry with :func:`kalman_filter`.)
+            API symmetry with `kalman_filter`.)
         solver: Optional solver strategy.
 
     Returns:
@@ -316,7 +316,7 @@ def kalman_gain(
         solver: Optional solver strategy. When ``None``, uses
             structural dispatch.
         woodbury_innovation: When ``True``, route the innovation
-            covariance through :class:`gaussx.LowRankUpdate`.
+            covariance through `gaussx.LowRankUpdate`.
 
     Returns:
         Kalman gain matrix of shape ``(N, M)``.

--- a/src/gaussx/_ssm/_matern.py
+++ b/src/gaussx/_ssm/_matern.py
@@ -15,7 +15,7 @@ class MaternSDE(SDEKernel):
     Supports orders 0 (Matern-1/2), 1 (Matern-3/2), and 2 (Matern-5/2).
     The state dimension is ``order + 1``.
 
-    Args:
+    Attributes:
         variance: Signal variance :math:`\sigma^2`.
         lengthscale: Lengthscale :math:`\ell`.
         order: Matern order (0, 1, or 2).

--- a/src/gaussx/_ssm/_matern.py
+++ b/src/gaussx/_ssm/_matern.py
@@ -16,8 +16,8 @@ class MaternSDE(SDEKernel):
     The state dimension is ``order + 1``.
 
     Attributes:
-        variance: Signal variance :math:`\sigma^2`.
-        lengthscale: Lengthscale :math:`\ell`.
+        variance: Signal variance $\sigma^2$.
+        lengthscale: Lengthscale $\ell$.
         order: Matern order (0, 1, or 2).
     """
 

--- a/src/gaussx/_ssm/_pairwise_marginals.py
+++ b/src/gaussx/_ssm/_pairwise_marginals.py
@@ -14,7 +14,7 @@ def pairwise_marginals(
 ) -> tuple[Float[Array, "Tm1 two_d"], Float[Array, "Tm1 two_d two_d"]]:
     r"""Joint p(x_k, x_{k+1}) for each consecutive pair.
 
-    For each pair ``(k, k+1)``, the joint distribution is::
+    For each pair ``(k, k+1)``, the joint distribution is:
 
         p(x_k, x_{k+1}) = N([mu_k; mu_{k+1}],
                              [[P_k,      C_k^T],

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -4,9 +4,9 @@ Implements the Särkkä-García-Fernández (IEEE TAC 2021) parallel
 formulation of the linear-Gaussian Kalman filter and Rauch-Tung-Striebel
 smoother. The forward (filtering) and backward (smoothing) recurrences
 are recast as inclusive associative scans of per-step elements, which
-:func:`jax.lax.associative_scan` evaluates with ``O(log T)`` depth on
+`jax.lax.associative_scan` evaluates with ``O(log T)`` depth on
 parallel hardware (GPU / TPU). On sequential hardware (CPU) the total
-work is strictly larger than :func:`gaussx.kalman_filter`'s ``O(T)``
+work is strictly larger than `gaussx.kalman_filter`'s ``O(T)``
 ``lax.scan``; the win is on accelerators with large ``T``.
 
 The default element math is the covariance-form combinators from §III.A /
@@ -181,13 +181,13 @@ def parallel_kalman_filter(
     woodbury_innovation: bool = False,
     form: str = "covariance",
 ) -> FilterState:
-    """Parallel Kalman filter via :func:`jax.lax.associative_scan`.
+    """Parallel Kalman filter via `jax.lax.associative_scan`.
 
-    Numerically equivalent to :func:`gaussx.kalman_filter` but with
+    Numerically equivalent to `gaussx.kalman_filter` but with
     ``O(log T)`` parallel depth on accelerators. Same generalised
     contract (TI / TV / operator-typed inputs, optional mask, scalar
     log-likelihood). Empty observation windows (``T == 0``) return a
-    zero-length :class:`FilterState` with ``log_likelihood == 0``.
+    zero-length `FilterState` with ``log_likelihood == 0``.
 
     Args:
         transition: State transition matrix or operator.
@@ -199,18 +199,18 @@ def parallel_kalman_filter(
         init_cov: Initial state covariance, shape ``(N, N)``.
         mask: Optional ``(T,)`` boolean mask; ``False`` runs predict-only
             and contributes 0 to the log-likelihood. Defaults to all-True.
-        solver: Accepted for API symmetry with :func:`kalman_filter` but
+        solver: Accepted for API symmetry with `kalman_filter` but
             not currently threaded through the per-element solves; the
             covariance-form combinator uses unstructured dense solves.
             The square-root form also uses dense solves for the affine
             terms.
         woodbury_innovation: When ``True``, delegates to
-            :func:`gaussx.kalman_filter` with the same flag so structured
+            `gaussx.kalman_filter` with the same flag so structured
             ``R`` uses the Woodbury innovation path.
         form: Either ``"covariance"`` (default) or ``"sqrt"``. The
             square-root form maintains lower-triangular covariance
             factors alongside the covariance updates and reconstructs
-            PSD covariance matrices in the returned :class:`FilterState`.
+            PSD covariance matrices in the returned `FilterState`.
             Note: the associative-scan equations themselves still use
             the covariance form internally; the factor path is a
             PSD-safety net for ill-conditioned float32 chains rather
@@ -220,7 +220,7 @@ def parallel_kalman_filter(
         ValueError: If ``form`` is not ``"covariance"`` or ``"sqrt"``.
 
     Returns:
-        :class:`FilterState` with filtered / predicted means and covs
+        `FilterState` with filtered / predicted means and covs
         and the total log-likelihood.
     """
     if form == "sqrt":
@@ -367,14 +367,14 @@ def parallel_rts_smoother(
     solver: AbstractSolverStrategy | None = None,
     form: str = "covariance",
 ) -> tuple[Float[Array, "T N"], Float[Array, "T N N"]]:
-    """Parallel RTS smoother via reverse :func:`jax.lax.associative_scan`.
+    """Parallel RTS smoother via reverse `jax.lax.associative_scan`.
 
-    Pairs with :func:`parallel_kalman_filter`. Numerically equivalent to
-    :func:`gaussx.rts_smoother` with ``O(log T)`` parallel depth.
+    Pairs with `parallel_kalman_filter`. Numerically equivalent to
+    `gaussx.rts_smoother` with ``O(log T)`` parallel depth.
 
     Args:
-        filter_state: Output of :func:`parallel_kalman_filter` or
-            :func:`gaussx.kalman_filter`.
+        filter_state: Output of `parallel_kalman_filter` or
+            `gaussx.kalman_filter`.
         transition: State transition matrix or operator.
         process_noise: Unused — kept for API symmetry with the sequential
             smoother.
@@ -383,7 +383,7 @@ def parallel_rts_smoother(
         form: Either ``"covariance"`` (default) or ``"sqrt"``. The
             square-root form maintains lower-triangular factors
             alongside the smoother associative scan and returns
-            PSD-reconstructed covariances (see :func:`parallel_kalman_filter`
+            PSD-reconstructed covariances (see `parallel_kalman_filter`
             for the same caveat about the internal combinator).
 
     Raises:

--- a/src/gaussx/_ssm/_parallel_kalman_sqrt.py
+++ b/src/gaussx/_ssm/_parallel_kalman_sqrt.py
@@ -41,7 +41,7 @@ def _factor_from_psd(X: Float[Array, "... N N"]) -> Float[Array, "... N N"]:
     """Build a lower-triangular PSD square root for a symmetric covariance.
 
     Symmetrises ``X``, clamps eigenvalues to ``[0, ∞)``, and reduces the
-    resulting square root through :func:`tria`. Returns a
+    resulting square root through `tria`. Returns a
     lower-triangular ``L`` with ``L @ L.T ≈ X`` (PSD-projected).
     """
     X = _sym(X)

--- a/src/gaussx/_ssm/_periodic.py
+++ b/src/gaussx/_ssm/_periodic.py
@@ -13,12 +13,12 @@ from gaussx._ssm._sde_kernel import SDEKernel, SDEParams
 class CosineSDE(SDEKernel):
     r"""State-space representation of the cosine kernel.
 
-    Models :math:`k(\tau) = \sigma^2 \cos(\omega_0 \tau)` via a 2-D
+    Models $k(\tau) = \sigma^2 \cos(\omega_0 \tau)$ via a 2-D
     rotation SDE. State dimension is 2.
 
     Attributes:
-        variance: Signal variance :math:`\sigma^2`.
-        frequency: Angular frequency :math:`\omega_0`.
+        variance: Signal variance $\sigma^2$.
+        frequency: Angular frequency $\omega_0$.
     """
 
     variance: Float[Array, ""]
@@ -58,9 +58,9 @@ class PeriodicSDE(SDEKernel):
     to ``n_harmonics`` terms. State dimension is ``2 * n_harmonics``.
 
     Attributes:
-        variance: Signal variance :math:`\sigma^2`.
-        lengthscale: Lengthscale :math:`\ell`.
-        period: Period :math:`T`.
+        variance: Signal variance $\sigma^2$.
+        lengthscale: Lengthscale $\ell$.
+        period: Period $T$.
         n_harmonics: Number of Fourier harmonics (truncation order).
     """
 

--- a/src/gaussx/_ssm/_periodic.py
+++ b/src/gaussx/_ssm/_periodic.py
@@ -16,7 +16,7 @@ class CosineSDE(SDEKernel):
     Models :math:`k(\tau) = \sigma^2 \cos(\omega_0 \tau)` via a 2-D
     rotation SDE. State dimension is 2.
 
-    Args:
+    Attributes:
         variance: Signal variance :math:`\sigma^2`.
         frequency: Angular frequency :math:`\omega_0`.
     """
@@ -57,7 +57,7 @@ class PeriodicSDE(SDEKernel):
     Approximates the periodic kernel via Fourier series truncation
     to ``n_harmonics`` terms. State dimension is ``2 * n_harmonics``.
 
-    Args:
+    Attributes:
         variance: Signal variance :math:`\sigma^2`.
         lengthscale: Lengthscale :math:`\ell`.
         period: Period :math:`T`.

--- a/src/gaussx/_ssm/_sde_kernel.py
+++ b/src/gaussx/_ssm/_sde_kernel.py
@@ -16,7 +16,7 @@ from gaussx._linalg._symmetrize import symmetrize
 class SDEParams(NamedTuple):
     """Continuous-time SDE parameters for a stationary kernel.
 
-    Defines the linear time-invariant SDE::
+    Defines the linear time-invariant SDE:
 
         dx = F x dt + L dW,   W ~ N(0, Q_c dt)
 
@@ -40,8 +40,8 @@ class SDEParams(NamedTuple):
 class SDEKernel(eqx.Module):
     """Abstract base class for state-space kernel representations.
 
-    Subclasses implement :meth:`sde_params` to provide the continuous-time
-    SDE matrices ``(F, L, H, Q_c, P_inf)``. The default :meth:`discretise`
+    Subclasses implement `sde_params` to provide the continuous-time
+    SDE matrices ``(F, L, H, Q_c, P_inf)``. The default `discretise`
     uses the matrix exponential for discretization; subclasses may override
     with closed-form solutions.
     """
@@ -63,7 +63,7 @@ class SDEKernel(eqx.Module):
     ) -> tuple[Float[Array, "d d"], Float[Array, "d d"]]:
         """Discretise the SDE at time step ``dt``.
 
-        Default implementation computes::
+        Default implementation computes:
 
             A = expm(F * dt)
             Q = P_inf - A @ P_inf @ A^T

--- a/src/gaussx/_ssm/_site_natural.py
+++ b/src/gaussx/_ssm/_site_natural.py
@@ -2,10 +2,10 @@
 
 These functions implement expectation-propagation (EP) site operations on
 scalar or diagonal Gaussians. They are not general-purpose Gaussian
-parameterization conversions — for those see :mod:`gaussx._expfam._natural`.
+parameterization conversions — for those see `gaussx._expfam._natural`.
 
 For block-tridiagonal (SSM) parameterizations see
-:mod:`gaussx._ssm._ssm_natural`.
+`gaussx._ssm._ssm_natural`.
 """
 
 from __future__ import annotations

--- a/src/gaussx/_ssm/_spingp.py
+++ b/src/gaussx/_ssm/_spingp.py
@@ -24,7 +24,7 @@ def _build_likelihood_precision(
     """Build block-tridiagonal likelihood precision from emission model.
 
     For scalar or vector observations at each time step, the likelihood
-    precision contribution is block-diagonal (zero sub-diagonals)::
+    precision contribution is block-diagonal (zero sub-diagonals):
 
         Lambda_lik[k] = H_k^T R_k^{-1} H_k
 
@@ -106,19 +106,19 @@ def spingp_log_likelihood(
     r"""Log marginal likelihood via sparse inverse GP formulation.
 
     Computes the log marginal likelihood using the precision-form
-    Kalman filter (SpInGP)::
+    Kalman filter (SpInGP):
 
-        1. Likelihood precision sites: :math:`\Lambda_{lik} = H^T R^{-1} H`
-        2. Posterior precision: :math:`\Lambda_{post} = \Lambda_{prior} + \Lambda_{lik}`
+        1. Likelihood precision sites: $\Lambda_{lik} = H^T R^{-1} H$
+        2. Posterior precision: $\Lambda_{post} = \Lambda_{prior} + \Lambda_{lik}$
         3. log p(y) via banded Cholesky logdet and quadratic form
 
-    The full expression is::
+    The full expression is:
 
         log p(y) = -0.5 * (N_{obs} * log(2\pi) + log|R|_{total}
                    + y^T R^{-1} y - \eta^T \Lambda_{post}^{-1} \eta
                    + log|\Lambda_{post}| - log|\Lambda_{prior}|)
 
-    where :math:`\eta = H^T R^{-1} y`.
+    where $\eta = H^T R^{-1} y$.
 
     All operations exploit banded structure for O(Nd³) cost.
 
@@ -185,7 +185,7 @@ def spingp_posterior(
     r"""Posterior mean and precision via SpInGP.
 
     Computes the posterior by adding likelihood precision sites to the
-    prior precision and solving for the posterior mean::
+    prior precision and solving for the posterior mean:
 
         \Lambda_{post} = \Lambda_{prior} + H^T R^{-1} H
         \mu_{post} = \Lambda_{post}^{-1} H^T R^{-1} y

--- a/src/gaussx/_ssm/_ssm_natural.py
+++ b/src/gaussx/_ssm/_ssm_natural.py
@@ -5,8 +5,8 @@ and natural/expectation parameterizations of the joint Gaussian, exploiting the
 block-tridiagonal sparsity of the precision matrix.
 
 For **general-purpose** (dense or operator-based) Gaussian parameterization
-conversions see :mod:`gaussx._expfam._natural`. For **per-site** (scalar/
-diagonal EP) conversions see :mod:`gaussx._ssm._site_natural`.
+conversions see `gaussx._expfam._natural`. For **per-site** (scalar/
+diagonal EP) conversions see `gaussx._ssm._site_natural`.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ def ssm_to_naturals(
 ) -> tuple[Float[Array, " Nd"], BlockTriDiag]:
     r"""Convert SSM parameters to natural parameters.
 
-    For a linear-Gaussian state-space model::
+    For a linear-Gaussian state-space model:
 
         x_0 \sim N(\mu_0, P_0)
         x_{k+1} = A_k x_k + \epsilon_k,\quad \epsilon_k \sim N(0, Q_{k+1})
@@ -41,7 +41,7 @@ def ssm_to_naturals(
     the joint prior ``p(x_0, \ldots, x_{N-1})`` has a block-tridiagonal
     precision matrix. This function returns its natural parameters
     ``(\theta_1, \theta_2)`` where ``\theta_2 = -\tfrac{1}{2}\Lambda``
-    (matching the convention in :func:`gaussx.mean_cov_to_natural`).
+    (matching the convention in `gaussx.mean_cov_to_natural`).
 
     Args:
         A: Transition matrices, shape ``(N-1, d, d)``.
@@ -56,7 +56,7 @@ def ssm_to_naturals(
     Returns:
         Tuple ``(theta_linear, theta_precision)`` where
         ``theta_linear`` has shape ``(N*d,)`` and
-        ``theta_precision`` is a :class:`~gaussx.BlockTriDiag`
+        ``theta_precision`` is a `BlockTriDiag`
         in the ``eta_2 = -0.5 * Lambda`` convention.
     """
     N = Q.shape[0]
@@ -132,7 +132,7 @@ def naturals_to_ssm(
     Args:
         theta_linear: Natural location parameter, shape ``(N*d,)``.
         theta_precision: Natural precision parameter as
-            :class:`~gaussx.BlockTriDiag` (eta2 convention).
+            `BlockTriDiag` (eta2 convention).
         solver: Optional solver strategy for structured linear algebra.
             When ``None``, falls back to structural dispatch. This parameter
             is accepted for API consistency but is not currently used by the
@@ -209,7 +209,7 @@ def ssm_to_expectations(
     parameters ``(eta1, eta2)`` of the joint Gaussian where:
 
     - ``eta1 = E[x]`` (concatenated means)
-    - ``eta2`` is a :class:`~gaussx.BlockTriDiag` storing the
+    - ``eta2`` is a `BlockTriDiag` storing the
       block-tridiagonal subset of ``E[xx^T]`` (second moments matching
       the Gauss-Markov sparsity pattern, not the full dense matrix)
 
@@ -226,7 +226,7 @@ def ssm_to_expectations(
 
     Returns:
         Tuple ``(eta1, eta2)`` where ``eta1`` has shape ``(N*d,)``
-        and ``eta2`` is a :class:`~gaussx.BlockTriDiag`.
+        and ``eta2`` is a `BlockTriDiag`.
     """
     _N, _d = means.shape
 
@@ -260,7 +260,7 @@ def expectations_to_ssm(
 
     Args:
         eta1: Concatenated means, shape ``(N*d,)``.
-        eta2: Second-moment :class:`~gaussx.BlockTriDiag`.
+        eta2: Second-moment `BlockTriDiag`.
 
     Returns:
         Tuple ``(means, covs, cross_covs)`` where:

--- a/src/gaussx/_ssm/_utils.py
+++ b/src/gaussx/_ssm/_utils.py
@@ -84,11 +84,11 @@ def _innovation_covariance(
     """Build ``S = H P Hᵀ + R`` as dense or as a low-rank update.
 
     When ``H`` is an operator, the dense path goes through
-    :func:`gaussx.sandwich` so matched ``Kronecker`` / ``BlockDiag`` /
+    `gaussx.sandwich` so matched ``Kronecker`` / ``BlockDiag`` /
     diagonal structure is preserved during construction.
 
     The Woodbury branch wraps ``R`` as the base of a
-    :class:`gaussx.LowRankUpdate`, so downstream solves and log-dets
+    `gaussx.LowRankUpdate`, so downstream solves and log-dets
     require ``R`` to be invertible. If you anticipate (numerically)
     singular ``R`` — e.g. a ``DiagonalLinearOperator`` with zeros —
     leave ``woodbury=False`` so the full ``S = H P Hᵀ + R`` matrix is

--- a/src/gaussx/_strategies/_auto.py
+++ b/src/gaussx/_strategies/_auto.py
@@ -20,7 +20,7 @@ class AutoSolver(AbstractSolverStrategy):
     - Large PSD: CGSolver
     - Large general: DenseSolver (fallback)
 
-    Args:
+    Attributes:
         size_threshold: Matrix dimension above which iterative
             solvers are preferred. Default: 1000.
     """

--- a/src/gaussx/_strategies/_base.py
+++ b/src/gaussx/_strategies/_base.py
@@ -15,7 +15,7 @@ class AbstractSolveStrategy(eqx.Module):
 
     A solve strategy encapsulates the choice of algorithm for
     solving ``A x = b``.  Separating solve from logdet lets
-    users mix-and-match via :class:`ComposedSolver`.
+    users mix-and-match via `ComposedSolver`.
     """
 
     @abc.abstractmethod
@@ -41,7 +41,7 @@ class AbstractLogdetStrategy(eqx.Module):
 
     A logdet strategy encapsulates the choice of algorithm for
     computing ``log |det(A)|``.  Separating logdet from solve
-    lets users mix-and-match via :class:`ComposedSolver`.
+    lets users mix-and-match via `ComposedSolver`.
 
     All implementations accept an optional ``key`` parameter for
     stochastic methods.  Deterministic strategies ignore it.
@@ -71,8 +71,8 @@ class AbstractSolverStrategy(AbstractSolveStrategy, AbstractLogdetStrategy):
     decouples distribution objects from solver implementation
     details.
 
-    Subclasses must implement both :meth:`solve` and :meth:`logdet`.
-    For independent control, see :class:`AbstractSolveStrategy` and
-    :class:`AbstractLogdetStrategy`, composable via
-    :class:`ComposedSolver`.
+    Subclasses must implement both `solve` and `logdet`.
+    For independent control, see `AbstractSolveStrategy` and
+    `AbstractLogdetStrategy`, composable via
+    `ComposedSolver`.
     """

--- a/src/gaussx/_strategies/_bbmm.py
+++ b/src/gaussx/_strategies/_bbmm.py
@@ -25,7 +25,7 @@ class BBMMSolver(AbstractSolverStrategy):
     ``solve_and_logdet`` deterministic functions of the operator —
     no PRNG key is needed at call time.
 
-    Args:
+    Attributes:
         cg_max_iter: Maximum CG iterations.
         cg_tolerance: Relative tolerance for CG.
         lanczos_iter: Lanczos iterations for SLQ.

--- a/src/gaussx/_strategies/_cg.py
+++ b/src/gaussx/_strategies/_cg.py
@@ -19,7 +19,7 @@ class CGSolver(AbstractSolverStrategy):
     for large PSD operators where dense factorization is too
     expensive.
 
-    Args:
+    Attributes:
         rtol: Relative tolerance for CG.
         atol: Absolute tolerance for CG.
         max_steps: Maximum CG iterations.

--- a/src/gaussx/_strategies/_composed.py
+++ b/src/gaussx/_strategies/_composed.py
@@ -20,14 +20,14 @@ class ComposedSolver(AbstractSolverStrategy):
     log-determinant estimator, or an iterative CG solve with a
     closed-form Kronecker log-determinant.
 
-    Accepts either fine-grained protocols (:class:`AbstractSolveStrategy`,
-    :class:`AbstractLogdetStrategy`) or full solver strategies.
+    Accepts either fine-grained protocols (`AbstractSolveStrategy`,
+    `AbstractLogdetStrategy`) or full solver strategies.
 
     Attributes:
         solve_strategy: Strategy whose ``.solve()`` method will be used.
         logdet_strategy: Strategy whose ``.logdet()`` method will be used.
 
-    Example::
+    Examples:
 
         solver = ComposedSolver(
             solve_strategy=DenseSolver(),

--- a/src/gaussx/_strategies/_composed.py
+++ b/src/gaussx/_strategies/_composed.py
@@ -23,7 +23,7 @@ class ComposedSolver(AbstractSolverStrategy):
     Accepts either fine-grained protocols (:class:`AbstractSolveStrategy`,
     :class:`AbstractLogdetStrategy`) or full solver strategies.
 
-    Args:
+    Attributes:
         solve_strategy: Strategy whose ``.solve()`` method will be used.
         logdet_strategy: Strategy whose ``.logdet()`` method will be used.
 

--- a/src/gaussx/_strategies/_dispatch.py
+++ b/src/gaussx/_strategies/_dispatch.py
@@ -20,7 +20,7 @@ def dispatch_solve(
         operator: The linear operator A.
         vector: Right-hand side b.
         solver: Optional solve strategy. When ``None``, falls back
-            to :func:`gaussx.solve` (structural dispatch).
+            to `gaussx.solve` (structural dispatch).
 
     Returns:
         Solution x.
@@ -43,7 +43,7 @@ def dispatch_logdet(
     Args:
         operator: The linear operator A.
         solver: Optional logdet strategy. When ``None``, falls back
-            to :func:`gaussx.logdet` (structural dispatch).
+            to `gaussx.logdet` (structural dispatch).
         key: Optional PRNG key for stochastic estimators.
 
     Returns:

--- a/src/gaussx/_strategies/_lsmr.py
+++ b/src/gaussx/_strategies/_lsmr.py
@@ -20,7 +20,7 @@ class LSMRSolver(AbstractSolverStrategy):
 
     Suitable for rectangular, ill-conditioned, or regularized systems.
 
-    The undamped path delegates to :class:`lineax.LSMR` (with lineax's
+    The undamped path delegates to `lineax.LSMR` (with lineax's
     implicit-differentiation rules). lineax's LSMR has no Tikhonov
     ``damp`` parameter, so damped solves use matfree's LSMR, which has
     a custom VJP for memory-efficient backpropagation.

--- a/src/gaussx/_strategies/_lsmr.py
+++ b/src/gaussx/_strategies/_lsmr.py
@@ -25,7 +25,7 @@ class LSMRSolver(AbstractSolverStrategy):
     ``damp`` parameter, so damped solves use matfree's LSMR, which has
     a custom VJP for memory-efficient backpropagation.
 
-    Args:
+    Attributes:
         atol: Absolute tolerance.
         btol: Relative tolerance on the residual.
         ctol: Condition number tolerance (the lineax path uses

--- a/src/gaussx/_strategies/_minres.py
+++ b/src/gaussx/_strategies/_minres.py
@@ -162,7 +162,7 @@ class MINRESSolver(AbstractSolverStrategy):
     Use cases: EP natural parameters, saddle-point systems,
     Laplace approximation Hessians.
 
-    Args:
+    Attributes:
         rtol: Relative tolerance for MINRES.
         atol: Absolute tolerance for MINRES.
         max_steps: Maximum MINRES iterations.

--- a/src/gaussx/_strategies/_precond_cg.py
+++ b/src/gaussx/_strategies/_precond_cg.py
@@ -22,7 +22,7 @@ class PreconditionedCGSolver(AbstractSolverStrategy):
     For operators of the form ``K + sigma^2 I``, preconditioning
     dramatically reduces the number of CG iterations.
 
-    Args:
+    Attributes:
         preconditioner_rank: Rank of the partial Cholesky. Set to 0
             to disable preconditioning (falls back to plain CG).
         shift: Diagonal shift ``s`` for the preconditioner.

--- a/src/gaussx/_strategies/_slq_logdet.py
+++ b/src/gaussx/_strategies/_slq_logdet.py
@@ -50,7 +50,7 @@ class SLQLogdet(AbstractLogdetStrategy):
         num_probes: Number of probe vectors for Hutchinson estimator.
         lanczos_order: Order of the Lanczos decomposition.
         seed: Seed for probe vector generation (used when no
-            ``key`` is passed to :meth:`logdet`).
+            ``key`` is passed to `logdet`).
         sampler: Probe distribution (``"signs"``, ``"normal"``,
             ``"sphere"``).
     """
@@ -118,7 +118,7 @@ class SLQLogdet(AbstractLogdetStrategy):
 class IndefiniteSLQLogdet(AbstractLogdetStrategy):
     """Stochastic ``log|det(A)|`` for symmetric (possibly indefinite) operators.
 
-    Like :class:`SLQLogdet` but uses ``log(|lambda|)`` as the matrix
+    Like `SLQLogdet` but uses ``log(|lambda|)`` as the matrix
     function, so it works on indefinite and negative-definite matrices.
     Supports a diagonal shift ``(A + shift * I)``.
 
@@ -201,7 +201,7 @@ class IndefiniteSLQLogdet(AbstractLogdetStrategy):
 class DenseLogdet(AbstractLogdetStrategy):
     """Dense log-determinant via gaussx structural dispatch.
 
-    Delegates to :func:`gaussx.logdet` which automatically selects
+    Delegates to `gaussx.logdet` which automatically selects
     the best algorithm based on operator structure (Diagonal,
     BlockDiag, Kronecker, LowRankUpdate, or dense fallback).
     """

--- a/src/gaussx/_strategies/_slq_logdet.py
+++ b/src/gaussx/_strategies/_slq_logdet.py
@@ -46,7 +46,7 @@ class SLQLogdet(AbstractLogdetStrategy):
     Lanczos decomposition with sign-flip ("Rademacher") probe vectors
     by default.
 
-    Args:
+    Attributes:
         num_probes: Number of probe vectors for Hutchinson estimator.
         lanczos_order: Order of the Lanczos decomposition.
         seed: Seed for probe vector generation (used when no
@@ -122,7 +122,7 @@ class IndefiniteSLQLogdet(AbstractLogdetStrategy):
     function, so it works on indefinite and negative-definite matrices.
     Supports a diagonal shift ``(A + shift * I)``.
 
-    Args:
+    Attributes:
         num_probes: Number of probe vectors for Hutchinson estimator.
         lanczos_order: Order of the Lanczos decomposition.
         shift: Diagonal shift applied before computing the logdet.

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,49 @@
+"""Guard against Sphinx/reStructuredText markup in docstrings.
+
+The docs are built with MkDocs + mkdocstrings (MathJax for math,
+``[`x`][path]`` for cross-references), which do **not** render Sphinx/RST
+constructs such as ``:math:`...``` or ``.. math::`` — they leak into the
+rendered page as literal text. Doctests cannot catch this because they only
+execute ``>>>`` examples and ignore the surrounding prose, so this test scans
+the source for the offending markup directly.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import gaussx
+
+
+# Patterns that MkDocs/mkdocstrings will not render (use $...$/$$...$$ for math,
+# `name` / [`name`][path] for cross-references, and fenced code blocks instead).
+RST_PATTERNS = {
+    ":math: role (use $...$)": re.compile(r":math:`"),
+    ".. math:: directive (use $$...$$)": re.compile(r"\.\. math::"),
+    ":class:/:func:/:meth:/:mod:/:data: role (use `name`)": re.compile(
+        r":(?:class|func|meth|mod|data|attr|obj|exc|ref|term):`"
+    ),
+    ".. <directive>:: (use an admonition / fenced code block)": re.compile(
+        r"\.\. (?:note|warning|code|code-block|seealso|admonition|versionadded"
+        r"|versionchanged|deprecated|rubric)::"
+    ),
+    "backslash-escaped suffix (e.g. `Block`\\ s — drop the backslash)": re.compile(
+        r"`+\\+ [A-Za-z]"
+    ),
+}
+
+PKG_DIR = Path(gaussx.__file__).parent
+SRC_FILES = sorted(PKG_DIR.rglob("*.py"))
+
+
+@pytest.mark.parametrize(
+    "path", SRC_FILES, ids=lambda p: str(p.relative_to(PKG_DIR.parent))
+)
+def test_no_rst_markup_in_source(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    offenders = [label for label, pat in RST_PATTERNS.items() if pat.search(text)]
+    assert not offenders, (
+        f"{path.name} contains Sphinx/RST markup that MkDocs won't render: "
+        f"{offenders}. Convert it to MkDocs syntax."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.17"
+version = "0.0.18"
 source = { editable = "." }
 dependencies = [
     { name = "einx" },


### PR DESCRIPTION
## Summary

Replaces the API reference — previously a single flat page containing just `::: gaussx`, dumping all 269 public exports into one unstructured wall — with a themed reference following the structure and formatting conventions of the geonnax docs (the best-formatted of the three repos).

### Themed API reference

- **Overview page** (`api/index.md`): section table mapped to the package's four-layer architecture, plus a package-wide **Conventions** section (operators are lineax `equinox.Module` pytrees; tags drive structural dispatch; `solver=None` means structural dispatch; lazy-over-dense with `DenseFallbackWarning`; pure functions with explicit PRNG keys).
- **Ten themed pages**, each with prose framing and math where it helps:
  - Primitives (solve / logdet / cholesky / trace / diag / sqrt / inv / eig / svd / root decompositions)
  - Operators & Tags (Kronecker, BlockDiag, LowRankUpdate, Toeplitz, block-tridiagonal, kernel operators, structural tags)
  - Solvers & Preconditioners (strategies, the `linear_solve` front door, SLQ logdets, preconditioners)
  - Linear-Algebra Utilities (`safe_cholesky`, `symmetrize`, Woodbury/Schur identities, matrix-RHS solves)
  - Distributions & Exponential Family (MVN / MVN-precision, Gaussian sugar ops, natural-parameter conversions)
  - Gaussian Processes (conditioning, Matheron updates, whitening, ELBOs, LOVE/LOO, OILMM)
  - Kernels & Approximations (Nyström, RFF, EigenPro, HSIC/MMD, grids)
  - Quadrature & Moment Matching (integrators, likelihoods, Ψ-statistics, uncertain-input GP prediction)
  - State-Space Models & Kalman (SDE kernels, sequential/parallel/infinite-horizon filtering, SpInGP, CVI sites)
  - Bayesian Inference & Ensembles (BLR, Newton/natural-gradient, ensemble DA: localization, inflation, ETKF)
- A coverage script cross-checks `src/gaussx/__init__.py` against the pages: **269/269 exports rendered exactly once** (no gaps, no duplicates).

### Formatting parity with geonnax

- mkdocstrings options upgraded: table-style docstring sections, symbol-type headings + TOC entries, source ordering, signature cross-references, annotated signatures, `!^_` member filter.
- Changelog added to the nav via the same `docs/CHANGELOG.md → ../CHANGELOG.md` symlink pyrox uses.

### Docstring fixes (the warning source)

38 `equinox.Module` class docstrings documented their fields under `Args:`. griffe cannot see equinox's generated `__init__`, so every one of these produced "Parameter does not appear in the function signature" warnings (~90 total) and rendered broken parameter tables. Renamed to `Attributes:` — geonnax's convention, where `Args:` is reserved for `.init()` classmethods. Applied via an AST pass that only touches class docstrings on classes without an explicit `__init__`.

`mkdocs build` is now **warning-free**. The `uv.lock` change is the self-version refresh (0.0.17 → 0.0.18) left over from the last release PR.

## Test plan

- [x] `make docs` (`mkdocs build`) — zero warnings
- [x] Export-coverage script — 269/269 public exports documented exactly once
- [x] `uv run pytest -q -n auto -m "not slow and not integration"` — 1248 passed
- [x] `ruff check .` / `ruff format --check .` / `ty check src/gaussx` — clean

https://claude.ai/code/session_017jRFJ2e3k8Gp8rzS6YzhW1

---
_Generated by [Claude Code](https://claude.ai/code/session_017jRFJ2e3k8Gp8rzS6YzhW1)_