### PR TITLE
docs: verify API coverage, rewrite vision, expand architecture with diagrams

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -41,8 +41,9 @@ A few patterns hold across the whole package:
 
 - **Lazy over dense.** Primitives like `inv`, `sqrt`, and `cholesky` return
   *operators*, not arrays, wherever structure allows; nothing is materialized until
-  `.as_matrix()` is called. When a structured path has to densify, a
-  `DenseFallbackWarning` is emitted.
+  `.as_matrix()` is called. Where a structured operator nevertheless has to be
+  materialized — `cholesky` of a `SumKronecker` — a `DenseFallbackWarning` points
+  you at the matrix-free alternative.
 
 - **Pure functions.** Outside the operator classes everything is a pure function:
   arrays and operators in, arrays and operators out. PRNG keys are explicit
@@ -51,3 +52,14 @@ A few patterns hold across the whole package:
 Every public class and function carries a Google-style docstring with shapes in
 [jaxtyping](https://docs.kidger.site/jaxtyping/) notation; tensor contraction and
 reshaping inside the package go through [einx](https://github.com/fferflo/einx).
+
+## See also
+
+- [Architecture](../architecture.md) — the layered stack, the dispatch flow chart,
+  per-primitive fast-path coverage, and where gaussx sits relative to
+  [pyrox-gp](https://github.com/jejjohnson/pyrox),
+  [finitevolX](https://github.com/jejjohnson/finitevolX), and
+  [spectraldiffx](https://github.com/jejjohnson/spectraldiffx).
+- [Vision](../vision.md) — why the library exists and what it deliberately is not.
+- [Unified Solvers](../design/unified-solvers.md) — how the solver substrate is
+  shared with the PDE packages.

--- a/docs/api/linalg.md
+++ b/docs/api/linalg.md
@@ -23,6 +23,15 @@ Woodbury, Schur complements, and conditional (Schur-complement) variances —
 the identities behind every Gaussian conditioning step, exposed directly so
 recipes never re-derive them.
 
+!!! warning "Legacy `conditional_variance` signature"
+    The pre-#152 three-positional form
+    `conditional_variance(base_diag, A_X, S_u)` is still accepted — it is
+    detected when the second positional argument is a
+    `lineax.AbstractLinearOperator` — but it emits a `DeprecationWarning` and
+    skips the $K_{XZ}$-based Schur subtraction, treating its first argument as
+    an already-computed Schur diagonal. Call
+    `conditional_variance(K_XX_diag, K_XZ, A_X, S_u=S_u)` instead.
+
 ::: gaussx
     options:
       show_root_heading: false

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -23,7 +23,17 @@ diagonalises in the joint eigenbasis with eigenvalues $\lambda_i + \mu_j$.
 
 $L + U\,\mathrm{diag}(d)\,V^\top$ with Woodbury-efficient solves and
 matrix-determinant-lemma logdets. The factories build the common special cases
-directly from arrays.
+directly from arrays. Pass `orthonormal=True` when $U$ and $V$ have orthonormal
+columns (truncated SVD, Nyström, ensemble factors) to unlock the stronger
+symmetry / PSD tag inference.
+
+!!! warning "`SVDLowRankUpdate` is deprecated"
+    It remains a `LowRankUpdate` subclass — so `isinstance` checks and
+    `singledispatch` registrations keyed on it still work — but it forces
+    `orthonormal=True` and emits a `DeprecationWarning` on construction. New
+    code should use `LowRankUpdate(base, U, S, V, orthonormal=True)` or
+    [`svd_low_rank_plus_diag`](#gaussx.svd_low_rank_plus_diag). It will be
+    removed in a future release.
 
 ::: gaussx
     options:

--- a/docs/api/primitives.md
+++ b/docs/api/primitives.md
@@ -3,9 +3,10 @@
 Layer 0: pure functions over `lineax.AbstractLinearOperator` with **structural
 dispatch** — each primitive inspects the operator (diagonal, Kronecker,
 block-diagonal, low-rank, block-tridiagonal, …) and routes to the cheapest exact
-algorithm, falling back to a dense computation (with a
-[`DenseFallbackWarning`](#gaussx.DenseFallbackWarning)) only when no structured
-path exists.
+algorithm, falling back to a dense computation only when no structured path
+exists. Where a structured operator has to be materialized anyway — `cholesky`
+of a `SumKronecker` — a [`DenseFallbackWarning`](#gaussx.DenseFallbackWarning)
+names the matrix-free alternative.
 
 ## Solve, logdet & Cholesky
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,8 +202,8 @@ flowchart LR
 | `SumKronecker` | $\sum_k A_k \otimes B_k$ | Structured Cholesky/sqrt for separable-plus-noise covariances |
 | `BlockDiag(A, B, ...)` | $\mathrm{diag}(A, B, \ldots)$ | Every primitive splits per block |
 | `BlockTriDiag(D, A)` | Symmetric block-tridiagonal precision | $O(N d^3)$ --- the precision structure of Markovian GPs |
-| `LowRankUpdate(L, U, d, V)` | $L + U\,\mathrm{diag}(d)\,V^\top$ | Woodbury solves, determinant-lemma logdets |
-| `SVDLowRankUpdate` | SVD-factored low-rank update | Numerically safer when the update is ill-conditioned |
+| `LowRankUpdate(L, U, d, V)` | $L + U\,\mathrm{diag}(d)\,V^\top$ | Woodbury solves, determinant-lemma logdets; pass `orthonormal=True` for SVD/Nyström factors |
+| `SVDLowRankUpdate` | *Deprecated* --- use `LowRankUpdate(..., orthonormal=True)` | Kept as a subclass so `isinstance` checks keep working; warns on construction |
 | `Toeplitz` | Symmetric Toeplitz | $O(n \log n)$ matvecs and sampling via FFT circulant embedding |
 | `KernelOperator(k, X)` | Dense Gram matrix | Kernel as a first-class operator |
 | `ImplicitKernelOperator(k, X)` | Matrix-free Gram operator | Rows generated per matvec --- never stores $N \times N$ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,165 +1,587 @@
 # Architecture
 
-gaussx is organized as a **four-layer stack** that extends lineax. Each layer builds on the one below. Users can enter at any layer depending on their needs.
+gaussx is organised as a **layered stack** on top of
+[lineax](https://github.com/patrick-kidger/lineax) and
+[matfree](https://github.com/pnkraemer/matfree). Each layer is usable on its
+own, and each layer only depends on the ones beneath it. You can enter wherever
+your problem lives: grab a single primitive, build a structured operator, swap a
+solver strategy, or call a finished recipe.
 
-## Four-Layer Stack
+## The stack at a glance
 
+```mermaid
+flowchart TB
+    subgraph L3["Layer 3 · Recipes"]
+        direction LR
+        GP["Gaussian processes<br/><small>conditioning · ELBOs · whitening · LOVE · OILMM</small>"]
+        SSM["State-space models<br/><small>SDE kernels · Kalman · RTS · SpInGP · CVI</small>"]
+        QUAD["Quadrature<br/><small>Gauss-Hermite · unscented · Taylor · MC</small>"]
+        INF["Inference and ensembles<br/><small>BLR · natural gradient · EnKF</small>"]
+        KERN["Kernels<br/><small>Nyström · RFF · EigenPro · HSIC/MMD</small>"]
+    end
+
+    subgraph L2["Layer 2 · Distributions and sugar"]
+        direction LR
+        DIST["MultivariateNormal<br/>MultivariateNormalPrecision"]
+        SUGAR["log_prob · entropy · KL<br/>conditional · Joseph · project"]
+        EF["Exponential family<br/><small>natural ↔ expectation · Fisher</small>"]
+    end
+
+    subgraph L15["Layer 1.5 · Strategies and preconditioners"]
+        direction LR
+        STRAT["DenseSolver · CGSolver · BBMM<br/>MINRES · LSMR · SLQ logdet"]
+        PRE["Jacobi · Nyström<br/>PartialCholesky · Operator"]
+        FRONT["linear_solve<br/><small>the front door</small>"]
+    end
+
+    subgraph L1["Layer 1 · Operators"]
+        direction LR
+        OPS["Kronecker · KroneckerSum · BlockDiag<br/>BlockTriDiag · LowRankUpdate · Toeplitz<br/>Kernel · Implicit · Interpolated · Masked"]
+        TAGS["Structural tags<br/><small>_tags.py</small>"]
+    end
+
+    subgraph L0["Layer 0 · Primitives"]
+        PRIM["solve · logdet · cholesky · diag · trace<br/>sqrt · inv · eig · svd · root_decomposition"]
+        LINALG["Linear-algebra utilities<br/><small>Woodbury · Schur · safe_cholesky · tridiagonal</small>"]
+    end
+
+    subgraph EXT["Foundations"]
+        direction LR
+        LINEAX["lineax<br/><small>solvers · AbstractLinearOperator · tags</small>"]
+        MATFREE["matfree<br/><small>Lanczos · SLQ · Hutchinson</small>"]
+        EQXDEP["equinox · jaxtyping · einx"]
+    end
+
+    L3 --> L2
+    L2 --> L15
+    L15 --> L1
+    L1 --> L0
+    L0 --> EXT
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  Layer 3 — Recipes                                      (v0.3+) │
-│  Kalman filter/smoother, Kronecker GP recipes, LOVE,             │
-│  CVI sites, SSM natural params, interpolation                    │
-├──────────────────────────────────────────────────────────────────┤
-│  Layer 2 — Distributions + Sugar                        (v0.2+) │
-│  MultivariateNormal, Schur complement, project,                  │
-│  conditional variance, exponential family                        │
-├──────────────────────────────────────────────────────────────────┤
-│  Layer 1 — Operators                                     (v0.0) │
-│  Kronecker, BlockDiag, BlockTriDiag, LowRankUpdate,              │
-│  ImplicitKernelOperator                                          │
-│  Extend lineax.AbstractLinearOperator                            │
-├──────────────────────────────────────────────────────────────────┤
-│  Layer 0 — Primitives                                    (v0.0) │
-│  solve, logdet, cholesky, diag, trace, sqrt, inv                 │
-│  Dispatch on operator type + tags                                │
-└──────────────────────────────────────────────────────────────────┘
-                 │                          │
-          ┌──────▼──────┐           ┌───────▼──────┐
-          │   lineax    │           │   matfree    │
-          │  (solvers)  │           │  (Lanczos,   │
-          │             │           │   SLQ, etc.) │
-          └─────────────┘           └──────────────┘
-```
 
-### Layer 0 --- Primitives
+| Layer | Name | Owns | Entry point |
+|-------|------|------|-------------|
+| 0 | **Primitives** | Pure functions with structural dispatch | [`solve`, `logdet`, `cholesky`, …](api/primitives.md) |
+| 1 | **Operators** | Structured matrices + tags | [`Kronecker`, `BlockDiag`, …](api/operators.md) |
+| 1.5 | **Strategies** | *How* a solve/logdet is computed | [`DenseSolver`, `CGSolver`, …](api/solvers.md) |
+| 2 | **Distributions** | Gaussians over operators, sugar ops, exp-family | [`MultivariateNormal`, …](api/distributions.md) |
+| 3 | **Recipes** | Domain sequences wiring layers 0–2 | [GP](api/gp.md) · [SSM](api/ssm.md) · [quadrature](api/quadrature.md) · [inference](api/inference.md) · [kernels](api/kernels.md) |
 
-Pure functions that match the equations in papers. Every function takes an operator and returns arrays or operators:
+---
+
+## Layer 0 --- Primitives
+
+Pure functions that match the equations in papers. Every one takes a
+`lineax.AbstractLinearOperator` and returns arrays or operators:
 
 ```python
-x = gaussx.solve(A, b)      # solve Ax = b
-ld = gaussx.logdet(A)        # log|det(A)|
-L = gaussx.cholesky(A)       # A = LL^T
-d = gaussx.diag(A)           # diagonal entries
-t = gaussx.trace(A)          # tr(A)
-S = gaussx.sqrt(A)           # S such that SS = A
+x     = gaussx.solve(A, b)   # solve A x = b
+ld    = gaussx.logdet(A)     # log|det(A)|
+L     = gaussx.cholesky(A)   # A = L L^T   (lazy, structure-preserving)
+d     = gaussx.diag(A)       # diagonal entries
+t     = gaussx.trace(A)      # tr(A)
+S     = gaussx.sqrt(A)       # S with S S = A
 A_inv = gaussx.inv(A)        # lazy A^{-1}
 ```
 
-Each primitive uses **isinstance dispatch** to select the efficient code path based on operator type:
+Two properties are worth internalising:
 
-| Operator | `solve` | `logdet` | `cholesky` |
-|----------|---------|----------|------------|
-| Diagonal | O(n) divide | O(n) sum(log) | O(n) sqrt |
-| BlockDiag | per-block | sum of logdets | per-block |
-| Kronecker | Roth's lemma | scaled sum | per-factor |
-| LowRankUpdate | Woodbury | det lemma | --- |
-| Dense | lineax solver | slogdet | jax.scipy cholesky |
+- **Lazy over dense.** `cholesky`, `sqrt`, and `inv` return *operators*.
+  The Cholesky of a `Kronecker` is a `Kronecker` of Cholesky factors; nothing
+  is materialized until you call `.as_matrix()`.
+- **The expensive surprise is flagged.** `cholesky(SumKronecker)` is the one
+  path where a structured operator you would reasonably expect to stay
+  structured must materialize the dense covariance, so it raises a
+  [`DenseFallbackWarning`](api/primitives.md#gaussx.DenseFallbackWarning) and
+  points you at `sqrt(...)` / `sumkronecker_sample(...)` instead. Ordinary
+  unstructured operators densify quietly --- there was never a fast path to
+  lose.
 
-For large unstructured operators, Layer 0 delegates to **matfree** for iterative/stochastic algorithms (Lanczos for logdet, Hutchinson for trace).
+### How dispatch actually works
 
-### Layer 1 --- Operators
+No registry, no metaclass, no plugin system. Each primitive is a chain of
+`isinstance` checks in a single readable function, ending in a dense fallback:
 
-Structured operators extending `lineax.AbstractLinearOperator`. Each is an `equinox.Module` (immutable PyTree), supports `mv`, `as_matrix`, `transpose`, and carries structural tags.
+```mermaid
+flowchart TD
+    A["gaussx.solve(A, b)"] --> ID{"Identity?"}
+    ID -- yes --> RID["return b"]
+    ID -- no --> DG{"Diagonal?"}
+    DG -- yes --> RDG["b / diag &nbsp;— O(n)"]
+    DG -- no --> BD{"BlockDiag?"}
+    BD -- yes --> RBD["solve each block, concatenate"]
+    BD -- no --> KR{"Kronecker?"}
+    KR -- yes --> RKR["Roth's column lemma<br/>per-factor solve"]
+    KR -- no --> LR{"LowRankUpdate?"}
+    LR -- yes --> RLR["Woodbury identity"]
+    LR -- no --> KS{"KroneckerSum?"}
+    KS -- yes --> RKS["joint eigenbasis<br/>λᵢ + μⱼ"]
+    KS -- no --> BT{"Block-tridiagonal?"}
+    BT -- yes --> RBT["block-banded forward/back substitution"]
+    BT -- no --> WR{"Wrapper?<br/><small>Tagged · Mul · Div · Neg · Composed</small>"}
+    WR -- yes --> RWR["unwrap, recurse,<br/>fix up the scalar"]
+    WR -- no --> FB["dense / iterative fallback<br/><small>lineax solver chosen from tags</small>"]
 
-| Operator | Represents | Efficient `mv` |
-|----------|-----------|----------------|
-| `Kronecker(A, B, ...)` | $A \otimes B \otimes \cdots$ | Roth's column lemma via einx |
-| `BlockDiag(A, B, ...)` | $\mathrm{diag}(A, B, \ldots)$ | Per-block, concatenate |
-| `BlockTriDiag(D, A)` | Symmetric block-tridiagonal precision | Banded block matvec |
-| `LowRankUpdate(L, U, d, V)` | $L + U \mathrm{diag}(d) V^\top$ | Base mv + rank-k update |
-| `ImplicitKernelOperator(k, X)` | Matrix-free kernel Gram operator | Nested `vmap` kernel matvec |
+    style FB stroke-dasharray: 5 5
+```
 
-`ImplicitKernelOperator` keeps structural claims explicit: if a kernel should be treated as symmetric or PSD by `lineax`, pass those tags when constructing it rather than relying on the operator to infer them.
+`logdet`, `cholesky`, `diag`, `trace`, `sqrt`, and `inv` follow the same shape
+with their own fast paths. Coverage differs per primitive --- `sqrt`, for
+instance, has no block-tridiagonal path and falls back there.
 
-Arithmetic (`+`, `@`, `*`) composes with lineax's built-in operators:
+| Operator | `solve` | `logdet` | `cholesky` | `diag` / `trace` | `sqrt` | `inv` |
+|----------|---------|----------|------------|------------------|--------|-------|
+| `Identity` / `Diagonal` | O(n) | O(n) | O(n) | O(n) | O(n) | O(n) |
+| `BlockDiag` | per block | sum of logdets | per block | per block | per block | per block |
+| `Kronecker` | Roth's lemma | scaled sum | per factor | per factor | per factor | per factor |
+| `KroneckerSum` | joint eigenbasis | $\sum \log(\lambda_i + \mu_j)$ | dense | eigen-based | `KroneckerSumSqrt` | lazy |
+| `SumKronecker` | dense | dense | dense (warns) | per term | `SumKroneckerSqrt` | lazy |
+| `LowRankUpdate` | Woodbury | determinant lemma | dense | base + update | dense | Woodbury (if symmetric) |
+| `BlockTriDiag` | block-banded | block Cholesky | block Cholesky | per block | dense | lazy |
+| Wrappers (`Tagged`, `Mul`, `Div`, `Neg`, `Composed`) | unwrap + recurse | unwrap + recurse | unwrap | unwrap + recurse | unwrap | unwrap + recurse |
+| Everything else | lineax solver | `slogdet` | `jax.scipy` Cholesky | dense | dense eigh | lazy `InverseOperator` |
+
+Several of the dense cells have an opt-in matrix-free escape hatch backed by
+[matfree](https://github.com/pnkraemer/matfree):
+
+- `diag(A, stochastic=True)` and `trace(A, stochastic=True)` switch to
+  Hutchinson / XTrace probing. `trace_and_diag` shares a single probe pass
+  between both estimates.
+- `sqrt(A, lanczos_order=k)` returns a lazy `SqrtOperator` that routes its
+  matvecs through Lanczos instead of an eigendecomposition.
+
+For `logdet`, the matrix-free route is a Layer 1.5 concern rather than a
+primitive flag: pass `SLQLogdet()` (or a `ComposedSolver`) as the `solver=`.
+
+---
+
+## Layer 1 --- Operators
+
+Structured operators extending `lineax.AbstractLinearOperator`. Each is an
+`equinox.Module` --- an immutable PyTree, safe under `jit`, `grad`, and `vmap`
+--- supporting `mv`, `as_matrix`, `transpose`, and carrying structural tags.
+
+```mermaid
+flowchart LR
+    ALO["lineax.AbstractLinearOperator"]
+
+    ALO --> P["Products and sums"]
+    ALO --> LRK["Low-rank"]
+    ALO --> B["Banded and structured"]
+    ALO --> K["Kernel operators"]
+    ALO --> LZ["Lazy algebra"]
+
+    P --> P1["Kronecker"]
+    P --> P2["KroneckerSum"]
+    P --> P3["SumKronecker"]
+    P --> P4["BlockDiag"]
+
+    LRK --> L1["LowRankUpdate"]
+    LRK --> L2["SVDLowRankUpdate"]
+
+    B --> B1["BlockTriDiag"]
+    B --> B2["Lower/UpperBlockTriDiag"]
+    B --> B3["Toeplitz"]
+    B --> B4["ToeplitzCholesky"]
+
+    K --> K1["KernelOperator"]
+    K --> K2["ImplicitKernelOperator"]
+    K --> K3["ImplicitCrossKernelOperator"]
+    K --> K4["InterpolatedOperator"]
+    K --> K5["MaskedOperator"]
+
+    LZ --> Z1["SumOperator"]
+    LZ --> Z2["ScaledOperator"]
+    LZ --> Z3["ProductOperator"]
+```
+
+| Operator | Represents | Why it is worth it |
+|----------|-----------|--------------------|
+| `Kronecker(A, B, ...)` | $A \otimes B \otimes \cdots$ | $O(\sum_i n_i^3)$ instead of $O((\prod_i n_i)^3)$; matvec is Roth's column lemma via einx |
+| `KroneckerSum(A, B)` | $A \oplus B = A \otimes I + I \otimes B$ | Diagonalises in the joint eigenbasis, eigenvalues $\lambda_i + \mu_j$ |
+| `SumKronecker` | $\sum_k A_k \otimes B_k$ | Structured Cholesky/sqrt for separable-plus-noise covariances |
+| `BlockDiag(A, B, ...)` | $\mathrm{diag}(A, B, \ldots)$ | Every primitive splits per block |
+| `BlockTriDiag(D, A)` | Symmetric block-tridiagonal precision | $O(N d^3)$ --- the precision structure of Markovian GPs |
+| `LowRankUpdate(L, U, d, V)` | $L + U\,\mathrm{diag}(d)\,V^\top$ | Woodbury solves, determinant-lemma logdets |
+| `SVDLowRankUpdate` | SVD-factored low-rank update | Numerically safer when the update is ill-conditioned |
+| `Toeplitz` | Symmetric Toeplitz | $O(n \log n)$ matvecs and sampling via FFT circulant embedding |
+| `KernelOperator(k, X)` | Dense Gram matrix | Kernel as a first-class operator |
+| `ImplicitKernelOperator(k, X)` | Matrix-free Gram operator | Rows generated per matvec --- never stores $N \times N$ |
+| `InterpolatedOperator` | $W K_{uu} W^\top$ (KISS-GP style) | Grid interpolation weights, sparse in effect |
+| `MaskedOperator` | Row/column sub-selection of a base operator | Irregular domains, held-out indices |
+
+Arithmetic composes with lineax's own operators, and the primitives unwrap the
+composition automatically:
 
 ```python
 K = gaussx.Kronecker(A, B)
-perturbed = K + 0.1 * lx.IdentityLinearOperator(...)
+perturbed = K + 0.1 * lx.IdentityLinearOperator(K.in_structure())
+gaussx.solve(perturbed, y)   # dispatches through the sum
 ```
 
-### Layer 1.5 --- Solver Strategies
+!!! warning "Tags are claims, not inferences"
+    `ImplicitKernelOperator` (and friends) will not guess that your kernel is
+    symmetric or PSD. If you want the Cholesky/CG fast paths, pass the tags
+    explicitly:
 
-Pair `solve` + `logdet` into reusable strategy objects:
+    ```python
+    op = gaussx.ImplicitKernelOperator(
+        kernel_fn, X,
+        tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
+    )
+    ```
+
+### Structural tags
+
+Tags mark structure and properties; the `is_*` predicates are what the
+primitives consult. gaussx re-exports lineax's property tags so user code needs
+only one import.
+
+| Tag | Source | Consulted by |
+|-----|--------|--------------|
+| `symmetric_tag` | lineax | solve, logdet, solver selection |
+| `positive_semidefinite_tag` | lineax | cholesky, sqrt, CG, SLQ |
+| `negative_semidefinite_tag` | lineax | `linear_solve` negation path |
+| `diagonal_tag` | lineax | all primitives (O(n) paths) |
+| `lower_triangular_tag` / `upper_triangular_tag` | lineax | triangular solves |
+| `unit_diagonal_tag` / `tridiagonal_tag` | lineax | specialised solves |
+| `kronecker_tag` | gaussx | all primitives (per factor) |
+| `kronecker_sum_tag` | gaussx | eigenbasis paths |
+| `block_diagonal_tag` | gaussx | all primitives (per block) |
+| `block_tridiagonal_tag` | gaussx | banded Cholesky |
+| `low_rank_tag` | gaussx | solve (Woodbury), logdet (determinant lemma) |
+
+Query with `is_kronecker`, `is_low_rank`, `is_positive_semidefinite`, … to
+inspect an operator without knowing its concrete type. Full list in the
+[Operators & Tags](api/operators.md) reference.
+
+---
+
+## Layer 1.5 --- Strategies & preconditioners
+
+A **strategy** bundles a `solve` and a `logdet` algorithm behind one object.
+Anything in gaussx that takes a `solver=` keyword takes one of these, and
+`solver=None` means "use structural dispatch".
+
+```mermaid
+flowchart TB
+    CALL["caller with solver=..."] --> DISP{"solver is None?"}
+    DISP -- yes --> PRIMS["Layer 0 primitives<br/><small>structural dispatch</small>"]
+    DISP -- no --> STRAT["AbstractSolverStrategy"]
+
+    STRAT --> DENSE["DenseSolver<br/><small>structural + dense</small>"]
+    STRAT --> AUTO["AutoSolver<br/><small>picks by type + size</small>"]
+    STRAT --> ITER["CGSolver · PreconditionedCGSolver<br/>MINRESSolver · LSMRSolver · BBMMSolver"]
+    STRAT --> COMP["ComposedSolver<br/><small>solve from one, logdet from another</small>"]
+
+    COMP --> ITER
+    COMP --> LOGDET["DenseLogdet · SLQLogdet<br/>IndefiniteSLQLogdet"]
+
+    ITER -->|"preconditioner="| PRECOND["AbstractPreconditioner"]
+    PRECOND --> PJ["JacobiPreconditioner"]
+    PRECOND --> PN["NystromPreconditioner"]
+    PRECOND --> PP["PartialCholeskyPreconditioner"]
+    PRECOND --> PO["OperatorPreconditioner<br/><small>bring your own M⁻¹</small>"]
+
+    AUTO --> DENSE
+    AUTO --> ITER
+```
 
 | Strategy | Algorithm | Best for |
 |----------|-----------|----------|
-| `DenseSolver` | Structural dispatch (Cholesky for PSD, etc.) | Small-medium, structured |
-| `CGSolver` | Iterative CG + stochastic Lanczos logdet | Large PSD, matrix-free |
+| `DenseSolver` | Structural dispatch, Cholesky for PSD | Small/medium, structured |
+| `AutoSolver` | Structured → dense; small → dense; large PSD → CG | When you would rather not choose |
+| `CGSolver` | Conjugate gradients (+ optional preconditioner) | Large PSD, matrix-free |
+| `PreconditionedCGSolver` | CG with a required preconditioner | Ill-conditioned kernel matrices |
+| `MINRESSolver` | MINRES | Symmetric indefinite |
+| `LSMRSolver` | LSMR | Least squares / rectangular |
+| `BBMMSolver` | Batched blocked matrix-matrix CG | Many right-hand sides at once |
+| `ComposedSolver` | Any solve + any logdet | The standard large-kernel recipe: CG solve, SLQ logdet |
+| `DenseLogdet` | Eigendecomposition | Exactness |
+| `SLQLogdet` / `IndefiniteSLQLogdet` | Stochastic Lanczos quadrature | Large PSD / symmetric-indefinite estimates |
 
-Strategies decouple the distribution from the solver --- a `MultivariateNormal` doesn't know or care whether it's doing dense Cholesky or iterative CG.
+`AutoSolver`'s rule is deliberately boring and readable: structured operators go
+to `DenseSolver` (structural dispatch is already the fast path), dense operators
+below `size_threshold` (default 1000) go to `DenseSolver`, large PSD operators
+go to `CGSolver`, everything else falls back to `DenseSolver`.
 
-### Layer 2 --- Distributions + Sugar
+### The front door
 
-- `MultivariateNormal(loc, cov_operator, solver=...)` --- accepts any covariance operator and any solver strategy
-- Compound operations: `project`, `unwhiten`, `schur_complement`, `conditional_variance`
-- Gaussian exponential family: natural/expectation parameters, Fisher information
+[`linear_solve`](api/solvers.md#gaussx.linear_solve) is the high-level entry
+point. It accepts a lineax operator *or* a bare `(matvec, in_structure)` pair,
+normalises negative-definite systems, picks an iterative solver from the
+operator's tags, and threads a preconditioner through.
+`as_linear_operator` wraps a raw matvec callable into a tagged
+`FunctionLinearOperator` for matrix-free workflows.
 
-### Layer 3 --- Recipes
+`AbstractPreconditioner.as_operator(A)` receives the *system* operator, so
+static preconditioners (Jacobi, or an externally supplied approximate inverse)
+can ignore it while data-dependent ones (partial Cholesky) build their factor
+lazily at solve time. This is the seam through which PDE packages inject their
+own approximate inverses --- a spectral solve or a multigrid V-cycle is wrapped
+in `OperatorPreconditioner` and passed in, so **gaussx never imports the
+packages that build them**.
 
-Cross-library patterns: Kalman filter, RTS smoother, ensemble covariance, natural gradient updates, Kronecker GP marginal likelihood / posterior prediction, LOVE predictive variance, CVI site updates, and SSM-natural conversions. Thin wiring of Layer 0--2 operations into domain-specific sequences.
+---
 
-Two API constraints worth knowing:
+## Layer 2 --- Distributions & sugar
 
-- `kronecker_posterior_predictive(...)` needs exact test prior diagonals via `K_test_diag_factors` for predictive variances.
-- `ssm_to_naturals(...)` expects `Q[0] == P_0` and raises on inconsistent initial covariance inputs.
+```mermaid
+flowchart LR
+    subgraph DISTS["Distributions (NumPyro-compatible)"]
+        MVN["MultivariateNormal<br/><small>carries Σ as an operator</small>"]
+        MVNP["MultivariateNormalPrecision<br/><small>carries Λ = Σ⁻¹ directly</small>"]
+    end
 
-## Structural Tags
+    subgraph OPSUGAR["Sugar operations"]
+        LP["gaussian_log_prob · gaussian_entropy<br/>quadratic_form · add_jitter"]
+        KL["kl_standard_normal<br/>dist_kl_divergence"]
+        COND["conditional · project<br/>joseph_update"]
+    end
 
-Operators carry tags that drive dispatch. gaussx extends lineax's tag set:
+    subgraph EFAM["Exponential family"]
+        NAT["η₁ = Λμ,&nbsp; η₂ = −½Λ"]
+        CONV["natural ↔ mean/cov ↔ expectation"]
+        FISH["log_partition · fisher_info<br/>sufficient_stats · kl_divergence"]
+    end
 
-| Tag | Source | Used by |
-|-----|--------|---------|
-| `symmetric_tag` | lineax | solve, logdet |
-| `positive_semidefinite_tag` | lineax | cholesky, sqrt, CG |
-| `diagonal_tag` | lineax | all primitives (O(n) paths) |
-| `kronecker_tag` | gaussx | all primitives (per-factor) |
-| `block_diagonal_tag` | gaussx | all primitives (per-block) |
-| `low_rank_tag` | gaussx | solve (Woodbury), logdet (det lemma) |
+    MVN --> LP
+    MVNP --> LP
+    LP --> P0["Layer 0: solve · logdet · cholesky"]
+    KL --> P0
+    COND --> P0
+    NAT --> CONV --> FISH --> P0
+```
 
-Query functions (`is_kronecker`, `is_block_diagonal`, `is_low_rank`, plus all lineax queries) let you inspect operator properties without knowing the concrete type.
+- **`MultivariateNormal(loc, cov_operator, solver=...)`** takes *any* covariance
+  operator and *any* solver strategy. The distribution owns the math; the
+  strategy owns the numerics.
+- **`MultivariateNormalPrecision`** carries $\Lambda = \Sigma^{-1}$ directly ---
+  the natural home for natural-parameter guides, where materializing $\Sigma$
+  would be wasted work.
+- Both require `numpyro`, which is an **optional** dependency. The rest of
+  gaussx imports fine without it (see the guarded import at the bottom of
+  `src/gaussx/__init__.py`).
+- **Sugar ops** evaluate $\log\mathcal{N}(x \mid \mu, \Sigma)$, entropy,
+  quadratic forms, KLs, conditioning, and the numerically stable Joseph-form
+  covariance update --- all through structured `solve` + `logdet`.
+- **Exponential family** provides the conversions (mean/cov ↔ natural ↔
+  expectation), log-partition, Fisher information, and sufficient statistics
+  that natural-gradient and EP updates are built from.
+
+---
+
+## Layer 3 --- Recipes
+
+Layer 3 is thin wiring: domain-specific sequences of Layer 0–2 operations. It is
+where the library stops being linear algebra and starts being *someone's
+method*. Five families, each with its own API page.
+
+```mermaid
+flowchart TB
+    subgraph R["Layer 3"]
+        direction TB
+        A["Gaussian processes<br/><small>_gp/</small>"]
+        B["State-space models<br/><small>_ssm/</small>"]
+        C["Quadrature and moments<br/><small>_quadrature/</small>"]
+        D["Inference and ensembles<br/><small>_inference/</small>"]
+        E["Kernel approximations<br/><small>_kernels/</small>"]
+    end
+
+    A -->|"conditioning · ELBO · whitening"| A1["base_conditional · collapsed_elbo<br/>unwhiten · love_variance · oilmm_project"]
+    B -->|"filtering · smoothing"| B1["kalman_filter · rts_smoother<br/>parallel_* · spingp_* · cvi_update_sites"]
+    C -->|"expectations under a Gaussian"| C1["GaussHermite · Unscented · Taylor · MC<br/>ep_tilted_moments · uncertain_gp_predict"]
+    D -->|"posterior updates"| D1["blr_full_update · damped_natural_update<br/>ensemble_kalman_gain · gaspari_cohn"]
+    E -->|"low-rank kernels"| E1["nystrom_operator · rff_operator<br/>eigenpro_* · hsic · mmd_squared"]
+```
+
+**Gaussian processes** ([API](api/gp.md)) --- posterior conditioning, prediction
+caches, Matheron pathwise sampling, whitened parameterizations, Gaussian and MC
+ELBOs, the collapsed (Titsias) bound, LOVE predictive variances, closed-form
+leave-one-out CV, Kronecker GP marginal likelihood, and OILMM multi-output
+projections.
+
+**State-space models** ([API](api/ssm.md)) --- stationary 1-D kernels with
+rational spectral densities have exact SDE representations, turning $O(N^3)$ GP
+inference into $O(N d^3)$ Kalman filtering. Ships the SDE kernel zoo (Matérn,
+periodic, quasi-periodic, cosine, constant, plus sum/product composition), the
+sequential filter and RTS smoother, their $O(\log N)$ parallel associative-scan
+counterparts, square-root variants, steady-state (infinite-horizon) filters via
+the discrete algebraic Riccati equation, SpInGP, and CVI site machinery for
+non-conjugate likelihoods.
+
+**Quadrature & moment matching** ([API](api/quadrature.md)) --- one
+`AbstractIntegrator` interface over Gauss-Hermite, unscented/cubature, Taylor,
+and Monte Carlo rules. Everything needing an expectation (expected
+log-likelihoods, EP tilted moments, uncertain-input GP prediction, $\Psi$
+statistics) takes an integrator argument, so swapping the rule never touches the
+model.
+
+**Bayesian inference & ensembles** ([API](api/inference.md)) --- conjugate BLR
+updates (full and diagonal), Newton and damped natural-gradient steps,
+Gauss-Newton curvature, Riemannian PSD correction, ensemble covariances and
+Kalman gain, ETKF transforms, Gaspari-Cohn localization, and the RTPP/RTPS
+inflation family.
+
+**Kernels & approximations** ([API](api/kernels.md)) --- Nyström and RFF
+approximations returned as `LowRankUpdate` operators (so Woodbury applies
+automatically), EigenPro spectral preconditioning, kernel centering, HSIC, MMD,
+and the grid/interpolation helpers behind KISS-GP-style operators.
+
+Two API constraints worth knowing up front:
+
+- `kronecker_posterior_predictive(...)` needs exact test prior diagonals via
+  `K_test_diag_factors=` for predictive variances.
+- `ssm_to_naturals(...)` expects `Q[0] == P_0` and raises on an inconsistent
+  initial covariance.
+
+---
+
+## Package layout
+
+Every subpackage is private (`_`-prefixed); the public API is re-exported
+through `src/gaussx/__init__.py`, which is the single source of truth for
+what is supported.
+
+```
+src/gaussx/
+├── __init__.py             # Public API — 269 names
+├── _tags.py                # Structural tags + is_* predicates
+├── _einx.py                # einx wrappers (all reshape / einsum goes here)
+├── _solve_frontend.py      # linear_solve + as_linear_operator
+├── _testing.py             # Test utilities (random PD matrices, assertions)
+│
+├── _primitives/            # Layer 0 — solve, logdet, cholesky, diag, trace,
+│                           #   sqrt, inv, eig, svd, root, frobenius, submatrix
+├── _linalg/                # Layer 0 — Woodbury, Schur, safe_cholesky,
+│                           #   tridiagonal, Lyapunov, symmetrize, batched matvec
+│
+├── _operators/             # Layer 1 — Kronecker, KroneckerSum, SumKronecker,
+│                           #   BlockDiag, BlockTriDiag, LowRankUpdate, SVD
+│                           #   low-rank, Toeplitz, kernel/implicit/interpolated/
+│                           #   masked operators, lazy algebra, capacitance
+│
+├── _strategies/            # Layer 1.5 — Dense, Auto, CG, PreconditionedCG,
+│                           #   MINRES, LSMR, BBMM, Composed, SLQ logdets
+├── _preconditioners/       # Layer 1.5 — Jacobi, Nyström, PartialCholesky,
+│                           #   Operator (bring-your-own M⁻¹)
+│
+├── _distributions/         # Layer 2 — MultivariateNormal(+Precision),
+│                           #   log-prob/entropy/KL, conditional, Joseph, project
+├── _expfam/                # Layer 2 — natural ↔ expectation, Fisher, partition
+│
+├── _gp/                    # Layer 3 — conditioning, ELBOs, whitening, LOVE,
+│                           #   LOO, Matheron, OILMM, Kronecker GP, caches
+├── _ssm/                   # Layer 3 — SDE kernels, Kalman/RTS (sequential,
+│                           #   parallel, sqrt, infinite-horizon), SpInGP, CVI
+├── _quadrature/            # Layer 3 — integrators, likelihoods, expectations,
+│                           #   Ψ-statistics, uncertain-input GP prediction, ADF
+├── _inference/             # Layer 3 — BLR, natural gradient, EnKF, localization
+└── _kernels/               # Layer 3 — Nyström, RFF, EigenPro, HSIC/MMD, grids
+```
+
+Layer 3 lives in *named* subpackages (`_gp/`, `_ssm/`, …) rather than a single
+`_recipes/` directory --- the families grew large enough to deserve their own
+namespaces, and each maps one-to-one onto an API reference page.
+
+---
 
 ## Dependencies
 
 | Package | Role | Required |
 |---------|------|----------|
-| `jax` / `jaxlib` | Array backend | Yes |
-| `equinox` | Module system, PyTrees | Yes |
-| `lineax` | Linear operators, solvers | Yes |
-| `matfree` | Krylov methods, stochastic trace | Yes |
-| `jaxtyping` | Array type annotations | Yes |
-| `einx` | Tensor reshaping/contraction (Principle 5) | Yes |
-| `numpyro` | Distributions (Layer 2) | Planned |
+| [`jax`](https://github.com/jax-ml/jax) / `jaxlib` | Array backend | Yes |
+| [`equinox`](https://github.com/patrick-kidger/equinox) | Module system, PyTrees | Yes |
+| [`lineax`](https://github.com/patrick-kidger/lineax) | Base operators, solvers, property tags | Yes |
+| [`matfree`](https://github.com/pnkraemer/matfree) | Lanczos, SLQ, Hutchinson | Yes |
+| [`jaxtyping`](https://github.com/patrick-kidger/jaxtyping) | Array shape annotations | Yes |
+| [`einx`](https://github.com/fferflo/einx) | Tensor reshaping/contraction | Yes |
+| [`numpyro`](https://github.com/pyro-ppl/numpyro) | `MultivariateNormal` distributions | Optional (`gaussx[numpyro]`) |
 
-## Package Layout
+---
 
+## Where gaussx sits in the ecosystem
+
+gaussx is deliberately a *floor*, not a *building*. It owns structured operators
+and the primitives over them; everything domain-specific is somebody else's
+library.
+
+```mermaid
+flowchart TB
+    subgraph UP["Built on"]
+        LINEAX["lineax"]
+        MATFREE["matfree"]
+        EQX["equinox"]
+    end
+
+    GX["<b>gaussx</b><br/><small>structured operators · primitives · Gaussians</small>"]
+
+    subgraph PROB["Probabilistic modelling"]
+        PYROX["pyrox-gp<br/><small>GP models, kernels, guides on NumPyro</small>"]
+        FILTERAX["filterax<br/><small>ensemble filtering</small>"]
+        OPTAXB["optax_bayes<br/><small>natural-gradient optimizers</small>"]
+    end
+
+    subgraph PDE["PDE / geoscience"]
+        FVX["finitevolX<br/><small>finite-volume ops, Arakawa C-grids</small>"]
+        SDX["spectraldiffx<br/><small>pseudospectral discretization</small>"]
+    end
+
+    LINEAX --> GX
+    MATFREE --> GX
+    EQX --> GX
+
+    GX -->|"operators · solvers · distributions"| PYROX
+    GX -.->|"ensemble covariance · Kalman gain"| FILTERAX
+    GX -.->|"Fisher · natural params"| OPTAXB
+    GX -->|"CG · Nyström precond · tridiagonal"| FVX
+    GX -.->|"capacitance / Woodbury correction<br/>(planned)"| SDX
+
+    click LINEAX "https://github.com/patrick-kidger/lineax" _blank
+    click MATFREE "https://github.com/pnkraemer/matfree" _blank
+    click EQX "https://github.com/patrick-kidger/equinox" _blank
+    click PYROX "https://github.com/jejjohnson/pyrox" _blank
+    click FILTERAX "https://github.com/jejjohnson/filterax" _blank
+    click OPTAXB "https://github.com/jejjohnson/optax_bayes" _blank
+    click FVX "https://github.com/jejjohnson/finitevolX" _blank
+    click SDX "https://github.com/jejjohnson/spectraldiffx" _blank
 ```
-src/gaussx/
-├── __init__.py              # Public API
-├── _tags.py                 # Structural tags + queries
-├── _operators/              # Layer 1
-│   ├── _kronecker.py
-│   ├── _block_diag.py
-│   ├── _block_tridiag.py
-│   ├── _implicit_kernel.py
-│   └── _low_rank_update.py
-├── _primitives/             # Layer 0
-│   ├── _solve.py
-│   ├── _logdet.py
-│   ├── _cholesky.py
-│   ├── _diag.py
-│   ├── _trace.py
-│   ├── _sqrt.py
-│   └── _inv.py
-├── _strategies/             # Layer 1.5
-│   ├── _base.py
-│   ├── _dense.py
-│   └── _cg.py
-├── _recipes/                # Layer 3
-│   ├── _kalman.py
-│   ├── _kronecker_gp.py
-│   ├── _love.py
-│   ├── _cvi.py
-│   └── _ssm_natural.py
-└── _testing.py              # Test utilities
-```
+
+**[pyrox-gp](https://github.com/jejjohnson/pyrox)** is the largest consumer. It
+is the modelling shell gaussx deliberately refuses to be: kernels with
+hyperparameter priors, NumPyro sample sites, guides, likelihoods, sparse and
+Markov GP models. It reaches into gaussx for more than forty public symbols ---
+`Kronecker`, `BlockDiag`, `ImplicitKernelOperator`, the solver strategies,
+`MultivariateNormal(Precision)`, `base_conditional`,
+`variational_elbo_gaussian`, `whitened_svgp_predict`, `kalman_filter`,
+`rts_smoother`, `ep_tilted_moments`, the OILMM projections, and the
+natural-parameter conversions.
+
+**[finitevolX](https://github.com/jejjohnson/finitevolX)** takes the raw solver
+substrate: its tridiagonal solves are `gaussx.solve_tridiagonal` /
+`solve_tridiagonal_batched`, and its Nyström preconditioner wraps
+`gaussx.NystromPreconditioner` around a `gaussx.as_linear_operator` view of the
+(PSD-probed) finite-volume operator.
+
+**[spectraldiffx](https://github.com/jejjohnson/spectraldiffx)** is the planned
+next adopter: it supplies the base spectral solve and the boundary indices, and
+gaussx returns the reusable capacitance operator that corrects it
+(`gaussx.CapacitanceSolver`, already implemented on the gaussx side). That
+correction *is* the Woodbury identity --- the same code path that solves a
+low-rank-plus-diagonal covariance. Likewise
+[filterax](https://github.com/jejjohnson/filterax) and
+[optax_bayes](https://github.com/jejjohnson/optax_bayes) are the intended homes
+for the ensemble-filtering and natural-gradient-optimizer layers built on the
+Layer 3 primitives gaussx already ships.
+
+That overlap is not a coincidence. Under the SPDE view, elliptic differential
+operators and Gaussian precision operators are the same objects, so one tested
+CG loop, one Nyström preconditioner, and one Woodbury correction can serve a GP
+marginal likelihood and a masked Poisson solve alike. The
+[Unified Solvers](design/unified-solvers.md) design note works through where
+that boundary is drawn, and what gaussx will never accept (grids, coordinates,
+boundary conditions, spectral transforms, multigrid V-cycles --- those stay
+upstairs).
+
+For the philosophy behind these boundaries, see [Vision](vision.md). For the
+symbol-level reference, see the [API docs](api/index.md).

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,111 +1,245 @@
 # Vision
 
-> **gaussx** is a JAX/Equinox library that provides structured linear operators, Gaussian distributions, and exponential family primitives under one roof.
+> **gaussx** is a JAX/Equinox library for structured linear operators, Gaussian
+> distributions, and exponential-family primitives.
+>
+> Or, less politely: your covariance matrix has structure, your code is throwing
+> it away, and we would like a word.
 
-## Why structured linear algebra matters
+## The thirty-second version
 
-Linear algebra is the computational backbone of scientific computing and machine learning --- more foundational than most practitioners realize. Nearly every algorithm eventually bottlenecks on solving a linear system, computing a determinant, or factorizing a matrix:
+Somewhere in your program there is a matrix. It is not a random pile of numbers
+--- it is a Kronecker product, or block diagonal, or low-rank plus a diagonal,
+or Toeplitz, or the precision matrix of a Markov chain. It *knows* something
+about itself.
 
-- **Linear regression** solves $(X^\top X) \beta = X^\top y$
-- **Gaussian processes** need $(K + \sigma^2 I)^{-1} y$ and $\log|K + \sigma^2 I|$ for every evaluation of the marginal likelihood
-- **Kalman filters** compute the gain $K = P H^\top (H P H^\top + R)^{-1}$ at every time step
-- **Variational inference** requires $\log|\Sigma|$ and samples from $\mathcal{N}(\mu, \Sigma)$ --- both need a matrix square root or Cholesky factor
-- **Natural gradient methods** invert the Fisher information matrix $F^{-1} \nabla \mathcal{L}$ at each update
-- **Ensemble methods** form empirical covariances $\frac{1}{J} \sum (x_j - \bar{x})(x_j - \bar{x})^\top$ that are inherently low-rank
-- **Spatial statistics on grids** produce Kronecker-structured covariances $K_x \otimes K_y$ where naive $O(N^3)$ becomes $O(n_x^3 + n_y^3)$
-- **PDE solvers** invert elliptic operators, precondition iterative methods, and compute spectral decompositions
-- **Optimal transport** solves Sinkhorn iterations that reduce to repeated matrix-vector products
+And then you call `jnp.linalg.solve` on it, and all of that knowledge is
+thrown in the bin, and your laptop spends four minutes doing arithmetic that a
+pocket calculator could have done in one.
 
-The same handful of operations --- `solve`, `logdet`, `cholesky`, `trace`, `sqrt` --- appear again and again across these fields. The default approach of materializing a dense matrix and calling LAPACK works for toy problems but collapses at scale. Real problems have **structure**: the matrix is Kronecker, block diagonal, low-rank plus diagonal, sparse, or symmetric positive definite. Exploiting that structure is often the difference between $O(n^3)$ and $O(n)$ --- between a computation that takes hours and one that takes milliseconds.
+This is, we regret to say, barbaric.
 
-Yet in practice, every research codebase re-discovers and re-implements these structural tricks from scratch. The Woodbury identity gets hand-coded in the GP library, then again in the filtering library, then again in the Bayesian optimization library. Each implementation is correct but isolated. Bugs don't get shared fixes. Performance improvements don't propagate. And newcomers face a wall of bespoke linear algebra code before they can focus on their actual research problem.
+```python
+import gaussx
 
-gaussx exists to end this cycle: provide the structured operators and dispatch-based primitives once, correctly, and let every downstream library build on them.
+K = gaussx.Kronecker(A, B)   # 10,000 x 10,000, made of two 100 x 100 factors
 
-## Why gaussx (specifically)?
-
-Every project in the JAX scientific computing ecosystem reimplements the same linear algebra patterns:
-
-- **GP libraries** hand-roll Cholesky solvers, Woodbury identity, Kronecker eigendecomposition, stochastic trace estimation.
-- **Kernel methods** hand-roll kernel matrix operations, CG solvers, centering matrices, HSIC traces.
-- **Data assimilation** hand-rolls ensemble covariance computation, Kalman gain, matrix square roots for sigma points.
-- **Bayesian learning** hand-rolls Fisher information inversion, natural-to-expectation parameter conversions.
-
-The implementations are correct but scattered. Each project carries its own operator types, dispatch tables, and solve routines. Bug fixes don't propagate. Optimizations aren't shared. New projects start from scratch.
-
-Meanwhile, the existing tools each solve *part* of the problem:
-
-| Library | Strengths | Gap |
-|---------|-----------|-----|
-| **lineax** | Excellent solvers (CG, Cholesky, LU, GMRES, ...), clean operator abstraction | No Kronecker, BlockDiag, or LowRank operators; no logdet, trace, sqrt |
-| **CoLA** | Rich operator zoo, matrix functions (logdet, trace, sqrt, exp) | Multi-backend, not Equinox-native, weaker solver coverage |
-| **TFP JAX** | Battle-tested LinearOperators with batching | Heavy dependency with TF baggage |
-
-**gaussx fills the gap**: lineax's solvers + CoLA's operator breadth + Gaussian distribution layer, all native to JAX/Equinox.
-
-## Who is gaussx for?
-
-**GP researcher** --- "I have a spatiotemporal kernel that's Kronecker-structured. I want `logdet` and `solve` to automatically exploit that structure without me reimplementing the Kronecker eigendecomposition trick every time."
-
-**Data assimilation researcher** --- "I need ensemble covariance as a low-rank operator and Kalman gain via Woodbury. I want to call `low_rank_plus_diag(noise, U)` and get a structured operator back."
-
-**Bayesian ML researcher** --- "I'm implementing natural gradient methods. I need natural-to-expectation parameter conversions and Fisher information for Gaussians, working with structured precision operators."
-
-**Library developer** --- "I'm building a GP/filtering/optimization library. I need a shared linear algebra layer so I stop reimplementing `solve`, `logdet`, and `cholesky` with per-type dispatch in every project."
-
-**Student / newcomer** --- "I want `gaussx.solve(K, y)` to just work, whether my matrix is dense, Kronecker, or low-rank+diagonal."
-
-## Design Principles
-
-| # | Principle | What it means |
-|---|-----------|---------------|
-| 1 | **Extend, don't replace** | Build on lineax's `AbstractLinearOperator` and solver suite. Don't reinvent what already works. |
-| 2 | **Structure drives dispatch** | Operators carry structural tags (PSD, symmetric, Kronecker, ...). Primitives inspect types + tags via isinstance to select the efficient code path. No magic. |
-| 3 | **Math-first layers** | Layer 0 functions match the equations in papers: `solve(A, b)`, `logdet(A)`, `cholesky(A)`. A researcher should read the code and see the math. |
-| 4 | **One distribution, many strategies** | `MultivariateNormal` accepts any covariance operator and any solver strategy. The distribution handles the math, the solver handles the numerics. |
-| 5 | **einx for readability** | All tensor reshaping uses `rearrange` and `einsum`. Kronecker `mv` reads like Roth's column lemma. |
-
-## What gaussx is NOT
-
-| Not this | Use instead |
-|----------|-------------|
-| GP library (kernels, priors, inference) | pyrox_gp |
-| Probabilistic programming (MCMC, SVI) | NumPyro |
-| General-purpose optimization | optax / optimistix |
-| PDE solvers | finitevolx / spectraldiffx |
-| Ensemble Kalman filters | filterX (consumes gaussx) |
-| Multi-backend (PyTorch, NumPy) | JAX only |
-
-## Ecosystem
-
+x  = gaussx.solve(K, y)      # 100 x 100 twice, not 10,000 x 10,000 once
+ld = gaussx.logdet(K)        # a weighted sum of two small logdets
+L  = gaussx.cholesky(K)      # a Kronecker of two small Cholesky factors
 ```
-                    ┌──────────────┐
-                    │   lineax     │  Solvers, base operators, tags
-                    │   matfree    │  Iterative/stochastic LA
-                    └──────┬───────┘
-                           │ extends
-                    ┌──────▼───────┐
-                    │    gaussx    │  ← equinox, jaxtyping, einx
-                    └──────┬───────┘
-                           │ consumed by
-           ┌───────────────┼───────────────┐
-    ┌──────▼──────┐ ┌──────▼──────┐ ┌──────▼──────┐
-    │  pyrox_gp   │ │   filterX   │ │ optax_bayes │
-    │  (GPs)      │ │  (ensemble  │ │  (natural   │
-    │             │ │   Kalman)   │ │   gradient) │
-    └─────────────┘ └─────────────┘ └─────────────┘
+
+Same three lines you already write. Same math you already know. Around half a
+million times less arithmetic ($10^{12}$ flops down to $2 \times 10^6$). You are
+welcome.
+
+| If your matrix is... | Dense LAPACK | gaussx |
+|---|---|---|
+| Kronecker $A \otimes B$, factors $n_1, n_2$ | $O((n_1 n_2)^3)$ | $O(n_1^3 + n_2^3)$ |
+| Block diagonal, $k$ blocks of size $m$ | $O((km)^3)$ | $O(k m^3)$ |
+| Low-rank + diagonal, rank $k$ | $O(n^3)$ | $O(n k^2)$ via Woodbury |
+| Block-tridiagonal (state-space), $N$ steps | $O((Nd)^3)$ | $O(N d^3)$ |
+| Toeplitz | $O(n^3)$ | $O(n \log n)$ matvecs via FFT |
+| Genuinely unstructured and enormous | it will not finish | matrix-free CG + stochastic logdet |
+
+Those are not marketing numbers. They are the exponents. Exponents do not
+negotiate.
+
+## Why this keeps mattering
+
+Linear algebra is the load-bearing wall of scientific computing, and almost
+everyone treats it as wallpaper. Nearly every algorithm you care about
+eventually bottlenecks on the same tiny handful of operations:
+
+- **Linear regression** solves $(X^\top X)\beta = X^\top y$
+- **Gaussian processes** need $(K + \sigma^2 I)^{-1} y$ and $\log|K + \sigma^2 I|$ for *every* likelihood evaluation
+- **Kalman filters** compute the gain $K = P H^\top (H P H^\top + R)^{-1}$ at *every* time step
+- **Variational inference** wants $\log|\Sigma|$ and samples from $\mathcal{N}(\mu, \Sigma)$ --- both need a square root
+- **Natural gradients** invert the Fisher information, $F^{-1}\nabla\mathcal{L}$, at *every* update
+- **Ensemble methods** build empirical covariances that are low-rank by construction
+- **Spatial statistics on grids** produce $K_x \otimes K_y$, where $O(N^3)$ collapses to $O(n_x^3 + n_y^3)$
+- **PDE solvers** invert elliptic operators and precondition iterative methods
+- **Optimal transport** runs Sinkhorn iterations that are just matvecs wearing a hat
+
+Five verbs --- `solve`, `logdet`, `cholesky`, `trace`, `sqrt` --- carry entire
+research fields on their back. They deserve to be written once, by someone
+paying attention.
+
+## The part that is genuinely annoying
+
+Here is what actually happens in the wild. The Woodbury identity gets
+hand-coded in the GP library. Then again in the filtering library. Then again,
+subtly differently and with one sign wrong, in the Bayesian optimization
+library. Every implementation is *correct*, and every implementation is
+*alone*.
+
+So the bug fix in repo #1 never reaches repo #3. The clever preconditioner in
+repo #2 dies with the PhD student who wrote it. And every newcomer must climb a
+wall of bespoke matrix code before touching the science they actually came for.
+
+We find this waste offensive. Not "inefficient" --- **offensive**. gaussx
+exists to end it: write the structured operators and the dispatch once,
+carefully, and let everyone downstream inherit the good version.
+
+## But surely someone has done this?
+
+Partly. Everyone has done a *piece* of it, and we say that with real affection
+--- gaussx is built on two of them.
+
+| Library | What it does beautifully | Where it stops |
+|---------|--------------------------|----------------|
+| **[lineax](https://github.com/patrick-kidger/lineax)** | Superb solvers (CG, Cholesky, LU, GMRES, ...), a clean operator abstraction, properly JAX-native | No Kronecker / block-diagonal / low-rank operators; no `logdet`, `trace`, or `sqrt` |
+| **[CoLA](https://github.com/wilson-labs/cola)** | A rich operator zoo and real matrix functions | Multi-backend by design, so not Equinox-native; thinner solver coverage |
+| **[TFP on JAX](https://www.tensorflow.org/probability)** | Battle-tested `LinearOperator`s with batching | Arrives towing an entire TensorFlow |
+
+So: lineax has the solvers but not the shapes. CoLA has the shapes but not the
+home. TFP has both and a suitcase.
+
+**gaussx is the missing middle** --- lineax's solvers, a broader operator zoo, a
+Gaussian distribution layer on top, and every last line of it native to
+JAX and Equinox. One `pip install`. No suitcase.
+
+## Who this is for
+
+**The GP researcher.** *"My spatiotemporal kernel is Kronecker-structured. I
+want `logdet` and `solve` to notice that by themselves, forever, without me
+re-deriving the eigendecomposition trick at 1am."*
+
+**The data-assimilation person.** *"Ensemble covariance is low-rank. Kalman gain
+is Woodbury. I want to write `low_rank_plus_diag(noise, U)` and receive a real
+structured operator, not a 40,000 x 40,000 dense array and a memory error."*
+
+**The Bayesian ML researcher.** *"Natural gradients. I need natural
+$\leftrightarrow$ expectation conversions and Fisher information for Gaussians,
+over structured precision operators, differentiable end to end."*
+
+**The library author.** *"I am building the next GP / filtering / optimization
+package and I refuse to hand-roll `solve`, `logdet`, and `cholesky` with a
+per-type dispatch table one more time."*
+
+**The newcomer.** *"I would like `gaussx.solve(K, y)` to simply work."* It does.
+That is the whole idea.
+
+## Five principles we will not apologise for
+
+| # | Principle | In practice |
+|---|-----------|-------------|
+| 1 | **Extend, don't replace** | We build on lineax's `AbstractLinearOperator` and its solvers. Rewriting excellent code to put your own name on it is vanity, not engineering. |
+| 2 | **Structure drives dispatch** | Operators carry structural tags (PSD, symmetric, Kronecker, low-rank, ...). Primitives read the type and the tags and pick the fast path. Plain `isinstance` checks. No metaclasses, no registry, no mystery. |
+| 3 | **Math-first layers** | `solve(A, b)`, `logdet(A)`, `cholesky(A)`. You should be able to read the source with the paper open and see the same equation. |
+| 4 | **One distribution, many strategies** | `MultivariateNormal` takes *any* covariance operator and *any* solver strategy. The distribution owns the math; the strategy owns the numerics; neither is allowed to meddle. |
+| 5 | **Readable tensor code** | Every reshape and contraction goes through [einx](https://github.com/fferflo/einx), so a Kronecker matvec reads like Roth's column lemma instead of like index golf. |
+
+Principle 5 is the one people call fussy. It is not fussy. It is the difference
+between code you can review and code you merely hope about.
+
+## What gaussx refuses to be
+
+A library that does everything does nothing especially well. We have chosen our
+scope, and we intend to defend it.
+
+| Not this | Go here instead |
+|----------|-----------------|
+| A GP modelling library (kernels with priors, model shells, inference loops) | [pyrox-gp](https://github.com/jejjohnson/pyrox) |
+| Probabilistic programming (MCMC, SVI, samplers) | [NumPyro](https://github.com/pyro-ppl/numpyro) |
+| General-purpose optimization | [optax](https://github.com/google-deepmind/optax) / [optimistix](https://github.com/patrick-kidger/optimistix) |
+| PDE discretization, grids, boundary conditions | [finitevolX](https://github.com/jejjohnson/finitevolX) / [spectraldiffx](https://github.com/jejjohnson/spectraldiffx) |
+| Ensemble filtering applications | [filterax](https://github.com/jejjohnson/filterax) |
+| Bayesian optimizers as `optax` transforms | [optax_bayes](https://github.com/jejjohnson/optax_bayes) |
+| Multi-backend support (PyTorch, NumPy, ...) | JAX only, on purpose, forever |
+
+gaussx is structured operators and the primitives over them. That is the whole
+job. Everything else is somebody else's excellent library, and we would rather
+link to it than imitate it.
+
+## The family
+
+gaussx is the linear-algebra floor that the rest of the stack stands on.
+
+```mermaid
+flowchart TD
+    subgraph FOUND["Foundations"]
+        LX["lineax<br/><small>solvers, operators, tags</small>"]
+        MF["matfree<br/><small>Lanczos, SLQ, Hutchinson</small>"]
+        EQX["equinox + jaxtyping + einx"]
+    end
+
+    GX["<b>gaussx</b><br/><small>structured operators · primitives · Gaussians</small>"]
+
+    subgraph DOWN["Downstream"]
+        PYROX["pyrox-gp<br/><small>GP models on NumPyro</small>"]
+        FVX["finitevolX<br/><small>finite-volume PDE ops</small>"]
+    end
+
+    subgraph PLAN["Downstream (planned)"]
+        SDX["spectraldiffx<br/><small>pseudospectral PDE ops</small>"]
+        FLTR["filterax<br/><small>ensemble filtering</small>"]
+        OB["optax_bayes<br/><small>natural-gradient optimizers</small>"]
+    end
+
+    LX --> GX
+    MF --> GX
+    EQX --> GX
+    GX --> PYROX
+    GX --> FVX
+    GX -.-> SDX
+    GX -.-> FLTR
+    GX -.-> OB
+
+    click LX "https://github.com/patrick-kidger/lineax" _blank
+    click MF "https://github.com/pnkraemer/matfree" _blank
+    click PYROX "https://github.com/jejjohnson/pyrox" _blank
+    click FVX "https://github.com/jejjohnson/finitevolX" _blank
+    click SDX "https://github.com/jejjohnson/spectraldiffx" _blank
+    click FLTR "https://github.com/jejjohnson/filterax" _blank
+    click OB "https://github.com/jejjohnson/optax_bayes" _blank
 ```
+
+The interesting one is the PDE column. Under the SPDE view, an elliptic
+differential operator and a Gaussian precision operator are *the same object*
+--- so [finitevolX](https://github.com/jejjohnson/finitevolX) already takes its
+tridiagonal solves and Nyström preconditioner straight from gaussx, and
+[spectraldiffx](https://github.com/jejjohnson/spectraldiffx) is queued to take
+the capacitance (Woodbury) correction from the very same code that runs a GP
+marginal likelihood. Fix the CG loop once; every library downstream gets
+better. See
+[Unified Solvers](design/unified-solvers.md) for how that boundary is drawn,
+and the [Architecture](architecture.md) page for the full stack.
 
 ---
 
 ## Why "GaussX"?
 
-The name combines **Gauss** and **JAX** --- and that's not just branding.
+**Gauss** + **JAX**. And no, that is not merely branding.
 
-Carl Friedrich Gauss is arguably the most consequential figure in the history of computational mathematics. His fingerprints are on nearly every algorithm in this library: **Gaussian elimination** (the ancestor of every matrix factorization), the **method of least squares** (which he invented to track the orbit of Ceres in 1801), the **Gaussian distribution** (the central object of probability theory), and the **Gauss-Markov theorem** (which tells us why least squares is optimal). The **Cholesky decomposition** --- the workhorse of positive-definite systems --- is a direct descendant of Gaussian elimination. Even the **Fast Fourier Transform** traces back to a technique Gauss described in 1805, decades before Cooley and Tukey.
+Carl Friedrich Gauss is arguably the most consequential figure in the history of
+computational mathematics, and his fingerprints are on nearly every algorithm in
+this library. **Gaussian elimination**, ancestor of every matrix factorization.
+The **method of least squares**, which he invented in 1801 to find a lost
+asteroid --- a genuinely outrageous flex. The **Gaussian distribution**. The
+**Gauss-Markov theorem**, which explains *why* least squares is optimal. The
+**Cholesky decomposition** is Gaussian elimination in formal dress. Even the
+**FFT** traces back to a trick Gauss wrote down in 1805, a century and a half
+before Cooley and Tukey published it.
 
-The Gaussian distribution itself occupies a unique position in mathematics. It is the **maximum entropy distribution** for a given mean and variance --- the least assuming model you can write down. It is the **fixed point of the Central Limit Theorem** --- the distribution that sums converge to regardless of where they started. It is the **conjugate prior** for linear-Gaussian models, making Bayesian inference exact. And it is completely characterized by just two things: a mean vector and a covariance matrix. That covariance matrix --- its structure, its factorization, its determinant, its inverse --- is precisely what gaussx computes.
+The Gaussian distribution earns its place too. It is the **maximum-entropy**
+distribution for a given mean and variance --- the least presumptuous thing you
+can assume. It is the **fixed point of the Central Limit Theorem** --- where
+sums end up regardless of where they started. It is the **conjugate prior** that
+makes linear-Gaussian Bayesian inference exact rather than approximate. And it
+is fully described by exactly two things: a mean vector, and a covariance
+matrix.
 
-Every primitive in this library (`solve`, `logdet`, `cholesky`, `trace`, `sqrt`, `inv`) exists because someone, somewhere, needs to do something with a Gaussian covariance. GP regression needs `solve` and `logdet`. Kalman filtering needs `cholesky` and `solve`. Variational inference needs `sqrt` and `logdet`. Natural gradients need `inv`. The structured operators (`Kronecker`, `BlockDiag`, `LowRankUpdate`) exist because real-world covariances have exploitable structure.
+That covariance matrix --- its structure, its factorization, its determinant,
+its inverse --- is precisely and entirely what gaussx computes. Every primitive
+in the library (`solve`, `logdet`, `cholesky`, `trace`, `sqrt`, `inv`) exists
+because somebody, somewhere, needs to do something to a Gaussian covariance. GP
+regression needs `solve` and `logdet`. Kalman filtering needs `cholesky`.
+Variational inference needs `sqrt`. Natural gradients need `inv`. The structured
+operators exist because real covariances are never the shapeless dense blobs the
+textbook drew.
 
-gaussx is, at its core, a library for working with Gaussian covariance matrices --- fast, correctly, and in JAX.
+One mathematician, two centuries, five verbs, and a matrix that knows what it
+is.
+
+Voilà.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,7 +106,11 @@ markdown_extensions:
       generic: true
   - pymdownx.highlight:
       anchor_linenums: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details

--- a/tests/test_docs_api_coverage.py
+++ b/tests/test_docs_api_coverage.py
@@ -1,0 +1,97 @@
+"""Keep the API reference in sync with the public API.
+
+``docs/api/*.md`` lists symbols explicitly via mkdocstrings ``members:`` blocks
+rather than auto-generating pages, which keeps the reference organised by layer
+but lets it drift: a newly exported name silently gets no page, and a renamed
+one leaves a dangling entry that only shows up as a ``mkdocs build --strict``
+failure in CI. These tests close both gaps at unit-test speed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import gaussx
+
+
+DOCS_API_DIR = Path(__file__).resolve().parents[1] / "docs" / "api"
+
+# ``members: [a, b, c]`` (inline flow sequence).
+_INLINE_MEMBERS = re.compile(r"members:\s*\[([^\]]*)\]")
+# ``members:`` followed by a ``- name`` block sequence.
+_BLOCK_MEMBERS = re.compile(r"members:\s*\n((?:[ \t]*-[ \t]*\w+[ \t]*\n)+)")
+_BLOCK_ITEM = re.compile(r"-[ \t]*(\w+)")
+
+
+def _reference_pages() -> list[Path]:
+    """The reference pages, i.e. every page except the prose overview."""
+    return sorted(p for p in DOCS_API_DIR.glob("*.md") if p.name != "index.md")
+
+
+def _documented_members() -> dict[str, set[str]]:
+    """Map each reference page to the symbols it documents."""
+    pages: dict[str, set[str]] = {}
+    for path in _reference_pages():
+        text = path.read_text()
+        names: set[str] = set()
+        for group in _INLINE_MEMBERS.findall(text):
+            names |= {n.strip() for n in group.split(",") if n.strip()}
+        for group in _BLOCK_MEMBERS.findall(text):
+            names |= set(_BLOCK_ITEM.findall(group))
+        pages[path.name] = names
+    return pages
+
+
+def _public_api() -> set[str]:
+    """Every public name re-exported from ``gaussx/__init__.py``."""
+    return {name for name in dir(gaussx) if not name.startswith("_")}
+
+
+def test_docs_api_dir_is_discovered() -> None:
+    """Guard against the glob silently matching nothing."""
+    pages = _documented_members()
+    assert pages, f"no reference pages found under {DOCS_API_DIR}"
+    assert all(pages.values()), (
+        f"pages with no documented members: "
+        f"{sorted(name for name, members in pages.items() if not members)}"
+    )
+
+
+def test_every_public_symbol_is_documented() -> None:
+    """No public export may be missing from the API reference."""
+    undocumented = _public_api() - set().union(*_documented_members().values())
+    assert not undocumented, (
+        "public symbols missing from docs/api/*.md: "
+        f"{sorted(undocumented)}. Add each to the `members:` list of the page "
+        "matching its layer, or drop it from gaussx/__init__.py."
+    )
+
+
+def test_no_documented_symbol_is_stale() -> None:
+    """Every documented symbol must still exist on the public API."""
+    stale = set().union(*_documented_members().values()) - _public_api()
+    assert not stale, (
+        f"docs/api/*.md reference symbols that gaussx no longer exports: "
+        f"{sorted(stale)}. These break `mkdocs build --strict`."
+    )
+
+
+def test_no_symbol_is_documented_twice() -> None:
+    """Duplicate entries produce duplicate anchors and ambiguous cross-refs."""
+    pages = _documented_members()
+    duplicates = {
+        name: sorted(page for page, members in pages.items() if name in members)
+        for name in set().union(*pages.values())
+        if sum(name in members for members in pages.values()) > 1
+    }
+    assert not duplicates, f"symbols documented on more than one page: {duplicates}"
+
+
+@pytest.mark.parametrize("page", [p.name for p in _reference_pages()])
+def test_page_is_linked_from_api_index(page: str) -> None:
+    """Each reference page must be reachable from the API overview."""
+    index = (DOCS_API_DIR / "index.md").read_text()
+    assert f"({page})" in index, f"docs/api/{page} is not linked from docs/api/index.md"


### PR DESCRIPTION
Docs cleanup across three fronts: confirm the API reference is complete (and keep it that way), give the vision page a livelier voice, and bring the architecture page back in line with the code.

## API reference

Coverage was already complete — all **269** public exports from `gaussx/__init__.py` appear in `docs/api/*.md`, no stale entries, no duplicates, and `mkdocs build --strict` is clean. Rather than leave that to CI, `tests/test_docs_api_coverage.py` now enforces it at unit-test speed: it fails if a new export gets no page, a rename leaves a dangling entry, a symbol lands on two pages, or a reference page drops out of the API index.

Three accuracy problems did turn up:

- **`DenseFallbackWarning` was overstated.** `api/index.md` and `api/primitives.md` said it fires whenever a structured path densifies. It fires in exactly one place — `cholesky(SumKronecker)`. Both pages corrected.
- **`SVDLowRankUpdate` was presented as current API**, and the architecture table actively recommended it. It is a deprecated `LowRankUpdate` subclass that forces `orthonormal=True` and warns on construction. Now flagged on `api/operators.md`, pointing at `LowRankUpdate(..., orthonormal=True)` / `svd_low_rank_plus_diag()`, with the `orthonormal=` flag that replaced it documented.
- **`conditional_variance` still accepts its pre-#152 three-positional signature**, which warns and silently skips the `K_XZ` Schur subtraction. Now flagged on `api/linalg.md`.

## Vision

Rewritten with more energy. Opens with the concrete win — a 10,000×10,000 Kronecker solved as two 100×100 solves, roughly 500,000× less arithmetic — followed by a complexity table per structure type. Keeps all the substance: the motivating applications, the lineax / CoLA / TFP comparison, the personas, the five design principles, the scope boundaries, and the Gauss etymology. Every ecosystem package is now linked by name.

## Architecture

This page had drifted furthest.

- **Package layout was wrong.** It documented a `_recipes/` directory that does not exist — Layer 3 lives in `_gp/`, `_ssm/`, `_quadrature/`, `_inference/`, `_kernels/`. And `_linalg/`, `_preconditioners/`, `_expfam/`, `_distributions/`, `_solve_frontend.py`, `_einx.py` were missing entirely.
- **Proper diagrams.** Mermaid custom fence enabled in `mkdocs.yml`; the page now carries 7 diagrams — layer stack, `solve` dispatch flow, operator taxonomy, strategy/preconditioner wiring, Layer 2 map, Layer 3 map, ecosystem graph.
- **Per-primitive fast-path table** for `solve`, `logdet`, `cholesky`, `diag`, `trace`, `sqrt`, `inv` — read off the actual `isinstance` chains, marking which cells densify and which have matrix-free escape hatches.
- **Missing subsystems documented**: `AutoSolver`, MINRES, LSMR, BBMM, `ComposedSolver`, the SLQ logdet strategies, the preconditioner protocol, and the `linear_solve` front door.

## Cross-repo links

Relationships were verified in source rather than assumed:

- **[pyrox-gp](https://github.com/jejjohnson/pyrox)** — the largest consumer, using 45 public gaussx symbols.
- **[finitevolX](https://github.com/jejjohnson/finitevolX)** — imports `solve_tridiagonal` / `solve_tridiagonal_batched` and wraps `NystromPreconditioner`.
- **[spectraldiffx](https://github.com/jejjohnson/spectraldiffx)**, **[filterax](https://github.com/jejjohnson/filterax)**, **[optax_bayes](https://github.com/jejjohnson/optax_bayes)** — marked *planned*, with dashed edges. The unified-solvers design note has the spectraldiffx capacitance adoption as Phase 4, not done, so the docs do not claim otherwise.

## Verification

- `pytest -m "not slow and not integration"` — **1398 passed**
- `ruff check .` / `ruff format --check .` — clean
- `ty check src/gaussx` — clean
- `mkdocs build --strict` — clean, Mermaid blocks render on both pages

## Noted, not fixed

`src/gaussx/_operators/_svd_low_rank_update.py` is orphaned — it defines a second, non-deprecated `SVDLowRankUpdate`, but nothing imports it; the exported class comes from `_low_rank_update.py`. Dead code carrying a stale duplicate of a deprecated API. Left alone since deleting source is outside a docs cleanup, but worth removing separately.

Docs-only apart from the new test file; no source was touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTpgESwwnWBrLsfb8SHDYs)_