### PR TITLE
chore: knock off low-hanging issues (gh-202, gh-151, gh-135, gh-136, gh-106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,33 @@ Pure functions with `isinstance`-based structural dispatch. Each primitive autom
 
 ### Layer 1 -- Operators
 
-Extend `lineax.AbstractLinearOperator` with structured matrices:
+Extend `lineax.AbstractLinearOperator` with structured matrices. All are immutable `equinox.Module` pytrees, safe under `jit` / `grad` / `vmap`:
 
 | Operator | Description |
 |----------|-------------|
 | `Kronecker` | Kronecker product A_1 &otimes; ... &otimes; A_k |
 | `KroneckerSum` | Kronecker sum A &oplus; B = A &otimes; I + I &otimes; B |
+| `SumOfKroneckers` | Sum of Kronecker products &Sigma;_k A_k &otimes; B_k (**not** the same as `KroneckerSum`) |
 | `BlockDiag` | Block diagonal diag(A_1, ..., A_k) |
 | `BlockTriDiag` | Block tridiagonal (lower/upper variants) |
-| `LowRankUpdate` | A + UDV^T |
-| `SVDLowRankUpdate` | SVD-factored low-rank update |
-| `ImplicitKernelOperator` | Matrix-free kernel operator |
+| `LowRankUpdate` | A + UDV^T (pass `orthonormal=True` for SVD / Nystrom factors) |
+| `Toeplitz` | Symmetric Toeplitz, O(n log n) matvec via FFT |
+| `KernelOperator` | Rectangular kernel block K(X1, X2), matrix-free |
+| `ImplicitKernelOperator` | Square training covariance with fused noise, matrix-free |
+| `ImplicitCrossKernelOperator` | Rectangular data-inducing block, tunable scan chunk |
+| `InterpolatedOperator` | Grid-interpolated (KISS-GP style) |
+| `MaskedOperator` | Row/column sub-selection of a base operator |
+| `SumOperator`, `ScaledOperator`, `ProductOperator` | Lazy algebra |
 
-### Layer 1.5 -- Solver Strategies
+### Layer 1.5 -- Solver Strategies & Preconditioners
 
-Pluggable solve + logdet algorithms that decouple numerics from distributions:
+Pluggable solve + logdet algorithms that decouple numerics from distributions. `linear_solve` is the high-level front door; `solver=None` anywhere means structural dispatch:
 
-`DenseSolver` | `AutoSolver` | `CGSolver` | `PreconditionedCGSolver` | `LSMRSolver` | `BBMMSolver` | `ComposedSolver`
+**Solvers**: `DenseSolver` | `AutoSolver` | `CGSolver` | `PreconditionedCGSolver` | `MINRESSolver` | `LSMRSolver` | `BBMMSolver` | `ComposedSolver`
+
+**Logdets**: `DenseLogdet` | `SLQLogdet` | `IndefiniteSLQLogdet`
+
+**Preconditioners**: `JacobiPreconditioner` | `NystromPreconditioner` | `PartialCholeskyPreconditioner` | `OperatorPreconditioner` (bring your own M^-1)
 
 ### Layer 2 -- Distributions & Sugar
 
@@ -105,8 +115,15 @@ Cross-cutting patterns combining multiple layers:
 | **Gaussian sites (CVI)** | `GaussianSites`, `cvi_update_sites`, `sites_to_precision` |
 | **Kronecker GP** | `kronecker_mll`, `kronecker_posterior_predictive` |
 | **SpinGP** | `spingp_log_likelihood`, `spingp_posterior` |
-| **LOVE** | `love_cache`, `love_variance` |
-| **Ensemble** | `ensemble_covariance`, `ensemble_cross_covariance` |
+| **LOVE / LOO** | `love_cache`, `love_variance`, `leave_one_out_cv` |
+| **Ensemble (EnKF)** | `ensemble_covariance`, `ensemble_cross_covariance`, `ensemble_kalman_gain`, `etkf_transform` |
+| **Localization / inflation** | `gaspari_cohn`, `localized_kalman_gain`, `inflate_rtpp`, `inflate_rtps` |
+| **GP conditioning** | `base_conditional`, `predict_mean`, `predict_variance`, `build_prediction_cache` |
+| **Variational bounds** | `variational_elbo_gaussian`, `variational_elbo_mc`, `collapsed_elbo`, `gauss_kl` |
+| **Pathwise sampling** | `matheron_update` |
+| **Multi-output (OILMM)** | `oilmm_project`, `oilmm_back_project` |
+| **SDE kernels** | `MaternSDE`, `PeriodicSDE`, `QuasiPeriodicSDE`, `CosineSDE`, `ConstantSDE`, `SumSDE`, `ProductSDE` |
+| **Steady-state Kalman** | `infinite_horizon_filter`, `infinite_horizon_smoother`, `dare` |
 | **Interpolation** | `conditional_interpolate` |
 
 ### Exponential Family
@@ -117,9 +134,17 @@ Gaussian in natural parameter form: `GaussianExpFam` with conversions between na
 
 Gaussian-in / Gaussian-out transforms for nonlinear functions:
 
-- **Integrators**: `TaylorIntegrator`, `UnscentedIntegrator`, `MonteCarloIntegrator`
+- **Integrators**: `GaussHermiteIntegrator`, `TaylorIntegrator`, `UnscentedIntegrator`, `MonteCarloIntegrator`
+- **Likelihoods**: `GaussianLikelihood`, `HeteroscedasticGaussianLikelihood`, `BernoulliLikelihood`, `PoissonLikelihood`, `SoftmaxLikelihood`, `StudentTLikelihood`
 - **State estimation**: `AssumedDensityFilter`
+- **EP moments**: `ep_tilted_moments`
 - **GP predictions under input uncertainty**: `uncertain_gp_predict`, `uncertain_svgp_predict`, `uncertain_vgp_predict`, `uncertain_bgplvm_predict`
+
+## Documentation
+
+- **[API Reference](https://jejjohnson.github.io/gaussx/api/)** — organised by layer; every public symbol is documented
+- **[Architecture](https://jejjohnson.github.io/gaussx/architecture/)** — the layered stack, dispatch flow, and per-primitive fast-path coverage
+- **[Vision](https://jejjohnson.github.io/gaussx/vision/)** — why gaussx exists and what it deliberately is not
 
 ## API Notes
 
@@ -127,6 +152,7 @@ A few usage details that are easy to miss:
 
 - `gaussx.kronecker_posterior_predictive(...)` requires `K_test_diag_factors=` so predictive variances use the exact prior diagonal at the test points instead of reconstructing it from cross-covariances.
 - `gaussx.ssm_to_naturals(A, Q, mu_0, P_0)` expects `Q[0]` to equal `P_0`; the function raises a `ValueError` if the initial covariance is inconsistent.
+- `gaussx.SumKronecker` and `gaussx.SVDLowRankUpdate` are **deprecated** aliases (for `SumOfKroneckers` and `LowRankUpdate(..., orthonormal=True)`); both warn on construction and will be removed in a future release.
 - `gaussx.ImplicitKernelOperator(...)` only reports `lineax` structure such as symmetry or PSD when those tags are passed explicitly.
 
 ## Development

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -42,7 +42,7 @@ A few patterns hold across the whole package:
 - **Lazy over dense.** Primitives like `inv`, `sqrt`, and `cholesky` return
   *operators*, not arrays, wherever structure allows; nothing is materialized until
   `.as_matrix()` is called. Where a structured operator nevertheless has to be
-  materialized — `cholesky` of a `SumKronecker` — a `DenseFallbackWarning` points
+  materialized — `cholesky` of a `SumOfKroneckers` — a `DenseFallbackWarning` points
   you at the matrix-free alternative.
 
 - **Pure functions.** Outside the operator classes everything is a pure function:

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -13,11 +13,24 @@ The Kronecker product $A_1 \otimes A_2 \otimes \cdots$ gives $O(\sum_i n_i^3)$
 solves on a $\prod_i n_i$ grid; the Kronecker *sum* $A \otimes I + I \otimes B$
 diagonalises in the joint eigenbasis with eigenvalues $\lambda_i + \mu_j$.
 
+!!! warning "`KroneckerSum` and `SumOfKroneckers` are different operators"
+    They are not word-order variants of one idea:
+
+    | | Math | Eigendecomposition |
+    |---|---|---|
+    | `KroneckerSum(A, B)` | $A \otimes I + I \otimes B$ | Closed form — eigenvalues $\lambda_i + \mu_j$, eigenvectors $V_A \otimes V_B$ |
+    | `SumOfKroneckers(K_1, K_2, …)` | $\sum_k A_k \otimes B_k$ | None in general; `eigendecompose` handles the two-term symmetric case by densifying a $(n_c n_d)^2$ block |
+
+    `SumOfKroneckers` was called `SumKronecker` until gh-136. The old name
+    still imports and subclasses the new one — so `isinstance` checks keep
+    working — but emits a `DeprecationWarning` on construction and will be
+    removed in a future release.
+
 ::: gaussx
     options:
       show_root_heading: false
       show_root_toc_entry: false
-      members: [Kronecker, BlockDiag, KroneckerSum, KroneckerSumSqrt, SumKronecker]
+      members: [Kronecker, BlockDiag, KroneckerSum, KroneckerSumSqrt, SumOfKroneckers, SumKronecker]
 
 ## Low-rank updates
 
@@ -55,9 +68,44 @@ operators get $O(n \log n)$ matvecs and sampling via FFT circulant embedding.
 
 ## Kernel operators
 
-Kernel matrices as operators — dense (`KernelOperator`), matrix-free
-(`ImplicitKernelOperator`, rows generated on the fly per matvec), rectangular
-cross-kernels, and grid-interpolated (KISS-GP style) variants.
+Kernel matrices as operators, plus grid-interpolated (KISS-GP style) and masked
+variants.
+
+### Choosing between the three kernel operators
+
+All three are **matrix-free and scan-based** — none of them ever materializes
+its kernel block, and all three carry a `jax.custom_jvp` so first-order autodiff
+stays cheap. The word *implicit* in two of the names is therefore not the
+distinction it appears to be. What actually separates them is the **shape
+contract**, whether a **noise term is fused in**, and the **scan granularity**:
+
+| | `KernelOperator` | `ImplicitKernelOperator` | `ImplicitCrossKernelOperator` |
+|---|---|---|---|
+| **Shape** | Rectangular $(N, M)$ | Square $(N, N)$ | Rectangular $(N, M)$ |
+| **Points** | `X1`, `X2` (independent) | `X` (one set) | `X_data`, `X_inducing` |
+| **Noise term** | — | **fused** `+ noise_var * I` | — |
+| **Scan step** | one row of `X1` | one row of `X` | `batch_size` rows (default 1024) |
+| **Peak memory/step** | $O(M)$ | $O(N)$ | $O(\texttt{batch\_size} \times M)$ |
+| **Kernel signature** | `k(params, x, x')` (required) | `k(x, x')` or `k(params, x, x')` | `k(x, z)` or `k(params, x, z)` |
+
+Practical guidance:
+
+- Building a **training covariance** you will pass to CG or BBMM? Use
+  `ImplicitKernelOperator` — the fused noise term means $K$ and $\sigma^2 I$
+  never exist as separate operators.
+- Need a **general kernel block** between two point sets? `KernelOperator`.
+- Need a **data-inducing block** and want to trade peak memory for throughput?
+  `ImplicitCrossKernelOperator`, and tune `batch_size`.
+
+!!! note "Naming rule for future kernel operators"
+    Every kernel operator in gaussx is matrix-free, so *implicit*, *lazy*, and
+    *matrix-free* carry no information in a class name — and neither would
+    *scan*, since all three scan. Name a new kernel operator after the part of
+    its **contract** that differs: what shape it produces, what it fuses in, or
+    what point sets it relates. The existing `Implicit*` names predate this rule
+    and are kept for compatibility; see
+    [#135](https://github.com/jejjohnson/gaussx/issues/135) for the rename
+    discussion.
 
 ::: gaussx
     options:

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -74,8 +74,7 @@ variants.
 ### Choosing between the three kernel operators
 
 All three are **matrix-free and scan-based** — none of them ever materializes
-its kernel block, and all three carry a `jax.custom_jvp` so first-order autodiff
-stays cheap. The word *implicit* in two of the names is therefore not the
+its kernel block. The word *implicit* in two of the names is therefore not the
 distinction it appears to be. What actually separates them is the **shape
 contract**, whether a **noise term is fused in**, and the **scan granularity**:
 
@@ -87,6 +86,16 @@ contract**, whether a **noise term is fused in**, and the **scan granularity**:
 | **Scan step** | one row of `X1` | one row of `X` | `batch_size` rows (default 1024) |
 | **Peak memory/step** | $O(M)$ | $O(N)$ | $O(\texttt{batch\_size} \times M)$ |
 | **Kernel signature** | `k(params, x, x')` (required) | `k(x, x')` or `k(params, x, x')` | `k(x, z)` or `k(params, x, z)` |
+| **`jax.custom_jvp`** | always | only with `params=` | only with `params=` |
+
+!!! warning "The custom JVP follows `params`, not the class"
+    `KernelOperator` takes `params` as a required argument, so its matvec
+    always runs under a `jax.custom_jvp` that differentiates the kernel
+    without materializing Jacobians. The two `Implicit*` operators default to
+    `params=None`, and in that mode `mv` runs the ordinary scan with no custom
+    rule — autodiff falls back to differentiating straight through the scan.
+    Pass a `params` pytree (and use the `k(params, x, x')` signature) if you
+    are differentiating w.r.t. hyperparameters and want the efficient path.
 
 Practical guidance:
 

--- a/docs/api/primitives.md
+++ b/docs/api/primitives.md
@@ -5,7 +5,7 @@ dispatch** — each primitive inspects the operator (diagonal, Kronecker,
 block-diagonal, low-rank, block-tridiagonal, …) and routes to the cheapest exact
 algorithm, falling back to a dense computation only when no structured path
 exists. Where a structured operator has to be materialized anyway — `cholesky`
-of a `SumKronecker` — a [`DenseFallbackWarning`](#gaussx.DenseFallbackWarning)
+of a `SumOfKroneckers` — a [`DenseFallbackWarning`](#gaussx.DenseFallbackWarning)
 names the matrix-free alternative.
 
 ## Solve, logdet & Cholesky

--- a/docs/api/ssm.md
+++ b/docs/api/ssm.md
@@ -57,6 +57,15 @@ temporal inference.
 
 ## Process noise
 
+The exact discretisation $Q = P_\infty - A P_\infty A^\top$, which is the
+forward direction of the discrete Lyapunov equation that
+[`discrete_lyapunov_solve`](linalg.md#gaussx.discrete_lyapunov_solve) inverts.
+The congruence is delegated to
+[`cov_transform`](linalg.md#gaussx.cov_transform), so passing *operators*
+returns a lazy operator with structure intact — matched `Kronecker` factors stay
+factorised, a diagonal $P_\infty$ skips its $(N, N)$ materialization. Passing
+arrays returns an array.
+
 ::: gaussx
     options:
       show_root_heading: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ Two properties are worth internalising:
 - **Lazy over dense.** `cholesky`, `sqrt`, and `inv` return *operators*.
   The Cholesky of a `Kronecker` is a `Kronecker` of Cholesky factors; nothing
   is materialized until you call `.as_matrix()`.
-- **The expensive surprise is flagged.** `cholesky(SumKronecker)` is the one
+- **The expensive surprise is flagged.** `cholesky(SumOfKroneckers)` is the one
   path where a structured operator you would reasonably expect to stay
   structured must materialize the dense covariance, so it raises a
   [`DenseFallbackWarning`](api/primitives.md#gaussx.DenseFallbackWarning) and
@@ -135,7 +135,7 @@ instance, has no block-tridiagonal path and falls back there.
 | `BlockDiag` | per block | sum of logdets | per block | per block | per block | per block |
 | `Kronecker` | Roth's lemma | scaled sum | per factor | per factor | per factor | per factor |
 | `KroneckerSum` | joint eigenbasis | $\sum \log(\lambda_i + \mu_j)$ | dense | eigen-based | `KroneckerSumSqrt` | lazy |
-| `SumKronecker` | dense | dense | dense (warns) | per term | `SumKroneckerSqrt` | lazy |
+| `SumOfKroneckers` | dense | dense | dense (warns) | per term | `SumKroneckerSqrt` | lazy |
 | `LowRankUpdate` | Woodbury | determinant lemma | dense | base + update | dense | Woodbury (if symmetric) |
 | `BlockTriDiag` | block-banded | block Cholesky | block Cholesky | per block | dense | lazy |
 | Wrappers (`Tagged`, `Mul`, `Div`, `Neg`, `Composed`) | unwrap + recurse | unwrap + recurse | unwrap | unwrap + recurse | unwrap | unwrap + recurse |
@@ -173,7 +173,7 @@ flowchart LR
 
     P --> P1["Kronecker"]
     P --> P2["KroneckerSum"]
-    P --> P3["SumKronecker"]
+    P --> P3["SumOfKroneckers"]
     P --> P4["BlockDiag"]
 
     LRK --> L1["LowRankUpdate"]
@@ -199,7 +199,7 @@ flowchart LR
 |----------|-----------|--------------------|
 | `Kronecker(A, B, ...)` | $A \otimes B \otimes \cdots$ | $O(\sum_i n_i^3)$ instead of $O((\prod_i n_i)^3)$; matvec is Roth's column lemma via einx |
 | `KroneckerSum(A, B)` | $A \oplus B = A \otimes I + I \otimes B$ | Diagonalises in the joint eigenbasis, eigenvalues $\lambda_i + \mu_j$ |
-| `SumKronecker` | $\sum_k A_k \otimes B_k$ | Structured Cholesky/sqrt for separable-plus-noise covariances |
+| `SumOfKroneckers` | $\sum_k A_k \otimes B_k$ | Structured Cholesky/sqrt for separable-plus-noise covariances. *Not* the same as `KroneckerSum`; was named `SumKronecker`, which survives as a deprecated alias |
 | `BlockDiag(A, B, ...)` | $\mathrm{diag}(A, B, \ldots)$ | Every primitive splits per block |
 | `BlockTriDiag(D, A)` | Symmetric block-tridiagonal precision | $O(N d^3)$ --- the precision structure of Markovian GPs |
 | `LowRankUpdate(L, U, d, V)` | $L + U\,\mathrm{diag}(d)\,V^\top$ | Woodbury solves, determinant-lemma logdets; pass `orthonormal=True` for SVD/Nyström factors |
@@ -456,7 +456,7 @@ src/gaussx/
 ├── _linalg/                # Layer 0 — Woodbury, Schur, safe_cholesky,
 │                           #   tridiagonal, Lyapunov, symmetrize, batched matvec
 │
-├── _operators/             # Layer 1 — Kronecker, KroneckerSum, SumKronecker,
+├── _operators/             # Layer 1 — Kronecker, KroneckerSum, SumOfKroneckers,
 │                           #   BlockDiag, BlockTriDiag, LowRankUpdate, SVD
 │                           #   low-rank, Toeplitz, kernel/implicit/interpolated/
 │                           #   masked operators, lazy algebra, capacitance

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -84,7 +84,6 @@ from gaussx._inference import (
     localized_kalman_gain as localized_kalman_gain,
     log_marginal_likelihood as log_marginal_likelihood,
     newton_update as newton_update,
-    process_noise_covariance as process_noise_covariance,
     riemannian_psd_correction as riemannian_psd_correction,
     trace_correction as trace_correction,
 )
@@ -249,6 +248,7 @@ from gaussx._ssm import (
     pairwise_marginals as pairwise_marginals,
     parallel_kalman_filter as parallel_kalman_filter,
     parallel_rts_smoother as parallel_rts_smoother,
+    process_noise_covariance as process_noise_covariance,
     rts_smoother as rts_smoother,
     sde_autocovariance as sde_autocovariance,
     site_mean_var_from_natural as site_mean_var_from_natural,

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -141,6 +141,7 @@ from gaussx._operators import (
     ProductOperator as ProductOperator,
     ScaledOperator as ScaledOperator,
     SumKronecker as SumKronecker,
+    SumOfKroneckers as SumOfKroneckers,
     SumOperator as SumOperator,
     SVDLowRankUpdate as SVDLowRankUpdate,
     Toeplitz as Toeplitz,

--- a/src/gaussx/_inference/__init__.py
+++ b/src/gaussx/_inference/__init__.py
@@ -25,7 +25,6 @@ from gaussx._inference._inference import (
     gaussian_expected_log_lik,
     log_marginal_likelihood,
     newton_update,
-    process_noise_covariance,
     trace_correction,
 )
 from gaussx._inference._natural_gradient import (
@@ -33,6 +32,12 @@ from gaussx._inference._natural_gradient import (
     gauss_newton_precision,
     riemannian_psd_correction,
 )
+
+# ``process_noise_covariance`` is a state-space concept and now lives in
+# ``gaussx._ssm``. Re-exported here so the historical import path keeps
+# working. Imported from the leaf module rather than the ``_ssm`` package to
+# avoid pulling the whole subpackage in (and any future import cycle).
+from gaussx._ssm._discretise import process_noise_covariance
 
 
 __all__ = [

--- a/src/gaussx/_inference/_inference.py
+++ b/src/gaussx/_inference/_inference.py
@@ -184,26 +184,3 @@ def newton_update(
     nat1 = jacobian - hessian @ mean
     nat2 = -hessian
     return nat1, nat2
-
-
-def process_noise_covariance(
-    A: Float[Array, "N N"],
-    Pinf: Float[Array, "N N"],
-) -> Float[Array, "N N"]:
-    """Compute process noise from stationary covariance.
-
-    Computes:
-
-        Q = Pinf - A @ Pinf @ A^T
-
-    For a discrete-time state-space model with stationary covariance
-    ``Pinf`` and transition matrix ``A``.
-
-    Args:
-        A: State transition matrix, shape ``(N, N)``.
-        Pinf: Stationary covariance, shape ``(N, N)``.
-
-    Returns:
-        Process noise covariance Q, shape ``(N, N)``.
-    """
-    return Pinf - A @ Pinf @ A.T

--- a/src/gaussx/_operators/__init__.py
+++ b/src/gaussx/_operators/__init__.py
@@ -40,6 +40,7 @@ from gaussx._operators._low_rank_update import (
 from gaussx._operators._masked import MaskedOperator
 from gaussx._operators._sum_kronecker import (
     SumKronecker,
+    SumOfKroneckers,
     sumkronecker_sample as sumkronecker_sample,
 )
 from gaussx._operators._toeplitz import Toeplitz, ToeplitzCholesky, toeplitz_sample
@@ -280,21 +281,21 @@ def _(operator: Toeplitz) -> bool:
 # whose tag propagation lineax provides out of the box.
 
 
-# SumKronecker tag registrations
+# SumOfKroneckers tag registrations
 
 
-@lx.is_symmetric.register(SumKronecker)
-def _(operator: SumKronecker) -> bool:
+@lx.is_symmetric.register(SumOfKroneckers)
+def _(operator: SumOfKroneckers) -> bool:
     return all(lx.is_symmetric(kron) for kron in operator.operators)
 
 
-@lx.is_diagonal.register(SumKronecker)
-def _(operator: SumKronecker) -> bool:
+@lx.is_diagonal.register(SumOfKroneckers)
+def _(operator: SumOfKroneckers) -> bool:
     return False
 
 
-@lx.is_positive_semidefinite.register(SumKronecker)
-def _(operator: SumKronecker) -> bool:
+@lx.is_positive_semidefinite.register(SumOfKroneckers)
+def _(operator: SumOfKroneckers) -> bool:
     return lx.positive_semidefinite_tag in operator.tags
 
 
@@ -431,8 +432,8 @@ def _(operator: Toeplitz) -> bool:
     return lx.negative_semidefinite_tag in operator.tags
 
 
-@lx.is_negative_semidefinite.register(SumKronecker)
-def _(operator: SumKronecker) -> bool:
+@lx.is_negative_semidefinite.register(SumOfKroneckers)
+def _(operator: SumOfKroneckers) -> bool:
     return lx.negative_semidefinite_tag in operator.tags
 
 
@@ -474,7 +475,7 @@ _ALL_TRIDIAG_DEFAULTS = (
     ImplicitKernelOperator,
     MaskedOperator,
     Toeplitz,
-    SumKronecker,
+    SumOfKroneckers,
     InterpolatedOperator,
     KernelOperator,
     ImplicitCrossKernelOperator,
@@ -491,7 +492,7 @@ _TRI_DEFAULTS = (
     ImplicitKernelOperator,
     MaskedOperator,
     Toeplitz,
-    SumKronecker,
+    SumOfKroneckers,
     InterpolatedOperator,
     KernelOperator,
     ImplicitCrossKernelOperator,
@@ -542,6 +543,7 @@ __all__ = [
     "SVDLowRankUpdate",
     "ScaledOperator",
     "SumKronecker",
+    "SumOfKroneckers",
     "SumOperator",
     "Toeplitz",
     "ToeplitzCholesky",

--- a/src/gaussx/_operators/_implicit_cross_kernel.py
+++ b/src/gaussx/_operators/_implicit_cross_kernel.py
@@ -147,6 +147,20 @@ class ImplicitCrossKernelOperator(lx.AbstractLinearOperator):
     Adjoint / transpose computes ``K^T u = K(Z, X) u``, mapping an
     ``N``-vector to an ``M``-vector.
 
+    **Contract** (see the operators API page for the full comparison):
+
+    | Property | Value |
+    |---|---|
+    | Shape | Rectangular ``(N, M)`` — data rows against inducing columns |
+    | Evaluation | ``lax.scan`` over ``batch_size``-row chunks of ``X_data`` |
+    | Peak memory | ``O(batch_size * M)`` per step; ``(N, M)`` never formed |
+    | Noise term | None |
+    | Kernel signature | ``k(x, z)``, or ``k(params, x, z)`` with ``params=`` |
+
+    The tunable ``batch_size`` is what distinguishes this from
+    `KernelOperator`, which is also rectangular and scan-based but fixed
+    at one row per step: raising it trades peak memory for throughput.
+
     Supports two kernel signatures:
 
     - **No params** (default): ``k(x, z) -> scalar``.

--- a/src/gaussx/_operators/_implicit_kernel.py
+++ b/src/gaussx/_operators/_implicit_kernel.py
@@ -98,6 +98,20 @@ class ImplicitKernelOperator(lx.AbstractLinearOperator):
     The scan-based implementation is compatible with CG / BBMM solvers
     that only need matvec access.
 
+    **Contract** (see the operators API page for the full comparison):
+
+    | Property | Value |
+    |---|---|
+    | Shape | Square ``(N, N)`` — a single point set ``X`` |
+    | Evaluation | ``lax.scan`` over rows of ``X``, one row per step |
+    | Peak memory | ``O(N)`` per step; the ``(N, N)`` matrix is never formed |
+    | Noise term | **Fused** — applies ``K + noise_var * I`` in one pass |
+    | Kernel signature | ``k(x, x')``, or ``k(params, x, x')`` with ``params=`` |
+
+    The fused noise term is the reason to prefer this over
+    `KernelOperator` for a training covariance: ``K`` and ``sigma^2 I``
+    never exist as separate operators at scale.
+
     Supports two kernel signatures:
 
     - **No params** (default): ``k(x, x') -> scalar``.  Hyperparameters

--- a/src/gaussx/_operators/_kernel.py
+++ b/src/gaussx/_operators/_kernel.py
@@ -113,6 +113,21 @@ class KernelOperator(lx.AbstractLinearOperator):
     ``jax.custom_jvp`` keeps first-order autodiff efficient without
     materializing Jacobians.
 
+    **Contract** (see the operators API page for the full comparison):
+
+    | Property | Value |
+    |---|---|
+    | Shape | Rectangular ``(N, M)`` — ``X1`` and ``X2`` are independent |
+    | Evaluation | ``lax.scan`` over rows of ``X1``, one row per step |
+    | Peak memory | ``O(M)`` per step; the ``(N, M)`` block is never formed |
+    | Noise term | None — this is ``K``, not ``K + sigma^2 I`` |
+    | Kernel signature | ``k(params, x, x')``; ``params`` is a required argument |
+
+    Reach for this when you need a general kernel block. For a *square*
+    training covariance with the noise term fused in, use
+    `ImplicitKernelOperator`; for a data-inducing block where you want to
+    tune the scan chunk size, use `ImplicitCrossKernelOperator`.
+
     Batched inputs are supported: ``X1`` and ``X2`` may carry leading
     batch dimensions ``(*batch, N, D)`` / ``(*batch, M, D)`` (with
     matching ``*batch``). In that case ``mv`` expects a vector of shape

--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -13,7 +13,7 @@ from gaussx._operators._block_diag import _resolve_dtype, _to_frozenset
 from gaussx._operators._kronecker import Kronecker
 
 
-class SumKronecker(lx.AbstractLinearOperator):
+class SumOfKroneckers(lx.AbstractLinearOperator):
     r"""Sum of Kronecker products ``Σ_k A_k \otimes B_k``.
 
     Appears in multi-output GPs with correlated outputs, e.g.
@@ -27,6 +27,11 @@ class SumKronecker(lx.AbstractLinearOperator):
     dense ``(n_c n_d) x (n_c n_d)`` matrix internally, so it is
     intended for moderate factor sizes (typical for multi-output GPs
     where the task dimension is small).
+
+    Not to be confused with `KroneckerSum`, which is the standard
+    matrix-theory Kronecker *sum* ``A \otimes I + I \otimes B`` — a
+    different object with a closed-form eigendecomposition. This class is a
+    sum of arbitrary Kronecker *products*, which has none in general.
 
     Args:
         kron1: First Kronecker product ``A_1 \otimes B_1``.
@@ -49,7 +54,7 @@ class SumKronecker(lx.AbstractLinearOperator):
     ) -> None:
         operators = (kron1, kron2, *krons)
         if any(len(kron.operators) != 2 for kron in operators):
-            raise ValueError("SumKronecker requires two-factor Kronecker products.")
+            raise ValueError("SumOfKroneckers requires two-factor Kronecker products.")
         if any(kron.in_size() != kron1.in_size() for kron in operators[1:]):
             raise ValueError("Kronecker products must have the same size (input size).")
         if any(kron.out_size() != kron1.out_size() for kron in operators[1:]):
@@ -82,8 +87,8 @@ class SumKronecker(lx.AbstractLinearOperator):
             result = result + kron.as_matrix()
         return result
 
-    def transpose(self) -> SumKronecker:
-        return SumKronecker(
+    def transpose(self) -> SumOfKroneckers:
+        return SumOfKroneckers(
             *(
                 Kronecker(
                     kron.operators[0].T,
@@ -167,7 +172,7 @@ class SumKronecker(lx.AbstractLinearOperator):
 
 
 def sumkronecker_sample(
-    op: SumKronecker,
+    op: SumOfKroneckers,
     *,
     key: jax.Array,
     num_samples: int = 1,
@@ -177,11 +182,11 @@ def sumkronecker_sample(
 
     The square-root action is evaluated by ``matfree`` Lanczos against
     ``op.mv``. This avoids materialising the dense ``(n_A n_B) ×
-    (n_A n_B)`` covariance and costs ``lanczos_order`` SumKronecker
+    (n_A n_B)`` covariance and costs ``lanczos_order`` operator
     matvecs per sample.
 
     Args:
-        op: Positive-semidefinite SumKronecker covariance operator.
+        op: Positive-semidefinite `SumOfKroneckers` covariance operator.
         key: JAX PRNG key.
         num_samples: Number of independent samples to draw.
         lanczos_order: Lanczos truncation order.
@@ -193,7 +198,7 @@ def sumkronecker_sample(
 
     if op.in_size() != op.out_size():
         raise ValueError(
-            "sumkronecker_sample requires a square SumKronecker, got "
+            "sumkronecker_sample requires a square SumOfKroneckers, got "
             f"in_size={op.in_size()} and out_size={op.out_size()}."
         )
     if num_samples < 1:
@@ -204,3 +209,40 @@ def sumkronecker_sample(
         key, (num_samples, op.in_size()), dtype=op.in_structure().dtype
     )
     return jax.vmap(sqrt_op.mv)(eps)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated compatibility class
+# ---------------------------------------------------------------------------
+
+
+class SumKronecker(SumOfKroneckers):
+    """Deprecated alias for `SumOfKroneckers`.
+
+    The old name was one word-order away from `KroneckerSum`, a
+    different operator with a different eigendecomposition — picking the wrong
+    one produced silently wrong solves. Renamed in gh-136.
+
+    Subclasses `SumOfKroneckers` so ``isinstance`` checks and
+    ``singledispatch`` registrations keyed on this class keep working, and
+    emits a `DeprecationWarning` on construction. Note that instances built
+    via `SumOfKroneckers` are *not* instances of this subclass; internal
+    dispatch keys on the parent. Will be removed in a future release.
+    """
+
+    def __init__(
+        self,
+        kron1: Kronecker,
+        kron2: Kronecker,
+        *krons: Kronecker,
+        tags: object | frozenset[object] = frozenset(),
+    ) -> None:
+        import warnings
+
+        warnings.warn(
+            "SumKronecker is deprecated; use SumOfKroneckers "
+            "(KroneckerSum remains a different operator).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(kron1, kron2, *krons, tags=tags)

--- a/src/gaussx/_operators/_sum_kronecker.py
+++ b/src/gaussx/_operators/_sum_kronecker.py
@@ -88,7 +88,11 @@ class SumOfKroneckers(lx.AbstractLinearOperator):
         return result
 
     def transpose(self) -> SumOfKroneckers:
-        return SumOfKroneckers(
+        # ``type(self)`` rather than the literal class so the deprecated
+        # `SumKronecker` subclass survives a transpose — external
+        # ``isinstance`` checks and ``singledispatch`` registrations keyed on
+        # it would otherwise silently stop applying on ``op.T``.
+        return type(self)(
             *(
                 Kronecker(
                     kron.operators[0].T,
@@ -225,9 +229,11 @@ class SumKronecker(SumOfKroneckers):
 
     Subclasses `SumOfKroneckers` so ``isinstance`` checks and
     ``singledispatch`` registrations keyed on this class keep working, and
-    emits a `DeprecationWarning` on construction. Note that instances built
-    via `SumOfKroneckers` are *not* instances of this subclass; internal
-    dispatch keys on the parent. Will be removed in a future release.
+    emits a `DeprecationWarning` on construction. Structural operations that
+    rebuild the operator — ``transpose`` / ``.T`` — preserve this type, so
+    they warn again. Note that instances built via `SumOfKroneckers` are
+    *not* instances of this subclass; internal dispatch keys on the parent.
+    Will be removed in a future release.
     """
 
     def __init__(

--- a/src/gaussx/_primitives/_cholesky.py
+++ b/src/gaussx/_primitives/_cholesky.py
@@ -10,7 +10,7 @@ import lineax as lx
 from gaussx._operators._block_diag import BlockDiag
 from gaussx._operators._block_tridiag import BlockTriDiag, LowerBlockTriDiag
 from gaussx._operators._kronecker import Kronecker
-from gaussx._operators._sum_kronecker import SumKronecker
+from gaussx._operators._sum_kronecker import SumOfKroneckers
 
 
 class DenseFallbackWarning(UserWarning):
@@ -41,7 +41,7 @@ def cholesky(
         return _cholesky_kronecker(operator)
     if isinstance(operator, BlockTriDiag):
         return _cholesky_block_tridiag(operator)
-    if isinstance(operator, SumKronecker):
+    if isinstance(operator, SumOfKroneckers):
         return _cholesky_sum_kronecker(operator)
     if isinstance(operator, lx.TaggedLinearOperator):
         return cholesky(operator.operator)
@@ -93,12 +93,12 @@ def _cholesky_block_tridiag(operator: BlockTriDiag) -> LowerBlockTriDiag:
     return LowerBlockTriDiag(L_diag, B_sub)
 
 
-def _cholesky_sum_kronecker(operator: SumKronecker) -> lx.MatrixLinearOperator:
+def _cholesky_sum_kronecker(operator: SumOfKroneckers) -> lx.MatrixLinearOperator:
     import warnings
 
     warnings.warn(
-        "cholesky(SumKronecker) materialises the dense covariance. "
-        "Use sumkronecker_sample(...) or sqrt(SumKronecker) for matrix-free "
+        "cholesky(SumOfKroneckers) materialises the dense covariance. "
+        "Use sumkronecker_sample(...) or sqrt(SumOfKroneckers) for matrix-free "
         "Lanczos sampling.",
         DenseFallbackWarning,
         stacklevel=2,

--- a/src/gaussx/_primitives/_diag.py
+++ b/src/gaussx/_primitives/_diag.py
@@ -19,7 +19,7 @@ from gaussx._operators._block_tridiag import (
 from gaussx._operators._kronecker import Kronecker
 from gaussx._operators._kronecker_sum import KroneckerSum
 from gaussx._operators._low_rank_update import LowRankUpdate
-from gaussx._operators._sum_kronecker import SumKronecker
+from gaussx._operators._sum_kronecker import SumOfKroneckers
 from gaussx._primitives._samplers import SamplerName, resolve_sampler
 
 
@@ -61,7 +61,7 @@ def diag(
         return _diag_low_rank(operator)
     if isinstance(operator, KroneckerSum):
         return _diag_kronecker_sum(operator)
-    if isinstance(operator, SumKronecker):
+    if isinstance(operator, SumOfKroneckers):
         return ft.reduce(jnp.add, (diag(kron) for kron in operator.operators))
     if isinstance(operator, lx.TaggedLinearOperator):
         return diag(

--- a/src/gaussx/_primitives/_sqrt.py
+++ b/src/gaussx/_primitives/_sqrt.py
@@ -11,7 +11,7 @@ import matfree.funm
 from gaussx._operators._block_diag import BlockDiag, _resolve_dtype
 from gaussx._operators._kronecker import Kronecker
 from gaussx._operators._kronecker_sum import KroneckerSum, KroneckerSumSqrt
-from gaussx._operators._sum_kronecker import SumKronecker
+from gaussx._operators._sum_kronecker import SumOfKroneckers
 
 
 _DEFAULT_LANCZOS_ORDER = 50
@@ -34,7 +34,7 @@ def sqrt(
         operator: A PSD linear operator.
         lanczos_order: Order of Lanczos iteration for matrix-free
             sqrt. If ``None``, uses dense eigendecomposition for most
-            operators, *except* `SumKronecker` — where ``None``
+            operators, *except* `SumOfKroneckers` — where ``None``
             falls back to a Lanczos sqrt with the module default order
             (no closed-form sqrt exists for the sum-of-Kronecker
             structure). Pass an explicit ``lanczos_order`` to override
@@ -55,7 +55,7 @@ def sqrt(
         return _sqrt_kronecker(operator)
     if isinstance(operator, KroneckerSum):
         return _sqrt_kronecker_sum(operator)
-    if isinstance(operator, SumKronecker):
+    if isinstance(operator, SumOfKroneckers):
         return _sqrt_sum_kronecker(
             operator,
             lanczos_order=(
@@ -87,7 +87,7 @@ def _sqrt_kronecker_sum(operator: KroneckerSum) -> KroneckerSumSqrt:
 
 
 def _sqrt_sum_kronecker(
-    operator: SumKronecker,
+    operator: SumOfKroneckers,
     *,
     lanczos_order: int = _DEFAULT_LANCZOS_ORDER,
 ) -> SumKroneckerSqrt:
@@ -152,24 +152,24 @@ class SqrtOperator(lx.AbstractLinearOperator):
 
 
 class SumKroneckerSqrt(SqrtOperator):
-    """Lazy Lanczos square-root operator for ``SumKronecker`` covariances.
+    """Lazy Lanczos square-root operator for ``SumOfKroneckers`` covariances.
 
     Specialization of `SqrtOperator` that narrows ``original`` to a
-    `SumKronecker` operator. `mv` computes ``sqrt(A) v`` via
+    `SumOfKroneckers` operator. `mv` computes ``sqrt(A) v`` via
     matfree's Lanczos matrix-function product without materializing the full
     square root.
 
     Args:
-        original: The ``SumKronecker`` covariance to take the square root of.
+        original: The ``SumOfKroneckers`` covariance to take the square root of.
         lanczos_order: Number of Lanczos iterations; clamped to the operator
             size.
     """
 
-    original: SumKronecker
+    original: SumOfKroneckers
 
     def __init__(
         self,
-        original: SumKronecker,
+        original: SumOfKroneckers,
         lanczos_order: int = _DEFAULT_LANCZOS_ORDER,
     ) -> None:
         super().__init__(original, lanczos_order=lanczos_order)

--- a/src/gaussx/_primitives/_trace.py
+++ b/src/gaussx/_primitives/_trace.py
@@ -16,7 +16,7 @@ from gaussx._operators._block_tridiag import BlockTriDiag
 from gaussx._operators._kronecker import Kronecker
 from gaussx._operators._kronecker_sum import KroneckerSum
 from gaussx._operators._low_rank_update import LowRankUpdate
-from gaussx._operators._sum_kronecker import SumKronecker
+from gaussx._operators._sum_kronecker import SumOfKroneckers
 from gaussx._primitives._samplers import SamplerName, resolve_sampler
 
 
@@ -64,7 +64,7 @@ def trace(
         return _trace_low_rank(operator)
     if isinstance(operator, KroneckerSum):
         return _trace_kronecker_sum(operator)
-    if isinstance(operator, SumKronecker):
+    if isinstance(operator, SumOfKroneckers):
         return ft.reduce(jnp.add, (trace(kron) for kron in operator.operators))
     if isinstance(operator, lx.TaggedLinearOperator):
         return trace(

--- a/src/gaussx/_ssm/__init__.py
+++ b/src/gaussx/_ssm/__init__.py
@@ -9,6 +9,7 @@ from gaussx._ssm._cvi import (
     sites_to_precision,
 )
 from gaussx._ssm._dare import DAREResult, dare
+from gaussx._ssm._discretise import process_noise_covariance
 from gaussx._ssm._emission import EmissionModel
 from gaussx._ssm._infinite_horizon_kalman import (
     InfiniteHorizonState,
@@ -70,6 +71,7 @@ __all__ = [
     "pairwise_marginals",
     "parallel_kalman_filter",
     "parallel_rts_smoother",
+    "process_noise_covariance",
     "rts_smoother",
     "sde_autocovariance",
     "site_mean_var_from_natural",

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 import jax.scipy.linalg as jsl
+import lineax as lx
 from jaxtyping import Array, Float
 
 from gaussx._linalg._symmetrize import symmetrize
+from gaussx._operators._kronecker import Kronecker
+from gaussx._ssm._discretise import process_noise_covariance
 from gaussx._ssm._sde_kernel import SDEKernel, SDEParams
 
 
@@ -113,10 +116,19 @@ class ProductSDE(SDEKernel):
         size ``d_1 \cdot d_2``. Numerically equivalent to the dense
         ``expm`` on ``F`` but cheaper for moderate factor sizes.
 
-        ``Q = P_\infty - A P_\infty A^T`` is computed densely from the
-        resulting ``A``; with ``P_\infty = P_{\infty,1} \otimes
-        P_{\infty,2}`` this could itself be expressed as a Kronecker
-        difference, but is left dense to keep the consumer-facing
+        ``Q = P_\infty - A P_\infty A^T`` exploits the same factorisation.
+        By the mixed-product property,
+
+        $$
+        (A_1 \otimes A_2)(P_1 \otimes P_2)(A_1 \otimes A_2)^\top
+            = (A_1 P_1 A_1^\top) \otimes (A_2 P_2 A_2^\top),
+        $$
+
+        so the congruence is evaluated per factor via
+        `gaussx.process_noise_covariance` on `gaussx.Kronecker`
+        operands — ``O(d_1^3 + d_2^3)`` instead of the
+        ``O((d_1 d_2)^3)`` triple product on the full matrix. Only the
+        final ``Q`` is materialised, to keep the consumer-facing
         ``(A, Q)`` interface unchanged.
 
         Args:
@@ -133,10 +145,18 @@ class ProductSDE(SDEKernel):
 
         # Use the per-factor stationary covariances directly; building
         # the full ``F`` via ``self.sde_params()`` would defeat the
-        # whole point of this override.
-        P_inf = jnp.kron(p1.P_inf, p2.P_inf)
-        Q = P_inf - A @ P_inf @ A.T
-        Q = symmetrize(Q)
+        # whole point of this override. Keeping both operands as
+        # ``Kronecker`` lets the shared helper contract each factor
+        # separately instead of forming the (d1 d2)-square triple product.
+        A_op = Kronecker(
+            lx.MatrixLinearOperator(A1),
+            lx.MatrixLinearOperator(A2),
+        )
+        P_op = Kronecker(
+            lx.MatrixLinearOperator(p1.P_inf, lx.symmetric_tag),
+            lx.MatrixLinearOperator(p2.P_inf, lx.symmetric_tag),
+        )
+        Q = symmetrize(process_noise_covariance(A_op, P_op).as_matrix())
         return A, Q
 
 

--- a/src/gaussx/_ssm/_discretise.py
+++ b/src/gaussx/_ssm/_discretise.py
@@ -1,0 +1,40 @@
+"""Exact discretisation of stationary linear SDEs.
+
+Leaf module (no gaussx imports) so both `gaussx._ssm._sde_kernel` and the
+backwards-compatible `gaussx._inference` re-export can depend on it without
+an import cycle.
+"""
+
+from __future__ import annotations
+
+from jaxtyping import Array, Float
+
+
+def process_noise_covariance(
+    A: Float[Array, "N N"],
+    Pinf: Float[Array, "N N"],
+) -> Float[Array, "N N"]:
+    """Compute process noise from stationary covariance.
+
+    Computes:
+
+        Q = Pinf - A @ Pinf @ A^T
+
+    For a discrete-time state-space model with stationary covariance
+    ``Pinf`` and transition matrix ``A``. This is the standard
+    "steady-state trick": it follows from stationarity of the discretised
+    recursion ``Pinf = A Pinf A^T + Q``, and avoids matrix-fraction
+    integration (Särkkä & Solin 2019, §6.4).
+
+    The result is not symmetrised — callers that need a covariance clean of
+    floating-point asymmetry should wrap the result in
+    `gaussx.symmetrize`, as `gaussx.SDEKernel.discretise` does.
+
+    Args:
+        A: State transition matrix, shape ``(N, N)``.
+        Pinf: Stationary covariance, shape ``(N, N)``.
+
+    Returns:
+        Process noise covariance Q, shape ``(N, N)``.
+    """
+    return Pinf - A @ Pinf @ A.T

--- a/src/gaussx/_ssm/_discretise.py
+++ b/src/gaussx/_ssm/_discretise.py
@@ -1,20 +1,41 @@
-"""Exact discretisation of stationary linear SDEs.
-
-Leaf module (no gaussx imports) so both `gaussx._ssm._sde_kernel` and the
-backwards-compatible `gaussx._inference` re-export can depend on it without
-an import cycle.
-"""
+"""Exact discretisation of stationary linear SDEs."""
 
 from __future__ import annotations
 
+from typing import overload
+
+import lineax as lx
 from jaxtyping import Array, Float
 
+from gaussx._linalg._linalg import cov_transform
 
+
+@overload
 def process_noise_covariance(
     A: Float[Array, "N N"],
     Pinf: Float[Array, "N N"],
-) -> Float[Array, "N N"]:
-    """Compute process noise from stationary covariance.
+) -> Float[Array, "N N"]: ...
+
+
+@overload
+def process_noise_covariance(
+    A: lx.AbstractLinearOperator,
+    Pinf: Float[Array, "N N"] | lx.AbstractLinearOperator,
+) -> lx.AbstractLinearOperator: ...
+
+
+@overload
+def process_noise_covariance(
+    A: Float[Array, "N N"] | lx.AbstractLinearOperator,
+    Pinf: lx.AbstractLinearOperator,
+) -> lx.AbstractLinearOperator: ...
+
+
+def process_noise_covariance(
+    A: Float[Array, "N N"] | lx.AbstractLinearOperator,
+    Pinf: Float[Array, "N N"] | lx.AbstractLinearOperator,
+) -> Float[Array, "N N"] | lx.AbstractLinearOperator:
+    r"""Compute process noise from stationary covariance.
 
     Computes:
 
@@ -26,15 +47,45 @@ def process_noise_covariance(
     recursion ``Pinf = A Pinf A^T + Q``, and avoids matrix-fraction
     integration (Särkkä & Solin 2019, §6.4).
 
-    The result is not symmetrised — callers that need a covariance clean of
-    floating-point asymmetry should wrap the result in
-    `gaussx.symmetrize`, as `gaussx.SDEKernel.discretise` does.
+    It is the forward direction of the discrete Lyapunov equation that
+    `gaussx.discrete_lyapunov_solve` inverts: this maps
+    ``Pinf -> Q``, that one maps ``Q -> Pinf`` for the same ``A``.
+
+    The ``A Pinf A^T`` term is delegated to
+    `gaussx.cov_transform`, so structure is exploited rather than
+    re-derived: a diagonal ``Pinf`` skips its ``(N, N)`` materialization, and
+    matched `gaussx.Kronecker` / `gaussx.BlockDiag`
+    operands stay factorised through `gaussx.sandwich`.
+
+    Passing **operators** returns a lazy operator — nothing is materialized,
+    and the structural class of the result follows `gaussx.sandwich`.
+    Passing **arrays** returns an array, as before.
+
+    The result is not symmetrised. Callers that need a covariance clean of
+    floating-point asymmetry should wrap it in `gaussx.symmetrize`,
+    as `gaussx.SDEKernel.discretise` does.
 
     Args:
-        A: State transition matrix, shape ``(N, N)``.
-        Pinf: Stationary covariance, shape ``(N, N)``.
+        A: State transition matrix, shape ``(N, N)`` — array or operator.
+        Pinf: Stationary covariance, shape ``(N, N)`` — array or operator.
 
     Returns:
-        Process noise covariance Q, shape ``(N, N)``.
+        Process noise covariance Q, shape ``(N, N)``. An operator when
+        either argument is an operator, otherwise an array.
     """
-    return Pinf - A @ Pinf @ A.T
+    Pinf_op = (
+        Pinf
+        if isinstance(Pinf, lx.AbstractLinearOperator)
+        else lx.MatrixLinearOperator(Pinf, lx.symmetric_tag)
+    )
+    # One implementation of the congruence, for both paths. Wrapping a dense
+    # ``Pinf`` costs nothing at runtime — it is pytree bookkeeping at trace
+    # time, and the dense branch of ``cov_transform`` evaluates the identical
+    # ``A @ Pinf @ A.T`` expression.
+    congruence = cov_transform(A, Pinf_op)
+
+    if isinstance(A, lx.AbstractLinearOperator) or isinstance(
+        Pinf, lx.AbstractLinearOperator
+    ):
+        return Pinf_op - congruence
+    return Pinf - congruence.as_matrix()

--- a/src/gaussx/_ssm/_sde_kernel.py
+++ b/src/gaussx/_ssm/_sde_kernel.py
@@ -11,6 +11,7 @@ import jax.scipy.linalg as jsl
 from jaxtyping import Array, Float
 
 from gaussx._linalg._symmetrize import symmetrize
+from gaussx._ssm._discretise import process_noise_covariance
 
 
 class SDEParams(NamedTuple):
@@ -79,8 +80,7 @@ class SDEKernel(eqx.Module):
         """
         params = self.sde_params()
         A = jsl.expm(params.F * dt)
-        Q = params.P_inf - A @ params.P_inf @ A.T
-        Q = symmetrize(Q)
+        Q = symmetrize(process_noise_covariance(A, params.P_inf))
         return A, Q
 
     def discretise_sequence(

--- a/tests/linalg/test_symmetrize.py
+++ b/tests/linalg/test_symmetrize.py
@@ -1,0 +1,55 @@
+"""Tests for symmetrize."""
+
+import jax
+import jax.numpy as jnp
+
+from gaussx import symmetrize
+
+
+class TestSymmetrize:
+    def test_matches_definition(self, getkey):
+        """Returns 0.5 * (A + A^T)."""
+        N = 5
+        A = jax.random.normal(getkey(), (N, N))
+        assert jnp.allclose(symmetrize(A), 0.5 * (A + A.T))
+
+    def test_result_is_symmetric(self, getkey):
+        """Output is symmetric even when the input is not."""
+        N = 6
+        A = jax.random.normal(getkey(), (N, N))
+        S = symmetrize(A)
+        assert jnp.allclose(S, S.T)
+
+    def test_idempotent_on_symmetric_input(self, getkey):
+        """A symmetric matrix round-trips unchanged."""
+        N = 4
+        A = jax.random.normal(getkey(), (N, N))
+        S = A + A.T
+        assert jnp.allclose(symmetrize(S), S)
+
+    def test_drops_only_the_skew_part(self, getkey):
+        """symmetrize(A) + skew(A) reconstructs A exactly."""
+        N = 5
+        A = jax.random.normal(getkey(), (N, N))
+        skew = 0.5 * (A - A.T)
+        assert jnp.allclose(symmetrize(A) + skew, A)
+
+    def test_batched_over_leading_axes(self, getkey):
+        """Operates on the trailing two axes of a batched stack."""
+        A = jax.random.normal(getkey(), (3, 2, 4, 4))
+        S = symmetrize(A)
+        assert S.shape == A.shape
+        assert jnp.allclose(S, jnp.swapaxes(S, -1, -2))
+        # Each batch element equals the unbatched result.
+        assert jnp.allclose(S[1, 0], symmetrize(A[1, 0]))
+
+    def test_jit(self, getkey):
+        """Works under jit."""
+        N = 4
+        A = jax.random.normal(getkey(), (N, N))
+        assert jnp.allclose(jax.jit(symmetrize)(A), symmetrize(A))
+
+    def test_vmap(self, getkey):
+        """Works under vmap."""
+        A = jax.random.normal(getkey(), (3, 4, 4))
+        assert jnp.allclose(jax.vmap(symmetrize)(A), symmetrize(A))

--- a/tests/operators/test_sum_kronecker.py
+++ b/tests/operators/test_sum_kronecker.py
@@ -484,6 +484,21 @@ class TestSumKroneckerDeprecatedAlias:
         new = SumOfKroneckers(k1, k2)
         assert tree_allclose(old.as_matrix(), new.as_matrix())
 
+    def test_transpose_preserves_the_alias_type(self, getkey):
+        """`isinstance(op.T, SumKronecker)` kept working across the rename."""
+        k1, k2 = self._krons(getkey)
+        with pytest.warns(DeprecationWarning):
+            old = SumKronecker(k1, k2)
+        with pytest.warns(DeprecationWarning):
+            transposed = old.T
+        assert isinstance(transposed, SumKronecker)
+        assert tree_allclose(transposed.as_matrix(), old.as_matrix().T)
+
+    def test_transpose_of_the_new_name_is_not_the_alias(self, getkey):
+        k1, k2 = self._krons(getkey)
+        new = SumOfKroneckers(k1, k2)
+        assert type(new.T) is SumOfKroneckers
+
     def test_dispatch_is_unchanged_through_the_alias(self, getkey):
         """trace / diag route through the parent class, not the alias."""
         k1, k2 = self._krons(getkey)

--- a/tests/operators/test_sum_kronecker.py
+++ b/tests/operators/test_sum_kronecker.py
@@ -1,4 +1,4 @@
-"""Tests for the SumKronecker operator."""
+"""Tests for the SumOfKroneckers operator."""
 
 from __future__ import annotations
 
@@ -9,8 +9,20 @@ import jax.random as jr
 import lineax as lx
 import pytest
 
-from gaussx._operators import Kronecker, SumKronecker, sumkronecker_sample
-from gaussx._primitives import DenseFallbackWarning, SumKroneckerSqrt, cholesky, sqrt
+from gaussx._operators import (
+    Kronecker,
+    SumKronecker,
+    SumOfKroneckers,
+    sumkronecker_sample,
+)
+from gaussx._primitives import (
+    DenseFallbackWarning,
+    SumKroneckerSqrt,
+    cholesky,
+    diag,
+    sqrt,
+    trace,
+)
 from gaussx._testing import tree_allclose
 
 
@@ -24,7 +36,7 @@ def _make_psd_sum_kronecker(getkey):
     B1 = _make_psd(getkey(), 3)
     A2 = _make_psd(getkey(), 2)
     B2 = _make_psd(getkey(), 3)
-    return SumKronecker(
+    return SumOfKroneckers(
         Kronecker(
             lx.MatrixLinearOperator(A1, lx.positive_semidefinite_tag),
             lx.MatrixLinearOperator(B1, lx.positive_semidefinite_tag),
@@ -48,7 +60,7 @@ class TestConstruction:
         B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
         A2 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
         B2 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         assert SK.in_size() == 6
         assert SK.out_size() == 6
 
@@ -60,7 +72,7 @@ class TestConstruction:
             )
             for _ in range(3)
         ]
-        SK = SumKronecker(*terms)
+        SK = SumOfKroneckers(*terms)
         expected = terms[0].as_matrix()
         for term in terms[1:]:
             expected = expected + term.as_matrix()
@@ -73,7 +85,7 @@ class TestConstruction:
         k3 = Kronecker(A, B, C)
         k2 = Kronecker(A, B)
         with pytest.raises(ValueError, match="two-factor"):
-            SumKronecker(k3, k2)
+            SumOfKroneckers(k3, k2)
 
     def test_rejects_input_size_mismatch(self, getkey):
         k1 = Kronecker(
@@ -85,7 +97,7 @@ class TestConstruction:
             lx.MatrixLinearOperator(jr.normal(getkey(), (4, 4))),
         )
         with pytest.raises(ValueError, match="same size"):
-            SumKronecker(k1, k2)
+            SumOfKroneckers(k1, k2)
 
     def test_rejects_output_size_mismatch(self, getkey):
         k1 = Kronecker(
@@ -97,7 +109,7 @@ class TestConstruction:
             lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3))),
         )
         with pytest.raises(ValueError, match="output size"):
-            SumKronecker(k1, k2)
+            SumOfKroneckers(k1, k2)
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +123,7 @@ class TestMv:
         B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
         A2 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
         B2 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         v = jr.normal(getkey(), (6,))
         assert tree_allclose(SK.mv(v), SK.as_matrix() @ v)
 
@@ -122,7 +134,7 @@ class TestMv:
         sigma2 = 0.1
         I_a = lx.MatrixLinearOperator(jnp.sqrt(sigma2) * jnp.eye(2))
         I_b = lx.MatrixLinearOperator(jnp.sqrt(sigma2) * jnp.eye(3))
-        SK = SumKronecker(Kronecker(A, B), Kronecker(I_a, I_b))
+        SK = SumOfKroneckers(Kronecker(A, B), Kronecker(I_a, I_b))
         v = jr.normal(getkey(), (6,))
         expected = SK.as_matrix() @ v
         assert tree_allclose(SK.mv(v), expected)
@@ -139,7 +151,7 @@ class TestAsMatrix:
         B1_mat = jr.normal(getkey(), (3, 3))
         A2_mat = jr.normal(getkey(), (2, 2))
         B2_mat = jr.normal(getkey(), (3, 3))
-        SK = SumKronecker(
+        SK = SumOfKroneckers(
             Kronecker(
                 lx.MatrixLinearOperator(A1_mat),
                 lx.MatrixLinearOperator(B1_mat),
@@ -164,7 +176,7 @@ class TestTranspose:
         B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
         A2 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
         B2 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         assert tree_allclose(SK.T.as_matrix(), SK.as_matrix().T)
 
     def test_transpose_mv(self, getkey):
@@ -172,7 +184,7 @@ class TestTranspose:
         B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
         A2 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
         B2 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         v = jr.normal(getkey(), (6,))
         assert tree_allclose(SK.T.mv(v), SK.as_matrix().T @ v)
 
@@ -188,7 +200,7 @@ class TestTags:
         B1 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
         A2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (2,)))
         B2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         assert lx.is_symmetric(SK) is True
 
     def test_not_symmetric_when_factor_not_symmetric(self, getkey):
@@ -196,7 +208,7 @@ class TestTags:
         B1 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
         A2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (2,)))
         B2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         assert lx.is_symmetric(SK) is False
 
     def test_not_diagonal(self, getkey):
@@ -204,7 +216,7 @@ class TestTags:
         B1 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
         A2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (2,)))
         B2 = lx.DiagonalLinearOperator(jr.normal(getkey(), (3,)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         assert lx.is_diagonal(SK) is False
 
 
@@ -219,7 +231,7 @@ class TestEigendecompose:
         B1 = _make_psd(getkey(), 3)
         A2 = _make_psd(getkey(), 2)
         B2 = _make_psd(getkey(), 3)
-        SK = SumKronecker(
+        SK = SumOfKroneckers(
             Kronecker(
                 lx.MatrixLinearOperator(A1, lx.positive_semidefinite_tag),
                 lx.MatrixLinearOperator(B1, lx.positive_semidefinite_tag),
@@ -239,7 +251,7 @@ class TestEigendecompose:
         B1 = _make_psd(getkey(), 2)
         A2 = _make_psd(getkey(), 3)
         B2 = _make_psd(getkey(), 2)
-        SK = SumKronecker(
+        SK = SumOfKroneckers(
             Kronecker(
                 lx.MatrixLinearOperator(A1, lx.positive_semidefinite_tag),
                 lx.MatrixLinearOperator(B1, lx.positive_semidefinite_tag),
@@ -257,7 +269,7 @@ class TestEigendecompose:
         B1 = _make_psd(getkey(), 3)
         A2 = _make_psd(getkey(), 2)
         B2 = _make_psd(getkey(), 3)
-        SK = SumKronecker(
+        SK = SumOfKroneckers(
             Kronecker(
                 lx.MatrixLinearOperator(A1, lx.positive_semidefinite_tag),
                 lx.MatrixLinearOperator(B1, lx.positive_semidefinite_tag),
@@ -284,7 +296,7 @@ class TestJAX:
         B1 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
         A2 = lx.MatrixLinearOperator(jr.normal(getkey(), (2, 2)))
         B2 = lx.MatrixLinearOperator(jr.normal(getkey(), (3, 3)))
-        SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+        SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
         v = jr.normal(getkey(), (6,))
 
         @eqx.filter_jit
@@ -300,7 +312,7 @@ class TestJAX:
         v = jr.normal(getkey(), (6,))
 
         def loss(a1_mat):
-            SK = SumKronecker(
+            SK = SumOfKroneckers(
                 Kronecker(
                     lx.MatrixLinearOperator(a1_mat),
                     lx.MatrixLinearOperator(B1_mat),
@@ -319,7 +331,7 @@ class TestJAX:
 
 
 def test_eigendecompose_supports_diagonal_kron2_factors(getkey, monkeypatch):
-    """SumKronecker.eigendecompose accepts Diagonal kron2 factors and
+    """SumOfKroneckers.eigendecompose accepts Diagonal kron2 factors and
     routes their per-factor eig through the structural primitive,
     *not* through ``jnp.linalg.eigh`` on a materialized matrix.
 
@@ -342,7 +354,7 @@ def test_eigendecompose_supports_diagonal_kron2_factors(getkey, monkeypatch):
     B1 = lx.MatrixLinearOperator(B1_mat, lx.symmetric_tag)
     A2 = lx.DiagonalLinearOperator(A2_diag)
     B2 = lx.DiagonalLinearOperator(B2_diag)
-    SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+    SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
 
     # Wrap jnp.linalg.eigh so we can count calls and inspect argument
     # shapes. The Diagonal-factor path should produce *exactly one*
@@ -376,7 +388,7 @@ def test_eigendecompose_rejects_nonsymmetric_kron1(getkey):
     B2_mat = jr.normal(getkey(), (3, 3))
     A2 = lx.MatrixLinearOperator(A2_mat @ A2_mat.T, lx.symmetric_tag)
     B2 = lx.MatrixLinearOperator(B2_mat @ B2_mat.T, lx.symmetric_tag)
-    SK = SumKronecker(Kronecker(A1, B1), Kronecker(A2, B2))
+    SK = SumOfKroneckers(Kronecker(A1, B1), Kronecker(A2, B2))
 
     with pytest.raises(ValueError, match="kron1 factors"):
         SK.eigendecompose()
@@ -387,9 +399,9 @@ def test_sqrt_sum_kronecker_returns_lanczos_operator(getkey, monkeypatch):
     v = jr.normal(getkey(), (SK.in_size(),))
 
     def fail_as_matrix(self):
-        raise AssertionError("Lanczos sqrt should use SumKronecker.mv")
+        raise AssertionError("Lanczos sqrt should use SumOfKroneckers.mv")
 
-    monkeypatch.setattr(SumKronecker, "as_matrix", fail_as_matrix)
+    monkeypatch.setattr(SumOfKroneckers, "as_matrix", fail_as_matrix)
     sqrt_op = sqrt(SK, lanczos_order=SK.in_size())
     assert isinstance(sqrt_op, SumKroneckerSqrt)
     result = sqrt_op.mv(v)
@@ -436,3 +448,53 @@ def test_sumkronecker_sample_rejects_nonpositive_num_samples(getkey):
     SK = _make_psd_sum_kronecker(getkey)
     with pytest.raises(ValueError, match="num_samples"):
         sumkronecker_sample(SK, key=getkey(), num_samples=0)
+
+
+class TestSumKroneckerDeprecatedAlias:
+    """`SumKronecker` was renamed to `SumOfKroneckers` (gh-136).
+
+    The old name was one word-order away from `KroneckerSum`, a different
+    operator with a different eigendecomposition.
+    """
+
+    def _krons(self, getkey):
+        A = lx.MatrixLinearOperator(_make_psd(getkey(), 2), lx.symmetric_tag)
+        B = lx.MatrixLinearOperator(_make_psd(getkey(), 3), lx.symmetric_tag)
+        return Kronecker(A, B), Kronecker(A, B)
+
+    def test_construction_warns(self, getkey):
+        k1, k2 = self._krons(getkey)
+        with pytest.warns(DeprecationWarning, match="SumKronecker is deprecated"):
+            SumKronecker(k1, k2)
+
+    def test_alias_is_a_subclass(self):
+        assert issubclass(SumKronecker, SumOfKroneckers)
+
+    def test_alias_instances_pass_isinstance_checks(self, getkey):
+        """Existing `isinstance(x, SumOfKroneckers)` dispatch keeps working."""
+        k1, k2 = self._krons(getkey)
+        with pytest.warns(DeprecationWarning):
+            op = SumKronecker(k1, k2)
+        assert isinstance(op, SumOfKroneckers)
+
+    def test_alias_builds_an_equivalent_operator(self, getkey):
+        k1, k2 = self._krons(getkey)
+        with pytest.warns(DeprecationWarning):
+            old = SumKronecker(k1, k2)
+        new = SumOfKroneckers(k1, k2)
+        assert tree_allclose(old.as_matrix(), new.as_matrix())
+
+    def test_dispatch_is_unchanged_through_the_alias(self, getkey):
+        """trace / diag route through the parent class, not the alias."""
+        k1, k2 = self._krons(getkey)
+        with pytest.warns(DeprecationWarning):
+            old = SumKronecker(k1, k2)
+        new = SumOfKroneckers(k1, k2)
+        assert tree_allclose(trace(old), trace(new))
+        assert tree_allclose(diag(old), diag(new))
+
+    def test_exported_from_top_level(self):
+        import gaussx
+
+        assert gaussx.SumOfKroneckers is SumOfKroneckers
+        assert gaussx.SumKronecker is SumKronecker

--- a/tests/primitives/test_structured_dispatch.py
+++ b/tests/primitives/test_structured_dispatch.py
@@ -17,7 +17,7 @@ from gaussx._operators import (
     Kronecker,
     KroneckerSum,
     LowRankUpdate,
-    SumKronecker,
+    SumOfKroneckers,
 )
 from gaussx._operators._block_tridiag import LowerBlockTriDiag, UpperBlockTriDiag
 from gaussx._primitives._cholesky import cholesky
@@ -95,7 +95,7 @@ class TestSumKroneckerDispatch:
     def sum_kron(self, getkey):
         k1 = Kronecker(_psd_operator(getkey(), 3), _psd_operator(getkey(), 4))
         k2 = Kronecker(_psd_operator(getkey(), 3), _psd_operator(getkey(), 4))
-        return SumKronecker(k1, k2)
+        return SumOfKroneckers(k1, k2)
 
     def test_diag(self, sum_kron):
         assert tree_allclose(diag(sum_kron), jnp.diag(sum_kron.as_matrix()))

--- a/tests/ssm/test_sde_kernels.py
+++ b/tests/ssm/test_sde_kernels.py
@@ -2,17 +2,20 @@
 
 import jax
 import jax.numpy as jnp
+import lineax as lx
 import pytest
 
 from gaussx import (
     ConstantSDE,
     CosineSDE,
+    Kronecker,
     MaternSDE,
     PeriodicSDE,
     ProductSDE,
     QuasiPeriodicSDE,
     SDEParams,
     SumSDE,
+    discrete_lyapunov_solve,
     process_noise_covariance,
     symmetrize,
 )
@@ -206,3 +209,109 @@ class TestDiscretiseSharesProcessNoiseHelper:
         kern = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=2)
         _, Q = kern.discretise(jnp.array(0.3))
         assert jnp.allclose(Q, Q.T, atol=1e-12)
+
+
+class TestProcessNoiseCovarianceReuse:
+    """`process_noise_covariance` delegates its congruence to `cov_transform`.
+
+    That keeps one implementation of ``A P A^T`` in the package and lets
+    structured operands stay factorised instead of being materialised.
+    """
+
+    def _factors(self):
+        A1 = jnp.array([[0.9, 0.0], [0.0, 0.7]])
+        A2 = jnp.array([[0.5, 0.1], [0.1, 0.6]])
+        P1 = jnp.array([[2.0, 0.0], [0.0, 1.0]])
+        P2 = jnp.array([[1.5, 0.2], [0.2, 1.1]])
+        return A1, A2, P1, P2
+
+    def test_array_inputs_return_arrays(self):
+        A1, _, P1, _ = self._factors()
+        Q = process_noise_covariance(A1, P1)
+        assert isinstance(Q, jnp.ndarray)
+        assert jnp.allclose(Q, P1 - A1 @ P1 @ A1.T)
+
+    def test_operator_inputs_stay_lazy(self):
+        """Operator operands return an operator, not a materialised array."""
+        A1, _, P1, _ = self._factors()
+        Q = process_noise_covariance(
+            lx.MatrixLinearOperator(A1),
+            lx.MatrixLinearOperator(P1, lx.symmetric_tag),
+        )
+        assert isinstance(Q, lx.AbstractLinearOperator)
+        assert jnp.allclose(Q.as_matrix(), P1 - A1 @ P1 @ A1.T, atol=1e-6)
+
+    def test_kronecker_operands_keep_kronecker_structure(self):
+        """The congruence term must not collapse to a dense block."""
+        A1, A2, P1, P2 = self._factors()
+        A_op = Kronecker(lx.MatrixLinearOperator(A1), lx.MatrixLinearOperator(A2))
+        P_op = Kronecker(
+            lx.MatrixLinearOperator(P1, lx.symmetric_tag),
+            lx.MatrixLinearOperator(P2, lx.symmetric_tag),
+        )
+        Q = process_noise_covariance(A_op, P_op)
+
+        # Q = P - (A P A^T); the subtracted term is the sandwich.
+        sandwiched = Q.operator2.operator
+        assert isinstance(sandwiched, Kronecker)
+
+        A_dense, P_dense = A_op.as_matrix(), P_op.as_matrix()
+        expected = P_dense - A_dense @ P_dense @ A_dense.T
+        assert jnp.allclose(Q.as_matrix(), expected, atol=1e-5)
+
+    def test_diagonal_covariance_matches_dense(self):
+        A1, _, _, _ = self._factors()
+        d = jnp.array([2.0, 3.0])
+        Q = process_noise_covariance(A1, lx.DiagonalLinearOperator(d))
+        P_dense = jnp.diag(d)
+        assert jnp.allclose(Q.as_matrix(), P_dense - A1 @ P_dense @ A1.T, atol=1e-6)
+
+    def test_inverts_discrete_lyapunov_solve(self):
+        """Q -> P_inf -> Q is a round trip; the two are inverse maps."""
+        A1, _, P1, _ = self._factors()
+        Q = process_noise_covariance(A1, P1)
+        P_recovered = discrete_lyapunov_solve(A1, Q)
+        assert jnp.allclose(P_recovered, P1, atol=1e-5)
+
+
+class TestProductSDEKroneckerDiscretisation:
+    """`ProductSDE.discretise` contracts per factor, not on the full matrix."""
+
+    def _kernel(self):
+        return QuasiPeriodicSDE(
+            kernel1=MaternSDE(
+                variance=jnp.array(1.3), lengthscale=jnp.array(0.7), order=2
+            ),
+            kernel2=PeriodicSDE(
+                variance=jnp.array(1.0),
+                lengthscale=jnp.array(1.0),
+                period=jnp.array(2.0),
+                n_harmonics=3,
+            ),
+        )
+
+    def test_matches_dense_triple_product(self):
+        """Per-factor congruence agrees with the full (d1*d2)-square form."""
+        kern = self._kernel()
+        dt = jnp.array(0.37)
+        A, Q = kern.discretise(dt)
+        params = kern.sde_params()
+        Q_dense = symmetrize(process_noise_covariance(A, params.P_inf))
+        assert jnp.allclose(Q, Q_dense, atol=1e-5)
+
+    def test_result_is_symmetric(self):
+        kern = self._kernel()
+        _, Q = kern.discretise(jnp.array(0.2))
+        assert jnp.allclose(Q, Q.T, atol=1e-12)
+
+    def test_jit_compatible(self):
+        kern = self._kernel()
+
+        @jax.jit
+        def get_AQ(dt):
+            return kern.discretise(dt)
+
+        A, Q = get_AQ(jnp.array(0.37))
+        A_ref, Q_ref = kern.discretise(jnp.array(0.37))
+        assert jnp.allclose(A, A_ref, atol=1e-6)
+        assert jnp.allclose(Q, Q_ref, atol=1e-6)

--- a/tests/ssm/test_sde_kernels.py
+++ b/tests/ssm/test_sde_kernels.py
@@ -13,6 +13,8 @@ from gaussx import (
     QuasiPeriodicSDE,
     SDEParams,
     SumSDE,
+    process_noise_covariance,
+    symmetrize,
 )
 
 
@@ -172,3 +174,35 @@ class TestDiscretiseSequence:
         A_seq, Q_seq = kern.discretise_sequence(dts)
         assert A_seq.shape == (3, 2, 2)
         assert Q_seq.shape == (3, 2, 2)
+
+
+class TestDiscretiseSharesProcessNoiseHelper:
+    """`SDEKernel.discretise` must not re-inline the process-noise formula.
+
+    Two copies of ``Q = P_inf - A P_inf A^T`` had already drifted once: the
+    kernel path symmetrised the result and the standalone helper did not.
+    These tests pin the base implementation to the shared helper so a future
+    change to the numerics lands in both places (gh-151).
+    """
+
+    @pytest.mark.parametrize("order", [0, 1, 2])
+    def test_matches_shared_helper(self, order):
+        kern = MaternSDE(
+            variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=order
+        )
+        A, Q = kern.discretise(jnp.array(0.1))
+        expected = symmetrize(process_noise_covariance(A, kern.sde_params().P_inf))
+        assert jnp.allclose(Q, expected, atol=1e-12)
+
+    def test_helper_is_reachable_from_both_import_paths(self):
+        """The pre-move `_inference` path keeps working."""
+        from gaussx._inference import process_noise_covariance as legacy
+        from gaussx._ssm import process_noise_covariance as current
+
+        assert legacy is current is process_noise_covariance
+
+    def test_discretised_covariance_is_symmetric(self):
+        """`discretise` symmetrises; the bare helper deliberately does not."""
+        kern = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=2)
+        _, Q = kern.discretise(jnp.array(0.3))
+        assert jnp.allclose(Q, Q.T, atol=1e-12)


### PR DESCRIPTION
Five small open issues in one PR, one commit each. Two of them turned out to rest on premises the code has since outgrown — details below.

Closes #202
Closes #151
Closes #136
Refs #135 (step 1 only)
Refs #106

---

## #202 — `symmetrize` was already done

The issue asks for `gaussx.symmetrize` with signature `Float[Array, "... n n"] -> Float[Array, "... n n"]`, batched over leading axes. That function already exists in `_linalg/_symmetrize.py`, is exported from the top level, and is implemented exactly as proposed. The only unmet item on the definition of done was **the unit test**, so that is what this adds: the defining identity, symmetry of the output, idempotence on symmetric input, exact reconstruction when the skew part is added back, batching, and `jit` / `vmap`.

## #151 — the predicted drift had already happened

`SDEKernel.discretise()` inlined `Q = P_inf - A P_inf A^T`, duplicating `process_noise_covariance`. The issue warned the two copies could diverge "if one later gains a symmetrisation and the other doesn't" — that had **already occurred**: the kernel path symmetrised the result, the standalone helper did not.

`process_noise_covariance` moves from `_inference/_inference.py` to a new leaf module `_ssm/_discretise.py` (exact discretisation of a stationary SDE is a state-space concept, not an inference one), and `discretise()` now calls it.

One deliberate deviation: **the symmetrisation stays at the call site** rather than moving into the helper. Folding it in would have silently changed the output of the public `process_noise_covariance` for asymmetric inputs, which the issue's "no public API change / bit-for-bit equality" requirement rules out.

No public API change — `gaussx.process_noise_covariance` still resolves, and `gaussx._inference` re-exports it from the leaf module so the historical import path yields the same object (asserted in a test).

## #135 step 1 — the memory premise is stale

The issue distinguishes the three kernel operators as *"double vmap, O(NM)"* versus *"scan, O(N)"*. That is no longer true: **all three are scan-based today**. (They do not all carry a `jax.custom_jvp` unconditionally, as an earlier draft of this PR claimed: `KernelOperator` always does, while the two `Implicit*` operators only do when `params=` is passed. That is now spelled out in the table below.) `KernelOperator`'s own docstring already said "computed via scan (O(N) memory)".

So *implicit* is not the discriminator the issue says it is — **but neither would *scan* be**, which weakens the proposed `ScanKernelOperator` / `ScanCrossKernelOperator` rename. I have left step 2 open for you rather than adopting a prefix that does not discriminate either.

What step 1 does document, as a table in each class docstring plus a comparison table and a naming rule on the operators reference page, is what actually separates them:

| | `KernelOperator` | `ImplicitKernelOperator` | `ImplicitCrossKernelOperator` |
|---|---|---|---|
| Shape | Rectangular $(N, M)$ | Square $(N, N)$ | Rectangular $(N, M)$ |
| Noise term | — | **fused** `+ noise_var * I` | — |
| Scan step | one row of `X1` | one row of `X` | `batch_size` rows (default 1024) |
| Peak memory/step | $O(M)$ | $O(N)$ | $O(\texttt{batch\_size} \times M)$ |
| Kernel signature | `k(params, x, x')` (required) | `k(x, x')` or `k(params, x, x')` | `k(x, z)` or `k(params, x, z)` |
| `jax.custom_jvp` | always | only with `params=` | only with `params=` |

## #136 — `SumKronecker` → `SumOfKroneckers`

Adopts the name the issue recommends. `SumKronecker` survives as a deprecated subclass that warns on construction — following the `SVDLowRankUpdate` precedent already in the tree — so `isinstance` checks and `singledispatch` registrations keyed on the old class keep working. Internal dispatch in `_primitives/` now keys on the parent, so operators built either way take the same code path.

Scope note: **`SumKroneckerSqrt` and `sumkronecker_sample` keep their names.** They do not collide with `KroneckerSum`, and renaming them would widen the deprecation surface beyond what the issue asked for. Say the word if you want them migrated too.

## #106 — the README half

PR #204 covered the architecture and navigation half. This is the README, which had drifted furthest:

- **Layer 1**: added `SumOfKroneckers`, `Toeplitz`, all three kernel operators, `InterpolatedOperator`, `MaskedOperator`, and the lazy-algebra operators; noted the `orthonormal=` flag on `LowRankUpdate`.
- **Layer 1.5**: added the preconditioners and logdet strategies (entirely absent before) and the `linear_solve` front door.
- **Layer 3**: added EnKF gain/ETKF, localization and inflation, GP conditioning, variational bounds, Matheron sampling, OILMM, the SDE kernel zoo, and the steady-state Kalman family.
- Added a Documentation section and recorded both deprecated aliases under API Notes.

Every symbol named in the README is now verified to exist on the `gaussx` namespace (102 checked, 0 missing), and the quickstart was executed.

**Remaining #106 scope — notebook coverage.** Nav and notebooks are already in sync (30 notebooks, all listed, no orphans), and every API page has at least one corresponding example. Public areas with no dedicated notebook, as a concrete follow-up list: OILMM multi-output projections; Toeplitz / FFT operators; infinite-horizon Kalman (`dare`); SpInGP; `MaskedOperator` / `InterpolatedOperator` (KISS-GP); preconditioners. Happy to open that as a tracking issue — I have left #106 referenced rather than closed so you can decide.

## Verification

- `pytest -m "not slow and not integration"` — **1427 passed, 0 failed** (measured on `6639b26`). This PR adds **26 test functions** across 4 files and removes none. An earlier revision of this description claimed 1417 passing "up from 1398" — that pair of numbers did not reproduce, and the baseline has since moved anyway now that #210 is on `main`, so the delta is stated as added tests rather than as a total.
- `ruff check .` / `ruff format --check .` — clean
- `ty check src/gaussx` — clean
- `mkdocs build --strict` — clean
- Each of the five commits imports cleanly in isolation; export count moves 269 → 270 exactly at the rename commit

## Review follow-ups

Two P2 findings from the Codex review, both addressed:

- **`transpose` dropped the deprecated type** (`47aca06`). `SumOfKroneckers.transpose` hardcoded the parent class, so `SumKronecker(...).T` came back as `SumOfKroneckers` and external `isinstance` / `singledispatch` keyed on the old name silently stopped applying after a transpose — contradicting the compatibility guarantee above. Now constructs via `type(self)`, with regression tests both directions.
- **The custom-JVP claim was too broad** (`6639b26`). Both `Implicit*` operators set `_kernel_mv = None` under the default `params=None` and take the plain scan path. The operators reference page now carries the distinction as a table row plus a callout; the class docstrings already scoped it correctly.

## Note on the branch

This is on `claude/gaussx-issues-batch` rather than the usual `claude/gaussx-docs-cleanup-rm76m4`. That branch still holds the pre-squash commits of the merged #204, so it could not fast-forward; you chose a new branch over a force-push.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTpgESwwnWBrLsfb8SHDYs)_

