### PR TITLE
feat(ssm,distributions): per-channel observation mask and LGSSM densities

### DIFF
--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -18,6 +18,37 @@ be wasted work. Both require `numpyro` to be installed.
       show_root_toc_entry: false
       members: [MultivariateNormal, MultivariateNormalPrecision]
 
+## Sequential distributions
+
+The linear-Gaussian state-space model as a *density* rather than a set of
+functions: `log_prob` is the Kalman marginal likelihood $\log p(y_{1:T})$
+(delegated to [`kalman_filter`](ssm.md)), `sample` is ancestral forward
+simulation, and `event_shape` is $(T, M)$ so `log_prob` returns a scalar with
+no `.to_event()` wrapping. That makes them usable directly as a NumPyro
+likelihood site.
+
+`A`, `H`, `Q` and `R` each take a dense array *or* a lineax operator, exactly
+matching [`kalman_filter`](ssm.md)'s contract — a structured $Q$ / $R$ keeps its
+structure through the Cholesky in `sample`, and $H$ through the sandwich in
+`variance`.
+
+`MaskedLGSSM` carries a $(T, M)$ observation mask and returns the **exact**
+marginal $\log p(y_{\mathrm{obs}})$ — not a bound — because
+$p(y_{\mathrm{miss}} \mid y_{\mathrm{obs}})$ is closed-form Gaussian.
+`LGSSMFactory` is the `mask -> MaskedLGSSM` callable for conditional use; it
+is an `equinox.Module` rather than a closure so the state-space parameters
+stay visible to `equinox.filter_grad`.
+
+To use one as a normalizing-flow base, wrap it with `gauss_flows.NumpyroBase`,
+which already adapts any numpyro distribution — no bespoke adapter class is
+needed on either side. All three require `numpyro` to be installed.
+
+::: gaussx
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members: [LGSSM, MaskedLGSSM, LGSSMFactory]
+
 ## Gaussian sugar ops
 
 $$

--- a/docs/api/ssm.md
+++ b/docs/api/ssm.md
@@ -26,6 +26,36 @@ The forward filter and RTS smoother, their $O(\log N)$ parallel
 (associative-scan) counterparts, and the steady-state (infinite-horizon)
 variants built on the discrete algebraic Riccati equation.
 
+### Observation masks
+
+`kalman_filter` and `parallel_kalman_filter` take an optional `mask`,
+dispatched on its rank:
+
+| shape | meaning |
+|---|---|
+| `(T,)` | **Per-step gate.** `False` runs the predict step only and contributes nothing to the log-likelihood — the usual way to predict on a merged train/test grid. |
+| `(T, M)` | **Per-channel gate**, for partially observed multivariate series where different channels are measured at different times. |
+
+The per-channel path marginalises unobserved channels *exactly*: row $i$ of
+$H_t$ is zeroed, a unit block is substituted into $R_t$, and the residual
+entry is set to zero. The innovation covariance is then block-diagonal in the
+observed/masked split, so column $i$ of the gain vanishes and the masked
+channel cannot move the state — the posterior reproduces the row-deleted
+filter to machine precision, with no branching. A dummy block also
+contributes $-\tfrac12 \log 2\pi$ per masked channel to the full-vector
+density, which is stripped per step, so `log_likelihood` is the exact marginal
+$\log p(y_{\mathrm{obs}})$ and is invariant to both the mask pattern and the
+dummy variance.
+
+An all-`False` row of a `(T, M)` mask is equivalent to a `False` entry in the
+`(T,)` form, and `M == 1` is unambiguous either way. Masked entries of
+`observations` are never read, so they may be `NaN`. Operator-typed
+`obs_model` / `obs_noise` are materialised under a `(T, M)` mask, since
+zeroing rows is inherently dense; `form="sqrt"` supports the `(T,)` mask only
+and raises `NotImplementedError` otherwise. `rts_smoother` needs no mask of
+its own — it consumes filtered/predicted moments, which are already
+mask-aware.
+
 ::: gaussx
     options:
       show_root_heading: false

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -304,6 +304,11 @@ from gaussx._tags import (
 
 
 try:
+    from gaussx._distributions._lgssm import (
+        LGSSM as LGSSM,
+        LGSSMFactory as LGSSMFactory,
+        MaskedLGSSM as MaskedLGSSM,
+    )
     from gaussx._distributions._mvn import MultivariateNormal as MultivariateNormal
     from gaussx._distributions._mvn_prec import (
         MultivariateNormalPrecision as MultivariateNormalPrecision,

--- a/src/gaussx/_distributions/__init__.py
+++ b/src/gaussx/_distributions/__init__.py
@@ -18,6 +18,9 @@ from gaussx._distributions._project import project
 
 
 __all__ = [
+    "LGSSM",
+    "LGSSMFactory",
+    "MaskedLGSSM",
     "MultivariateNormal",
     "MultivariateNormalPrecision",
     "add_jitter",
@@ -32,8 +35,9 @@ __all__ = [
 ]
 
 
-# MultivariateNormal / MultivariateNormalPrecision require the optional
-# ``numpyro`` dependency. Exposing them via PEP 562 ``__getattr__`` means:
+# MultivariateNormal / MultivariateNormalPrecision / the LGSSM family
+# require the optional ``numpyro`` dependency. Exposing them via PEP 562
+# ``__getattr__`` means:
 #
 # - Importing ``gaussx._distributions`` always succeeds (so the non-numpyro
 #   helpers above are available in a base install).
@@ -43,6 +47,10 @@ __all__ = [
 # - Users get the expected ``ModuleNotFoundError`` (not a confusing
 #   ``ImportError``) if they directly access the name without the extra.
 def __getattr__(name: str) -> Any:
+    if name in ("LGSSM", "MaskedLGSSM", "LGSSMFactory"):
+        from gaussx._distributions import _lgssm
+
+        return getattr(_lgssm, name)
     if name == "MultivariateNormal":
         from gaussx._distributions._mvn import MultivariateNormal
 

--- a/src/gaussx/_distributions/_lgssm.py
+++ b/src/gaussx/_distributions/_lgssm.py
@@ -1,0 +1,363 @@
+"""Linear-Gaussian state-space models as sampleable densities."""
+
+from __future__ import annotations
+
+import math
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import numpyro.distributions as dist
+from jaxtyping import Array, Bool, Float
+from numpyro.distributions.util import lazy_property, validate_sample
+
+from gaussx._distributions._utils import _reshape_batch, _reshape_series
+from gaussx._einx import einsum, rearrange
+from gaussx._linalg._linalg import sandwich
+from gaussx._primitives._cholesky import cholesky as _cholesky
+from gaussx._primitives._diag import diag as _diag
+from gaussx._ssm._kalman import kalman_filter
+from gaussx._ssm._utils import _as_operator, _materialise, _matvec
+
+
+# Operator-or-array unions mirroring ``gaussx.kalman_filter``'s contract.
+_Transition = Float[Array, "N N"] | lx.AbstractLinearOperator
+_Emission = Float[Array, "M N"] | lx.AbstractLinearOperator
+_StateCov = Float[Array, "N N"] | lx.AbstractLinearOperator
+_ObsCov = Float[Array, "M M"] | lx.AbstractLinearOperator
+
+
+def _psd(operand: Float[Array, ...] | lx.AbstractLinearOperator):
+    """Operator view of a covariance, tagged PSD when wrapping an array."""
+    return _as_operator(operand, lx.positive_semidefinite_tag)
+
+
+def _out_size(operand: Float[Array, "M N"] | lx.AbstractLinearOperator) -> int:
+    """Number of output rows, without materialising an operator."""
+    if isinstance(operand, lx.AbstractLinearOperator):
+        return operand.out_size()
+    return operand.shape[0]
+
+
+class LGSSM(dist.Distribution):
+    r"""Linear-Gaussian state-space model as a density over ``(T, M)``.
+
+    Models
+
+    $$
+    x_t = A x_{t-1} + q_t,\quad q_t \sim N(0, Q), \qquad
+    y_t = H x_t + r_t,\quad r_t \sim N(0, R),
+    $$
+
+    with $x_0 \sim N(m_0, P_0)$ and $t = 1, \dots, T$. ``log_prob`` is
+    the Kalman marginal likelihood $\log p(y_{1:T})$, delegated to
+    `gaussx.kalman_filter`; ``sample`` is ancestral forward
+    simulation. ``event_shape`` is ``(T, M)``, so ``log_prob`` returns a
+    scalar and no ``.to_event()`` wrapping is needed.
+
+    Requires the ``numpyro`` optional extra
+    (``pip install "gaussx[numpyro]"``).
+
+    ``A``, ``H``, ``Q`` and ``R`` each accept a dense array *or* a
+    `lineax.AbstractLinearOperator`, exactly matching
+    `gaussx.kalman_filter`'s contract. Structured ``Q`` / ``R`` keep
+    their structure through the Cholesky in ``sample``, ``H`` through
+    the sandwich in ``variance``, and ``A`` / ``H`` apply via
+    structural matvec rather than a dense matmul. ``m0`` and ``P0`` are
+    dense, as they are for `gaussx.kalman_filter`.
+
+    Args:
+        A: Transition matrix or operator, shape ``(N, N)``.
+        H: Emission matrix or operator, shape ``(M, N)``.
+        Q: Process noise covariance or operator, shape ``(N, N)``.
+        R: Observation noise covariance or operator, shape ``(M, M)``.
+        m0: Initial state mean, shape ``(N,)``.
+        P0: Initial state covariance, shape ``(N, N)``.
+        n_steps: Sequence length ``T``.
+        validate_args: Whether to validate input arguments.
+
+    Examples:
+        >>> import jax.numpy as jnp, jax.random as jr
+        >>> from gaussx import LGSSM
+        >>> d = LGSSM(0.9 * jnp.eye(2), jnp.eye(2), 0.1 * jnp.eye(2),
+        ...           0.2 * jnp.eye(2), jnp.zeros(2), jnp.eye(2), n_steps=10)
+        >>> y = d.sample(jr.key(0))
+        >>> y.shape
+        (10, 2)
+        >>> d.log_prob(y).shape
+        ()
+
+    Notes:
+        To use as a normalizing-flow base, wrap with
+        ``gauss_flows.NumpyroBase``; no bespoke adapter is required.
+    """
+
+    arg_constraints = {}  # noqa: RUF012
+    support = dist.constraints.real_matrix
+    reparametrized_params = ["A", "H", "Q", "R", "m0", "P0"]  # noqa: RUF012
+    pytree_data_fields = ("A", "H", "Q", "R", "m0", "P0")
+
+    def __init__(
+        self,
+        A: _Transition,
+        H: _Emission,
+        Q: _StateCov,
+        R: _ObsCov,
+        m0: Float[Array, " N"],
+        P0: Float[Array, "N N"],
+        n_steps: int,
+        *,
+        validate_args: bool | None = None,
+    ) -> None:
+        self.A = A
+        self.H = H
+        self.Q = Q
+        self.R = R
+        self.m0 = m0
+        self.P0 = P0
+        super().__init__(
+            batch_shape=(),
+            event_shape=(n_steps, _out_size(H)),
+            validate_args=validate_args,
+        )
+
+    @property
+    def n_steps(self) -> int:
+        """Sequence length ``T``."""
+        return self.event_shape[0]
+
+    @property
+    def _obs_mask(self) -> Bool[Array, "T M"] | None:
+        """Observation mask handed to `gaussx.kalman_filter`."""
+        return None
+
+    def _log_prob_single(self, value: Float[Array, "T M"]) -> Float[Array, ""]:
+        return kalman_filter(
+            self.A,
+            self.H,
+            self.Q,
+            self.R,
+            value,
+            self.m0,
+            self.P0,
+            mask=self._obs_mask,
+        ).log_likelihood
+
+    @validate_sample
+    def log_prob(self, value: Float[Array, "*batch T M"]) -> Float[Array, "*batch"]:
+        leading_shape = value.shape[:-2]
+        value_flat = rearrange(value, "... T M -> (...) T M")
+        log_prob_flat = jax.vmap(self._log_prob_single)(value_flat)
+        return _reshape_batch(log_prob_flat, leading_shape)
+
+    def _sample_single(self, key: jax.Array) -> Float[Array, "T M"]:
+        """One ancestral forward simulation of the full ``(T, M)`` series.
+
+        Cholesky factors go through the structural
+        `gaussx.cholesky` primitive, so a Kronecker / block-diagonal
+        / diagonal covariance is never materialised.
+        """
+        N = self.m0.shape[0]
+        M = self.event_shape[1]
+        key_init, key_q, key_r = jax.random.split(key, 3)
+        L_P0 = _cholesky(_psd(self.P0))
+        L_Q = _cholesky(_psd(self.Q))
+        L_R = _cholesky(_psd(self.R))
+
+        x0 = self.m0 + L_P0.mv(jax.random.normal(key_init, (N,)))
+        eps_q = jax.random.normal(key_q, (self.n_steps, N))
+        eps_r = jax.random.normal(key_r, (self.n_steps, M))
+
+        def step(x, noise):
+            e_q, e_r = noise
+            x_next = _matvec(self.A, x) + L_Q.mv(e_q)
+            y = _matvec(self.H, x_next) + L_R.mv(e_r)
+            return x_next, y
+
+        _, ys = jax.lax.scan(step, x0, (eps_q, eps_r))
+        return ys
+
+    def sample(
+        self,
+        key: jax.Array | None,
+        sample_shape: tuple[int, ...] = (),
+    ) -> Float[Array, "*sample T M"]:
+        if key is None:
+            raise ValueError("PRNG key must be provided to sample from LGSSM.")
+        n_samples = math.prod(sample_shape) if sample_shape else 1
+        keys = jax.random.split(key, n_samples)
+        samples_flat = jax.vmap(self._sample_single)(keys)
+        return _reshape_series(samples_flat, sample_shape)
+
+    @lazy_property
+    def mean(self) -> Float[Array, "T M"]:
+        """Marginal mean $H A^t m_0$ of each observation, shape ``(T, M)``."""
+
+        def step(m, _):
+            m_next = _matvec(self.A, m)
+            return m_next, _matvec(self.H, m_next)
+
+        _, means = jax.lax.scan(step, self.m0, None, length=self.n_steps)
+        return means
+
+    @lazy_property
+    def variance(self) -> Float[Array, "T M"]:
+        """Marginal variance $\\mathrm{diag}(H P_t H^\\top + R)$, shape ``(T, M)``.
+
+        The state recursion runs on dense ``P_t`` — it is the evolving
+        quantity, so no input structure survives it — but the emission
+        step avoids forming ``H P H^T``: operators go through
+        `gaussx.sandwich` + `gaussx.diag`, arrays contract straight
+        to the diagonal.
+        """
+        A_dense = _materialise(self.A)
+        Q_dense = _materialise(self.Q)
+        diag_R = _diag(_as_operator(self.R))
+        H_op = self.H if isinstance(self.H, lx.AbstractLinearOperator) else None
+
+        def step(P, _):
+            P_next = A_dense @ P @ A_dense.T + Q_dense
+            if H_op is not None:
+                diag_HPH = _diag(sandwich(H_op, _psd(P_next)))
+            else:
+                diag_HPH = einsum(self.H, P_next, self.H, "m n, n k, m k -> m")
+            return P_next, diag_HPH + diag_R
+
+        _, variances = jax.lax.scan(step, self.P0, None, length=self.n_steps)
+        return variances
+
+
+class MaskedLGSSM(LGSSM):
+    r"""`LGSSM` whose ``log_prob`` marginalises unobserved channels exactly.
+
+    Takes a ``(T, M)`` boolean mask at construction. ``log_prob`` returns
+    the exact marginal $\log p(y_{\mathrm{obs}})$, not a bound: the
+    conditional $p(y_{\mathrm{miss}} \mid y_{\mathrm{obs}})$ is
+    closed-form Gaussian, so dropping dimensions costs nothing in
+    exactness. Masked entries of ``value`` are never read and may be
+    ``NaN``.
+
+    ``sample`` is inherited unchanged and simulates the **complete**
+    ``(T, M)`` series — the mask governs which entries the density
+    scores, not which are generated.
+
+    Args:
+        A: Transition matrix or operator, shape ``(N, N)``.
+        H: Emission matrix or operator, shape ``(M, N)``.
+        Q: Process noise covariance or operator, shape ``(N, N)``.
+        R: Observation noise covariance or operator, shape ``(M, M)``.
+        m0: Initial state mean, shape ``(N,)``.
+        P0: Initial state covariance, shape ``(N, N)``.
+        n_steps: Sequence length ``T``.
+        obs_mask: Observation mask, shape ``(T, M)``. ``True`` marks an
+            observed channel. An all-``False`` row leaves the state at
+            its predicted value and contributes nothing. Named
+            ``obs_mask`` so it does not shadow numpyro's inherited
+            ``Distribution.mask()`` method.
+        validate_args: Whether to validate input arguments.
+
+    Raises:
+        ValueError: If ``obs_mask`` does not have shape ``(n_steps, M)``.
+
+    Examples:
+        >>> import jax.numpy as jnp, jax.random as jr
+        >>> from gaussx import MaskedLGSSM
+        >>> mask = jr.bernoulli(jr.key(0), 0.7, (10, 2))
+        >>> d = MaskedLGSSM(0.9 * jnp.eye(2), jnp.eye(2), 0.1 * jnp.eye(2),
+        ...                 0.2 * jnp.eye(2), jnp.zeros(2), jnp.eye(2),
+        ...                 n_steps=10, obs_mask=mask)
+        >>> d.log_prob(d.sample(jr.key(1))).shape
+        ()
+    """
+
+    pytree_data_fields = ("A", "H", "Q", "R", "m0", "P0", "obs_mask")
+
+    # Named ``obs_mask`` rather than ``mask``: ``numpyro.distributions.
+    # Distribution.mask`` is an inherited *method* returning a
+    # ``MaskedDistribution`` (it backs ``numpyro.sample(..., obs_mask=)``),
+    # and shadowing it with an array would silently break that API on
+    # this subclass alone.
+    obs_mask: Bool[Array, "T M"]
+
+    def __init__(
+        self,
+        A: _Transition,
+        H: _Emission,
+        Q: _StateCov,
+        R: _ObsCov,
+        m0: Float[Array, " N"],
+        P0: Float[Array, "N N"],
+        n_steps: int,
+        obs_mask: Bool[Array, "T M"],
+        *,
+        validate_args: bool | None = None,
+    ) -> None:
+        obs_mask = jnp.asarray(obs_mask, dtype=bool)
+        expected = (n_steps, _out_size(H))
+        if obs_mask.shape != expected:
+            raise ValueError(
+                f"obs_mask must have shape {expected}; got shape {obs_mask.shape}."
+            )
+        self.obs_mask = obs_mask
+        super().__init__(A, H, Q, R, m0, P0, n_steps, validate_args=validate_args)
+
+    @property
+    def _obs_mask(self) -> Bool[Array, "T M"]:
+        return self.obs_mask
+
+
+class LGSSMFactory(eqx.Module):
+    """Callable ``obs_mask -> MaskedLGSSM``, for conditional use.
+
+    An `equinox.Module` rather than a closure so the state-space
+    parameters stay visible to `equinox.filter_grad` when passed as
+    ``gauss_flows.NumpyroBase(dist_factory=...)``.
+
+    Attributes:
+        A: Transition matrix or operator, shape ``(N, N)``.
+        H: Emission matrix or operator, shape ``(M, N)``.
+        Q: Process noise covariance or operator, shape ``(N, N)``.
+        R: Observation noise covariance or operator, shape ``(M, M)``.
+        m0: Initial state mean, shape ``(N,)``.
+        P0: Initial state covariance, shape ``(N, N)``.
+        n_steps: Sequence length ``T``.
+
+    Examples:
+        >>> import jax.numpy as jnp, jax.random as jr
+        >>> from gaussx import LGSSMFactory
+        >>> factory = LGSSMFactory(0.9 * jnp.eye(2), jnp.eye(2),
+        ...                        0.1 * jnp.eye(2), 0.2 * jnp.eye(2),
+        ...                        jnp.zeros(2), jnp.eye(2), n_steps=10)
+        >>> d = factory(jr.bernoulli(jr.key(0), 0.7, (10, 2)))
+        >>> d.event_shape
+        (10, 2)
+    """
+
+    A: _Transition
+    H: _Emission
+    Q: _StateCov
+    R: _ObsCov
+    m0: Float[Array, " N"]
+    P0: Float[Array, "N N"]
+    n_steps: int = eqx.field(static=True)
+
+    def __call__(self, obs_mask: Bool[Array, "T M"]) -> MaskedLGSSM:
+        """Build the `MaskedLGSSM` for a given observation mask.
+
+        Args:
+            obs_mask: Observation mask, shape ``(T, M)``.
+
+        Returns:
+            A `MaskedLGSSM` carrying this factory's parameters.
+        """
+        return MaskedLGSSM(
+            self.A,
+            self.H,
+            self.Q,
+            self.R,
+            self.m0,
+            self.P0,
+            self.n_steps,
+            obs_mask,
+        )

--- a/src/gaussx/_distributions/_utils.py
+++ b/src/gaussx/_distributions/_utils.py
@@ -55,6 +55,32 @@ def _reshape_batch(
     return rearrange(values, f"({batch_pattern}) -> {batch_pattern}", **axis_lengths)
 
 
+def _reshape_series(
+    values: Float[Array, "flat T M"],
+    batch_shape: tuple[int, ...],
+) -> Float[Array, "*batch T M"]:
+    """Reshape flat ``(T, M)`` series back to their original batch shape.
+
+    The rank-2-event counterpart of `_reshape_samples`, for
+    distributions whose ``event_shape`` is a matrix.
+
+    Args:
+        values: Flat series of shape ``(prod(batch_shape), T, M)``.
+        batch_shape: Target batch shape. When empty, the single series is
+            returned unwrapped.
+
+    Returns:
+        Array reshaped to ``(*batch_shape, T, M)``.
+    """
+    if not batch_shape:
+        return values[0]
+    batch_axes = _axis_names(len(batch_shape))
+    axis_lengths = dict(zip(batch_axes, batch_shape, strict=True))
+    batch_pattern = " ".join(batch_axes)
+    pattern = f"({batch_pattern}) T M -> {batch_pattern} T M"
+    return rearrange(values, pattern, **axis_lengths)
+
+
 def _reshape_samples(
     values: Float[Array, "flat N"],
     batch_shape: tuple[int, ...],

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -13,6 +13,7 @@ from gaussx._linalg._linalg import sandwich, solve_rows
 from gaussx._ssm._utils import (
     _innovation_covariance,
     _left_matmul,
+    _masked_obs_inputs,
     _materialise,
     _normalise_tv_inputs,
     _right_matmul_transpose,
@@ -48,7 +49,7 @@ def kalman_filter(
     init_mean: Float[Array, " N"],
     init_cov: Float[Array, "N N"],
     *,
-    mask: Bool[Array, " T"] | None = None,
+    mask: Bool[Array, " T"] | Bool[Array, "T M"] | None = None,
     solver: AbstractSolverStrategy | None = None,
     woodbury_innovation: bool = False,
 ) -> FilterState:
@@ -86,11 +87,29 @@ def kalman_filter(
         observations: Observed data, shape ``(T, M)``.
         init_mean: Initial state mean, shape ``(N,)``.
         init_cov: Initial state covariance, shape ``(N, N)``.
-        mask: Optional per-step boolean mask, shape ``(T,)``. ``True``
-            (or ``1``) runs the full predict + update step; ``False``
-            (or ``0``) runs the predict step only and skips the
-            log-likelihood contribution. Defaults to all-True. Useful
-            for prediction on merged train/test grids.
+        mask: Optional observation mask. Disambiguated by rank, so no
+            extra keyword is needed (``M == 1`` is unambiguous either
+            way, since a ``(T,)`` and a ``(T, 1)`` mask coincide).
+
+            - Shape ``(T,)`` — per-step gate. ``True`` (or ``1``) runs
+              the full predict + update step; ``False`` (or ``0``) runs
+              the predict step only and contributes nothing to the
+              log-likelihood. Useful for prediction on merged
+              train/test grids.
+            - Shape ``(T, M)`` — per-channel gate, for partially
+              observed multivariate series. ``False`` entries are
+              marginalised out exactly: the corresponding rows of
+              ``H_t`` are zeroed, a unit block is substituted into
+              ``R_t``, and the residual entry is set to zero. The
+              returned ``log_likelihood`` is the exact marginal
+              $\log p(y_{\mathrm{obs}})$, not the full-vector density.
+              Masked entries of ``observations`` are never read, so
+              they may be ``NaN``. An all-``False`` row is equivalent
+              to a ``False`` entry in the ``(T,)`` form.
+
+            Defaults to all-True. Operator-typed ``obs_model`` /
+            ``obs_noise`` are materialised under a ``(T, M)`` mask,
+            since zeroing rows is inherently a dense operation.
         solver: Optional solver strategy. When ``None``, uses
             structural dispatch.
         woodbury_innovation: When ``True``, build the innovation
@@ -118,6 +137,15 @@ def kalman_filter(
     A_op = transition if isinstance(transition, lx.AbstractLinearOperator) else None
     H_op = obs_model if isinstance(obs_model, lx.AbstractLinearOperator) else None
     R_op = obs_noise if isinstance(obs_noise, lx.AbstractLinearOperator) else None
+
+    # A per-channel mask rewrites the rows of H and the block structure
+    # of R, neither of which survives as a structured operator — so the
+    # (T, M) path drops to dense observation inputs.
+    channel_mask = mask is not None and jnp.ndim(mask) == 2
+    if channel_mask:
+        H_op = None
+        R_op = None
+
     A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
         transition,
         obs_model,
@@ -125,6 +153,7 @@ def kalman_filter(
         obs_noise,
         T=T,
         mask=mask,
+        M=M,
         materialise_transition=A_op is None,
         materialise_obs=H_op is None,
         # Skip the O(T M²) dense broadcast of structured R when the
@@ -145,52 +174,74 @@ def kalman_filter(
         else:
             P_pred = A_t @ P_filt @ A_t.T + Q_t
 
-        # --- Update (gated by mask via lax.cond so the predict-only
-        #             branch evaluates neither the update arithmetic
-        #             nor produces gradients for the dropped path). ---
-        def _do_update(_):
-            v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
-            # Resolve ``R`` for innovation: operator path uses the
-            # closed-over ``R_op`` (kept structural for Woodbury); array
-            # path falls back to the per-step ``R_t``.
-            R_innov = R_op if R_op is not None else R_t
-            # Resolve ``H`` similarly so the operator preserves structure
-            # in both the Woodbury and the structural-sandwich paths.
-            H_innov = H_op if H_op is not None else H_t
+        # --- Update ---
+        def _update(H_eff, R_eff, v, n_missing):
+            """Shared update body for the gated and per-channel paths.
+
+            ``H_eff`` is either a lineax operator (structural path) or a
+            dense ``(M, N)`` array; ``n_missing`` is the count of masked
+            channels, used to strip the dummy block's contribution from
+            the log-likelihood.
+            """
+            H_is_op = isinstance(H_eff, lx.AbstractLinearOperator)
             S_op = _innovation_covariance(
-                H_innov, P_pred, R_innov, woodbury=woodbury_innovation
+                H_eff, P_pred, R_eff, woodbury=woodbury_innovation
             )
 
             PHt = (
-                _right_matmul_transpose(P_pred, H_op)
-                if H_op is not None
-                else P_pred @ H_t.T
+                _right_matmul_transpose(P_pred, H_eff) if H_is_op else P_pred @ H_eff.T
             )  # (N, M)
             K = solve_rows(S_op, PHt, solver=solver)  # (N, M)
 
             x_upd = x_pred + K @ v
             if woodbury_innovation:
-                # Avoid materialising S for the covariance update. Use
-                # the operator path when available (H_t is a (0, 0)
-                # placeholder under operator mode).
-                HP_pred = (
-                    _left_matmul(H_op, P_pred) if H_op is not None else H_t @ P_pred
-                )
+                # Avoid materialising S for the covariance update.
+                HP_pred = _left_matmul(H_eff, P_pred) if H_is_op else H_eff @ P_pred
                 P_upd = P_pred - K @ HP_pred
             else:
                 P_upd = P_pred - K @ S_op.as_matrix() @ K.T
 
             Sinv_v = dispatch_solve(S_op, v, solver)
             ld = dispatch_logdet(S_op, solver)
-            ll_inc = -0.5 * (v @ Sinv_v + ld + M * _LOG_2PI)
+            # The dummy unit block contributes -0.5 * log(2 pi) per
+            # masked channel to the full-vector density; strip it here,
+            # per step, so the result is the exact marginal over the
+            # observed entries and is invariant to the dummy variance.
+            ll_inc = (
+                -0.5 * (v @ Sinv_v + ld + M * _LOG_2PI) + 0.5 * n_missing * _LOG_2PI
+            )
             return x_upd, P_upd, ll_inc
 
-        def _skip_update(_):
-            return x_pred, P_pred, jnp.array(0.0)
+        if channel_mask:
+            # No lax.cond: an all-False row degenerates to the
+            # predict-only step on its own, so the masked path is
+            # branch-free.
+            H_eff, R_eff, y_eff, n_missing = _masked_obs_inputs(H_t, R_t, y_t, mask_t)
+            x_filt_new, P_filt_new, ll_inc = _update(
+                H_eff, R_eff, y_eff - H_eff @ x_pred, n_missing
+            )
+        else:
+            # Gate the whole step via lax.cond so the predict-only
+            # branch evaluates neither the update arithmetic nor
+            # produces gradients for the dropped path.
+            def _do_update(_):
+                v = y_t - (H_op.mv(x_pred) if H_op is not None else H_t @ x_pred)
+                # Resolve ``R`` for innovation: operator path uses the
+                # closed-over ``R_op`` (kept structural for Woodbury);
+                # array path falls back to the per-step ``R_t``.
+                R_innov = R_op if R_op is not None else R_t
+                # Resolve ``H`` similarly so the operator preserves
+                # structure in both the Woodbury and the
+                # structural-sandwich paths.
+                H_innov = H_op if H_op is not None else H_t
+                return _update(H_innov, R_innov, v, 0.0)
 
-        x_filt_new, P_filt_new, ll_inc = jax.lax.cond(
-            mask_t, _do_update, _skip_update, operand=None
-        )
+            def _skip_update(_):
+                return x_pred, P_pred, jnp.array(0.0)
+
+            x_filt_new, P_filt_new, ll_inc = jax.lax.cond(
+                mask_t, _do_update, _skip_update, operand=None
+            )
         ll_new = ll + ll_inc
 
         carry_new = (x_filt_new, P_filt_new, ll_new)

--- a/src/gaussx/_ssm/_parallel_kalman.py
+++ b/src/gaussx/_ssm/_parallel_kalman.py
@@ -30,7 +30,11 @@ from gaussx._distributions._gaussian import _LOG_2PI
 from gaussx._linalg._symmetrize import symmetrize as _sym
 from gaussx._primitives._logdet import cholesky_logdet
 from gaussx._ssm._kalman import FilterState, kalman_filter
-from gaussx._ssm._utils import _materialise, _normalise_tv_inputs
+from gaussx._ssm._utils import (
+    _masked_obs_inputs,
+    _materialise,
+    _normalise_tv_inputs,
+)
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -176,7 +180,7 @@ def parallel_kalman_filter(
     init_mean: Float[Array, " N"],
     init_cov: Float[Array, "N N"],
     *,
-    mask: Bool[Array, " T"] | None = None,
+    mask: Bool[Array, " T"] | Bool[Array, "T M"] | None = None,
     solver: AbstractSolverStrategy | None = None,
     woodbury_innovation: bool = False,
     form: str = "covariance",
@@ -197,8 +201,13 @@ def parallel_kalman_filter(
         observations: Observed data, shape ``(T, M)``.
         init_mean: Initial state mean, shape ``(N,)``.
         init_cov: Initial state covariance, shape ``(N, N)``.
-        mask: Optional ``(T,)`` boolean mask; ``False`` runs predict-only
-            and contributes 0 to the log-likelihood. Defaults to all-True.
+        mask: Optional observation mask, dispatched on rank exactly as
+            in `gaussx.kalman_filter`. Shape ``(T,)`` gates whole
+            steps (``False`` runs predict-only and contributes 0 to the
+            log-likelihood); shape ``(T, M)`` gates individual channels
+            and yields the exact marginal log-likelihood over the
+            observed entries. Defaults to all-True. Not supported by
+            ``form="sqrt"``.
         solver: Accepted for API symmetry with `kalman_filter` but
             not currently threaded through the per-element solves; the
             covariance-form combinator uses unstructured dense solves.
@@ -271,34 +280,47 @@ def parallel_kalman_filter(
         )
 
     A_seq, H_seq, Q_seq, R_seq, mask_seq, _ = _normalise_tv_inputs(
-        transition, obs_model, process_noise, obs_noise, T=T, mask=mask
+        transition, obs_model, process_noise, obs_noise, T=T, mask=mask, M=M_obs
     )
+    # Work per-channel throughout: a ``(T,)`` gate is the special case
+    # where every channel of a step shares one flag, so broadcasting it
+    # reproduces the whole-step path exactly.
+    mask_ch = (
+        mask_seq
+        if mask_seq.ndim == 2
+        else jnp.broadcast_to(mask_seq[:, None], (T, M_obs))
+    )
+    step_active = jnp.any(mask_ch, axis=-1)
 
     # Build per-step elements. ``vmap`` of ``lax.cond`` evaluates both
     # branches and selects, so we instead substitute mask-aware safe
-    # inputs (H=0, R=I, y=0 for masked steps) into a single active path.
-    # With those substitutions the active builder collapses to
-    # (F, 0, Q, 0, 0) — exactly the predict-only element — and the
-    # Cholesky operates on the well-conditioned identity, so even
-    # garbage in masked H / R / y can't NaN the gradient.
+    # inputs (zeroed H rows, unit R block, zeroed y) into a single
+    # active path. For a fully-masked step those substitutions collapse
+    # the active builder to (F, 0, Q, 0, 0) — exactly the predict-only
+    # element — and the Cholesky operates on the well-conditioned
+    # identity, so even garbage in masked H / R / y can't NaN the
+    # gradient.
     def _build_step(F, H, Q, R, y, m):
-        H_eff = jnp.where(m, H, jnp.zeros_like(H))
-        R_eff = jnp.where(m, R, jnp.eye(M_obs, dtype=R.dtype))
-        y_eff = jnp.where(m, y, jnp.zeros_like(y))
+        H_eff, R_eff, y_eff, _ = _masked_obs_inputs(H, R, y, m)
         return _generic_filter_element_active(F, H_eff, Q, R_eff, y_eff)
 
-    elems = jax.vmap(_build_step)(A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
+    elems = jax.vmap(_build_step)(A_seq, H_seq, Q_seq, R_seq, observations, mask_ch)
 
     # Patch element 0 to absorb the initial prior. Outer ``lax.cond``
-    # genuinely skips the inactive branch (no ``vmap`` wrapping here).
+    # genuinely skips the inactive branch (no ``vmap`` wrapping here);
+    # a partially-observed step 0 takes the active branch on the
+    # substituted inputs.
+    H_first, R_first, y_first, _ = _masked_obs_inputs(
+        H_seq[0], R_seq[0], observations[0], mask_ch[0]
+    )
     first = jax.lax.cond(
-        mask_seq[0],
+        step_active[0],
         lambda: _first_filter_element_active(
             A_seq[0],
-            H_seq[0],
+            H_first,
             Q_seq[0],
-            R_seq[0],
-            observations[0],
+            R_first,
+            y_first,
             init_mean,
             init_cov,
         ),
@@ -332,21 +354,27 @@ def parallel_kalman_filter(
     # Log-likelihood from innovations. Same safe substitution as the
     # element builder so masked steps don't drive the Cholesky through
     # ill-conditioned user-supplied R / NaN gradients.
-    def _ll_contrib(y, m_pred, P_pred, H, R, m):
-        H_eff = jnp.where(m, H, jnp.zeros_like(H))
-        R_eff = jnp.where(m, R, jnp.eye(M_obs, dtype=R.dtype))
-        y_eff = jnp.where(m, y, jnp.zeros_like(y))
+    def _ll_contrib(y, m_pred, P_pred, H, R, m, active):
+        H_eff, R_eff, y_eff, n_missing = _masked_obs_inputs(H, R, y, m)
         v = y_eff - H_eff @ m_pred
         S = _sym(H_eff @ P_pred @ H_eff.T + R_eff)
         L = jnp.linalg.cholesky(S)
         Sinv_v = jax.scipy.linalg.cho_solve((L, True), v)
         quad = v @ Sinv_v
         logdet = cholesky_logdet(L)
-        contrib = -0.5 * (quad + logdet + M_obs * _LOG_2PI)
-        return jnp.where(m, contrib, jnp.zeros_like(contrib))
+        # Strip the dummy unit block's -0.5 * log(2 pi) per masked
+        # channel, so this is the exact marginal over observed entries.
+        contrib = -0.5 * (quad + logdet + M_obs * _LOG_2PI) + 0.5 * n_missing * _LOG_2PI
+        return jnp.where(active, contrib, jnp.zeros_like(contrib))
 
     ll_contribs = jax.vmap(_ll_contrib)(
-        observations, predicted_means, predicted_covs, H_seq, R_seq, mask_seq
+        observations,
+        predicted_means,
+        predicted_covs,
+        H_seq,
+        R_seq,
+        mask_ch,
+        step_active,
     )
     log_likelihood = jnp.sum(ll_contribs)
 

--- a/src/gaussx/_ssm/_parallel_kalman_sqrt.py
+++ b/src/gaussx/_ssm/_parallel_kalman_sqrt.py
@@ -97,8 +97,25 @@ def parallel_kalman_filter_sqrt(
     mask: Bool[Array, " T"] | None = None,
     solver: AbstractSolverStrategy | None = None,
 ) -> FilterState:
-    """Square-root parallel Kalman filter via associative scan."""
+    """Square-root parallel Kalman filter via associative scan.
+
+    Only the ``(T,)`` per-step mask is supported. A per-channel
+    ``(T, M)`` mask makes the innovation covariance block-degenerate,
+    which the triangularisation-based factor path is not set up to
+    handle; use the covariance form (or `gaussx.kalman_filter`)
+    for per-channel masking.
+
+    Raises:
+        NotImplementedError: If ``mask`` is a ``(T, M)`` per-channel
+            mask.
+    """
     del solver
+
+    if mask is not None and jnp.ndim(mask) == 2:
+        raise NotImplementedError(
+            "form='sqrt' does not support per-channel (T, M) masks; pass a "
+            "(T,) per-step mask, or use form='covariance' / kalman_filter."
+        )
 
     M_obs = observations.shape[-1]
     T = observations.shape[0]

--- a/src/gaussx/_ssm/_utils.py
+++ b/src/gaussx/_ssm/_utils.py
@@ -120,6 +120,56 @@ def _innovation_covariance(
     return lx.MatrixLinearOperator(S, lx.positive_semidefinite_tag)
 
 
+def _masked_obs_inputs(
+    H: Float[Array, "M N"],
+    R: Float[Array, "M M"],
+    y: Float[Array, " M"],
+    mask: Bool[Array, " M"],
+) -> tuple[
+    Float[Array, "M N"],
+    Float[Array, "M M"],
+    Float[Array, " M"],
+    Float[Array, ""],
+]:
+    r"""Substitute ``(H, R, y)`` so masked observation channels are inert.
+
+    Marginalising channel $i$ out of the update is equivalent to keeping
+    it but making it carry no information: zero the row $H_i$, replace
+    row/column $i$ of $R$ with the unit basis vector, and zero $y_i$.
+    The innovation covariance then splits as
+
+    $$
+    S = \begin{bmatrix} S_{\mathrm{obs}} & 0 \\ 0 & I \end{bmatrix},
+    $$
+
+    so column $i$ of the gain $K = P H^\top S^{-1}$ vanishes and the
+    masked channel cannot move the state. The posterior is therefore
+    *exactly* the row-deleted filter, with no branching.
+
+    The substitution is written with `jax.numpy.where` rather than a
+    multiply so a masked ``y`` entry may be ``NaN`` (the usual encoding
+    for "not measured") without poisoning the residual.
+
+    Args:
+        H: Observation matrix, shape ``(M, N)``.
+        R: Observation noise covariance, shape ``(M, M)``.
+        y: Observation vector, shape ``(M,)``.
+        mask: Per-channel boolean mask, shape ``(M,)``. ``True`` keeps
+            the channel.
+
+    Returns:
+        Tuple ``(H_eff, R_eff, y_eff, n_missing)`` where ``n_missing``
+        is the float count of masked channels, used to strip the dummy
+        block's contribution from the log-likelihood.
+    """
+    M = y.shape[-1]
+    H_eff = jnp.where(mask[:, None], H, jnp.zeros_like(H))
+    R_eff = jnp.where(mask[:, None] & mask[None, :], R, jnp.eye(M, dtype=R.dtype))
+    y_eff = jnp.where(mask, y, jnp.zeros_like(y))
+    n_missing = M - jnp.sum(mask.astype(y.dtype))
+    return H_eff, R_eff, y_eff, n_missing
+
+
 def _is_operator_input(value: object) -> bool:
     """True iff *value* is a lineax operator (and so signals TI mode)."""
     return isinstance(value, lx.AbstractLinearOperator)
@@ -132,7 +182,8 @@ def _normalise_tv_inputs(
     obs_noise: Float[Array, ...] | lx.AbstractLinearOperator,
     *,
     T: int,
-    mask: Bool[Array, " T"] | None,
+    mask: Bool[Array, " T"] | Bool[Array, "T M"] | None,
+    M: int | None = None,
     materialise_transition: bool = True,
     materialise_obs: bool = True,
     materialise_obs_noise: bool = True,
@@ -141,7 +192,7 @@ def _normalise_tv_inputs(
     Float[Array, "T M N"],
     Float[Array, "T N N"],
     Float[Array, "T M M"],
-    Bool[Array, " T"],
+    Bool[Array, " T"] | Bool[Array, "T M"],
     bool,
 ]:
     """Normalise the four shape-bearing args + ``mask`` for the scan body.
@@ -157,9 +208,18 @@ def _normalise_tv_inputs(
         Woodbury innovation) rather than index into the array. This
         avoids materialising structured operators into ``(T, …)`` dense
         stacks.
-    mask_seq : ``(T,)`` boolean array (defaults to all-True).
+    mask_seq : ``(T,)`` boolean array (defaults to all-True), or ``(T, M)``
+        when a per-channel mask was supplied. The rank is passed through
+        unchanged so the caller can dispatch on ``mask_seq.ndim``.
     is_time_invariant : True iff every shape-bearing input is either an
         operator or a 2D array (and was broadcast to ``(T, …)`` here).
+
+    Notes
+    -----
+    ``M`` is only needed to validate a per-channel ``(T, M)`` mask.
+    Leaving it ``None`` rejects 2D masks outright, which is how callers
+    that have no per-channel path (e.g. the square-root parallel filter)
+    opt out.
 
     Raises
     ------
@@ -249,13 +309,27 @@ def _normalise_tv_inputs(
     else:
         mask_seq = jnp.asarray(mask, dtype=bool)
         # Allow scalar broadcast for ergonomic ``mask=True`` / ``mask=False``;
-        # otherwise require a 1D array of length T to give a clear error
-        # before the scan rather than a confusing tracing failure.
+        # otherwise require ``(T,)`` (per-step gate) or ``(T, M)``
+        # (per-channel gate) to give a clear error before the scan rather
+        # than a confusing tracing failure.
         if mask_seq.ndim == 0:
             mask_seq = jnp.broadcast_to(mask_seq, (T,))
+        elif mask_seq.ndim == 2:
+            if M is None:
+                raise ValueError(
+                    "mask must be a scalar or have shape "
+                    f"({T},); got shape {mask_seq.shape}. Per-channel "
+                    "(T, M) masks are not supported by this filter."
+                )
+            if mask_seq.shape != (T, M):
+                raise ValueError(
+                    f"mask must be a scalar or have shape ({T},) or "
+                    f"({T}, {M}); got shape {mask_seq.shape}."
+                )
         elif mask_seq.shape != (T,):
+            expected = f"({T},)" if M is None else f"({T},) or ({T}, {M})"
             raise ValueError(
-                f"mask must be a scalar or have shape ({T},); got shape "
+                f"mask must be a scalar or have shape {expected}; got shape "
                 f"{mask_seq.shape}."
             )
 

--- a/tests/distributions/test_lgssm.py
+++ b/tests/distributions/test_lgssm.py
@@ -1,0 +1,425 @@
+"""Tests for the LGSSM / MaskedLGSSM / LGSSMFactory distributions."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytest.importorskip("numpyro")
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import numpy as np
+
+from gaussx import LGSSM, LGSSMFactory, MaskedLGSSM
+from gaussx._operators import Kronecker
+
+
+_LOG_2PI = float(np.log(2.0 * np.pi))
+
+
+def _make_params(key, N=3, M=4):
+    k = jr.split(key, 6)
+    A = 0.85 * jnp.eye(N) + 0.05 * jr.normal(k[0], (N, N))
+    H = jr.normal(k[1], (M, N))
+    Q_h = jr.normal(k[2], (N, N))
+    Q = Q_h @ Q_h.T + 0.3 * jnp.eye(N)
+    R_h = jr.normal(k[3], (M, M))
+    R = R_h @ R_h.T + 0.5 * jnp.eye(M)
+    m0 = jr.normal(k[4], (N,))
+    P0_h = jr.normal(k[5], (N, N))
+    P0 = P0_h @ P0_h.T + jnp.eye(N)
+    return A, H, Q, R, m0, P0
+
+
+def _dense_joint(A, H, Q, R, m0, P0, T):
+    """Mean and covariance of the dense ``(TM, TM)`` joint over ``y``."""
+    A, H, Q, R, m0, P0 = (np.asarray(v) for v in (A, H, Q, R, m0, P0))
+    N, M = A.shape[0], H.shape[0]
+    means_x = np.zeros((T, N))
+    covs_x = np.zeros((T, N, N))
+    m, P = m0, P0
+    for t in range(T):
+        m = A @ m
+        P = A @ P @ A.T + Q
+        means_x[t], covs_x[t] = m, P
+    mu = (H @ means_x.T).T.reshape(-1)
+    Sigma = np.zeros((T * M, T * M))
+    for s in range(T):
+        for t in range(s, T):
+            block = H @ covs_x[s] @ np.linalg.matrix_power(A, t - s).T @ H.T
+            if s == t:
+                block = block + R
+            Sigma[s * M : (s + 1) * M, t * M : (t + 1) * M] = block
+            Sigma[t * M : (t + 1) * M, s * M : (s + 1) * M] = block.T
+    return mu, Sigma
+
+
+def _mvn_logpdf(x, mu, Sigma):
+    residual = x - mu
+    return -0.5 * (
+        residual @ np.linalg.solve(Sigma, residual)
+        + np.linalg.slogdet(Sigma)[1]
+        + len(residual) * _LOG_2PI
+    )
+
+
+class TestLGSSM:
+    def test_log_prob_matches_dense_joint(self, getkey):
+        T = 8
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        y = d.sample(getkey())
+
+        mu, Sigma = _dense_joint(A, H, Q, R, m0, P0, T)
+        expected = _mvn_logpdf(np.asarray(y).reshape(-1), mu, Sigma)
+        assert abs(float(d.log_prob(y)) - expected) <= 1e-13
+
+    def test_log_prob_is_scalar(self, getkey):
+        """``event_shape`` rank is what makes this a scalar — easy to get wrong."""
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=6)
+        assert d.event_shape == (6, H.shape[0])
+        assert d.batch_shape == ()
+        assert d.log_prob(d.sample(getkey())).shape == ()
+
+    @pytest.mark.slow
+    def test_sample_shapes(self, getkey):
+        T, M = 7, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        assert d.sample(getkey()).shape == (T, M)
+        assert d.sample(getkey(), (5,)).shape == (5, T, M)
+        assert d.sample(getkey(), (2, 3)).shape == (2, 3, T, M)
+
+    def test_sample_requires_key(self, getkey):
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=4)
+        with pytest.raises(ValueError, match="PRNG key"):
+            d.sample(None)
+
+    def test_mean_and_variance_match_dense_joint(self, getkey):
+        T = 6
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        mu, Sigma = _dense_joint(A, H, Q, R, m0, P0, T)
+
+        assert d.mean.shape == d.event_shape
+        assert d.variance.shape == d.event_shape
+        assert np.abs(np.asarray(d.mean).reshape(-1) - mu).max() <= 1e-12
+        variance_flat = np.asarray(d.variance).reshape(-1)
+        assert np.abs(variance_flat - np.diag(Sigma)).max() <= 1e-12
+
+    @pytest.mark.slow
+    def test_batched_log_prob(self, getkey):
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=5)
+        ys = d.sample(getkey(), (4,))
+        batched = d.log_prob(ys)
+        assert batched.shape == (4,)
+        assert jnp.allclose(batched[1], d.log_prob(ys[1]))
+
+    @pytest.mark.slow
+    def test_jit_vmap_over_batch(self, getkey):
+        A, H, Q, R, m0, P0 = _make_params(getkey())
+        d = LGSSM(A, H, Q, R, m0, P0, n_steps=5)
+        ys = d.sample(getkey(), (16,))
+        out = eqx.filter_jit(jax.vmap(d.log_prob))(ys)
+        assert out.shape == (16,)
+        assert jnp.isfinite(out).all()
+
+
+class TestOperatorInputs:
+    """Structured operators must be accepted wherever kalman_filter takes them."""
+
+    def _operator_model(self, getkey, T=6):
+        """Same model expressed densely and as operators."""
+        N1, N2, M1, M2 = 2, 2, 2, 2
+        k = jr.split(getkey(), 4)
+        A_op = Kronecker(
+            lx.MatrixLinearOperator(0.9 * jnp.eye(N1)),
+            lx.MatrixLinearOperator(0.8 * jnp.eye(N2)),
+        )
+        H_op = Kronecker(
+            lx.MatrixLinearOperator(jr.normal(k[0], (M1, N1))),
+            lx.MatrixLinearOperator(jr.normal(k[1], (M2, N2))),
+        )
+        Q_op = Kronecker(
+            lx.MatrixLinearOperator(0.2 * jnp.eye(N1), lx.positive_semidefinite_tag),
+            lx.MatrixLinearOperator(0.3 * jnp.eye(N2), lx.positive_semidefinite_tag),
+        )
+        R_op = lx.DiagonalLinearOperator(0.4 * jnp.ones(M1 * M2))
+        P0 = jnp.eye(N1 * N2)
+        m0 = jr.normal(k[2], (N1 * N2,))
+        dense = tuple(op.as_matrix() for op in (A_op, H_op, Q_op, R_op))
+        return (A_op, H_op, Q_op, R_op, P0, m0), dense, T
+
+    @pytest.mark.slow
+    def test_log_prob_matches_dense(self, getkey):
+        ops, dense, T = self._operator_model(getkey)
+        A_op, H_op, Q_op, R_op, P0, m0 = ops
+        A, H, Q, R = dense
+
+        d_op = LGSSM(A_op, H_op, Q_op, R_op, m0, P0, n_steps=T)
+        d_dense = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        assert d_op.event_shape == d_dense.event_shape
+
+        y = d_dense.sample(getkey())
+        assert abs(float(d_op.log_prob(y) - d_dense.log_prob(y))) <= 1e-10
+
+    @pytest.mark.slow
+    def test_sample_and_moments_match_dense(self, getkey):
+        ops, dense, T = self._operator_model(getkey)
+        A_op, H_op, Q_op, R_op, P0, m0 = ops
+        A, H, Q, R = dense
+
+        d_op = LGSSM(A_op, H_op, Q_op, R_op, m0, P0, n_steps=T)
+        d_dense = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+
+        key = getkey()
+        assert jnp.abs(d_op.sample(key) - d_dense.sample(key)).max() <= 1e-10
+        assert jnp.abs(d_op.mean - d_dense.mean).max() <= 1e-10
+        assert jnp.abs(d_op.variance - d_dense.variance).max() <= 1e-10
+
+    def test_masked_operator_log_prob(self, getkey):
+        ops, dense, T = self._operator_model(getkey)
+        A_op, H_op, Q_op, R_op, P0, m0 = ops
+        A, H, Q, R = dense
+        M = H.shape[0]
+        mask = jr.bernoulli(getkey(), 0.6, (T, M))
+
+        d_op = MaskedLGSSM(A_op, H_op, Q_op, R_op, m0, P0, n_steps=T, obs_mask=mask)
+        d_dense = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        y = d_dense.sample(getkey())
+        assert abs(float(d_op.log_prob(y) - d_dense.log_prob(y))) <= 1e-10
+
+
+class TestMaskedLGSSM:
+    def test_log_prob_is_exact_marginal(self, getkey):
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jr.bernoulli(getkey(), 0.6, (T, M))
+        d = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        y = d.sample(getkey())
+
+        mu, Sigma = _dense_joint(A, H, Q, R, m0, P0, T)
+        idx = np.where(np.asarray(mask).reshape(-1))[0]
+        expected = _mvn_logpdf(
+            np.asarray(y).reshape(-1)[idx], mu[idx], Sigma[np.ix_(idx, idx)]
+        )
+        assert abs(float(d.log_prob(y)) - expected) <= 1e-13
+
+    def test_all_true_mask_equals_lgssm(self, getkey):
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        base = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        masked = MaskedLGSSM(
+            A, H, Q, R, m0, P0, n_steps=T, obs_mask=jnp.ones((T, M), dtype=bool)
+        )
+        y = base.sample(getkey())
+        assert masked.log_prob(y) == base.log_prob(y)
+
+    def test_fully_unobserved_timestep(self, getkey):
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jnp.ones((T, M), dtype=bool).at[3].set(False)
+        d = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        assert jnp.isfinite(d.log_prob(d.sample(getkey())))
+
+    def test_masked_entries_may_be_nan(self, getkey):
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jr.bernoulli(getkey(), 0.6, (T, M))
+        d = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        y = d.sample(getkey())
+        assert d.log_prob(jnp.where(mask, y, jnp.nan)) == d.log_prob(y)
+
+    def test_wrong_mask_shape_raises(self, getkey):
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        with pytest.raises(ValueError, match="obs_mask must have shape"):
+            MaskedLGSSM(
+                A,
+                H,
+                Q,
+                R,
+                m0,
+                P0,
+                n_steps=T,
+                obs_mask=jnp.ones((T, M + 1), dtype=bool),
+            )
+
+    def test_sample_returns_complete_series(self, getkey):
+        """The mask governs scoring, not generation."""
+        T, M = 8, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jnp.zeros((T, M), dtype=bool).at[0, 0].set(True)
+        d = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        y = d.sample(getkey())
+        assert y.shape == (T, M)
+        assert jnp.isfinite(y).all()
+
+
+class TestPytree:
+    """Guards against the hand-written ``tree_unflatten`` trap.
+
+    ``equinox.partition`` walks the tree with boolean sentinel leaves, so
+    any ``__init__`` that infers shapes from its arguments explodes on
+    reconstruction. A ``log_prob``-only suite passes with that bug present.
+    """
+
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_round_trip(self, getkey, masked):
+        T, M = 6, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        if masked:
+            d = MaskedLGSSM(
+                A,
+                H,
+                Q,
+                R,
+                m0,
+                P0,
+                n_steps=T,
+                obs_mask=jr.bernoulli(getkey(), 0.6, (T, M)),
+            )
+        else:
+            d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        y = d.sample(getkey())
+
+        leaves, treedef = jax.tree_util.tree_flatten(d)
+        rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert rebuilt.event_shape == d.event_shape
+        assert rebuilt.log_prob(y) == d.log_prob(y)
+
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_eqx_partition(self, getkey, masked):
+        T, M = 6, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        if masked:
+            d = MaskedLGSSM(
+                A,
+                H,
+                Q,
+                R,
+                m0,
+                P0,
+                n_steps=T,
+                obs_mask=jr.bernoulli(getkey(), 0.6, (T, M)),
+            )
+        else:
+            d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+
+        arrays, static = eqx.partition(d, eqx.is_inexact_array)
+        assert len(jax.tree_util.tree_leaves(arrays)) == 6
+        assert eqx.combine(arrays, static).event_shape == d.event_shape
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("masked", [False, True])
+    def test_filter_grad_reaches_ssm_params(self, getkey, masked):
+        T, M = 6, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        if masked:
+            d = MaskedLGSSM(
+                A,
+                H,
+                Q,
+                R,
+                m0,
+                P0,
+                n_steps=T,
+                obs_mask=jr.bernoulli(getkey(), 0.6, (T, M)),
+            )
+        else:
+            d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+        y = d.sample(getkey())
+
+        grads = eqx.filter_grad(lambda dist: -dist.log_prob(y))(d)
+        leaves = [g for g in jax.tree_util.tree_leaves(grads) if g is not None]
+        assert len(leaves) == 6  # A, H, Q, R, m0, P0
+        assert all(jnp.isfinite(g).all() for g in leaves)
+        norm = jnp.sqrt(sum(jnp.sum(g**2) for g in leaves))
+        assert float(norm) > 0.0
+
+
+class TestFactory:
+    def test_builds_masked_lgssm(self, getkey):
+        T, M = 6, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jr.bernoulli(getkey(), 0.6, (T, M))
+        factory = LGSSMFactory(A, H, Q, R, m0, P0, n_steps=T)
+        d = factory(mask)
+
+        assert isinstance(d, MaskedLGSSM)
+        assert d.event_shape == (T, M)
+        direct = MaskedLGSSM(A, H, Q, R, m0, P0, n_steps=T, obs_mask=mask)
+        y = direct.sample(getkey())
+        assert d.log_prob(y) == direct.log_prob(y)
+
+    @pytest.mark.slow
+    def test_filter_grad_through_factory(self, getkey):
+        """The whole point of the Module: params stay visible to filter_grad."""
+        T, M = 6, 4
+        A, H, Q, R, m0, P0 = _make_params(getkey(), M=M)
+        mask = jr.bernoulli(getkey(), 0.6, (T, M))
+        factory = LGSSMFactory(A, H, Q, R, m0, P0, n_steps=T)
+        y = factory(mask).sample(getkey())
+
+        grads = eqx.filter_grad(lambda f: -f(mask).log_prob(y))(factory)
+        leaves = [g for g in jax.tree_util.tree_leaves(grads) if g is not None]
+        assert len(leaves) == 6
+        norm = jnp.sqrt(sum(jnp.sum(g**2) for g in leaves))
+        assert float(norm) > 0.0
+
+
+@pytest.mark.slow
+def test_sample_moments_match_analytic(getkey):
+    """Empirical moments of 200k samples against the analytic joint."""
+    T, N, M = 5, 2, 2
+    A = jnp.array([[0.8, 0.1], [0.0, 0.7]])
+    H = jnp.array([[1.0, 0.3], [0.2, 1.0]])
+    Q = 0.2 * jnp.eye(N)
+    R = 0.3 * jnp.eye(M)
+    m0 = jnp.array([0.5, -0.2])
+    P0 = jnp.eye(N)
+    d = LGSSM(A, H, Q, R, m0, P0, n_steps=T)
+
+    samples = d.sample(getkey(), (200_000,)).reshape(200_000, -1)
+    mu, Sigma = _dense_joint(A, H, Q, R, m0, P0, T)
+
+    # Monte-Carlo error at 200k samples is ~1e-2 for these magnitudes.
+    assert np.abs(np.asarray(samples.mean(0)) - mu).max() <= 2e-2
+    assert np.abs(np.asarray(jnp.cov(samples.T)) - Sigma).max() <= 2e-2
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_numpyro_svi_reduces_loss(getkey):
+    """LGSSM used as an observed site inside a NumPyro model."""
+    import numpyro
+    import numpyro.distributions as ndist
+    from numpyro.infer import SVI, Trace_ELBO
+    from numpyro.infer.autoguide import AutoNormal
+
+    T, N, M = 8, 2, 2
+    A_true = jnp.array([[0.8, 0.1], [0.0, 0.7]])
+    H = jnp.eye(M)
+    Q = 0.2 * jnp.eye(N)
+    R = 0.3 * jnp.eye(M)
+    m0 = jnp.zeros(N)
+    P0 = jnp.eye(N)
+    y = LGSSM(A_true, H, Q, R, m0, P0, n_steps=T).sample(getkey())
+
+    def model(obs):
+        a = numpyro.sample("a", ndist.Normal(0.0, 1.0).expand([N, N]).to_event(2))
+        numpyro.sample("y", LGSSM(a, H, Q, R, m0, P0, n_steps=T), obs=obs)
+
+    svi = SVI(model, AutoNormal(model), numpyro.optim.Adam(1e-2), Trace_ELBO())
+    result = svi.run(jr.key(0), 200, y, progress_bar=False)
+
+    losses = np.asarray(result.losses)
+    assert np.isfinite(losses).all()
+    assert losses[-20:].mean() < losses[:20].mean()

--- a/tests/ssm/test_kalman_channel_mask.py
+++ b/tests/ssm/test_kalman_channel_mask.py
@@ -1,0 +1,487 @@
+"""Per-dimension ``(T, M)`` observation mask for the Kalman filters.
+
+The masked update is verified against two independent references:
+
+- a **row-deleted** filter that physically drops the unobserved rows of
+  ``H`` / ``R`` / ``y`` at each step, and
+- the **dense** ``(TM, TM)`` joint Gaussian, restricted to the observed
+  entries.
+
+The log-likelihood correction gets its own regression tests. The dummy
+unit block contributes a spurious ``-0.5 * log(2 pi)`` per masked channel;
+under a *fixed* mask that is a constant offset, so it never changes an
+argmax and a fixed-mask test passes with the bug present. The tests below
+vary the mask and pin the offset exactly.
+
+Sequential-filter correctness stays in the fast lane; the
+`parallel_kalman_filter` cases are marked ``slow`` (the associative-scan
+trace alone costs ~10 s to compile), matching how ``test_parallel_kalman.py``
+already marks its suite.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+
+from gaussx import (
+    kalman_filter,
+    parallel_kalman_filter,
+    parallel_rts_smoother,
+    rts_smoother,
+)
+
+
+_LOG_2PI = float(np.log(2.0 * np.pi))
+
+
+class _RowDeleted(NamedTuple):
+    """Moments and log-likelihood of the row-deleted reference filter."""
+
+    means: np.ndarray
+    covs: np.ndarray
+    pred_means: np.ndarray
+    pred_covs: np.ndarray
+    log_likelihood: float
+
+
+def _tol(reference, rtol=1e-14):
+    """Machine-precision tolerance scaled to the reference's magnitude.
+
+    ``getkey`` reseeds per run, so a bare absolute bound is a function of
+    the draw: filtered covariances here range over roughly ``1``-``20``.
+    Scaling keeps the ``1e-14`` target meaningful across draws.
+    """
+    return rtol * max(1.0, float(np.abs(np.asarray(reference)).max()))
+
+
+def _make_model(key, N=3, M=4, T=10):
+    """A well-conditioned, genuinely coupled time-invariant LGSSM."""
+    k = jr.split(key, 7)
+    A = 0.85 * jnp.eye(N) + 0.05 * jr.normal(k[0], (N, N))
+    H = jr.normal(k[1], (M, N))
+    Q_h = jr.normal(k[2], (N, N))
+    Q = Q_h @ Q_h.T + 0.3 * jnp.eye(N)
+    R_h = jr.normal(k[3], (M, M))
+    R = R_h @ R_h.T + 0.5 * jnp.eye(M)
+    m0 = jr.normal(k[4], (N,))
+    P0_h = jr.normal(k[5], (N, N))
+    P0 = P0_h @ P0_h.T + jnp.eye(N)
+    y = jr.normal(k[6], (T, M))
+    return A, H, Q, R, y, m0, P0
+
+
+def _partial_mask(key, T, M):
+    """A mask with a fully-masked row, a fully-observed row, and gaps."""
+    mask = jr.bernoulli(key, 0.6, (T, M))
+    return mask.at[2].set(False).at[5].set(True)
+
+
+def _row_deleted_filter(A, H, Q, R, y, m0, P0, mask):
+    """NumPy reference that physically deletes unobserved rows."""
+    A, H, Q, R, y, mask = (np.asarray(v) for v in (A, H, Q, R, y, mask))
+    x, P, ll = np.asarray(m0), np.asarray(P0), 0.0
+    means, covs, pred_means, pred_covs = [], [], [], []
+    for t in range(y.shape[0]):
+        x_pred = A @ x
+        P_pred = A @ P @ A.T + Q
+        pred_means.append(x_pred)
+        pred_covs.append(P_pred)
+        idx = np.where(mask[t])[0]
+        if len(idx):
+            H_s, R_s = H[idx], R[np.ix_(idx, idx)]
+            v = y[t][idx] - H_s @ x_pred
+            S = H_s @ P_pred @ H_s.T + R_s
+            K = P_pred @ H_s.T @ np.linalg.inv(S)
+            x = x_pred + K @ v
+            P = P_pred - K @ S @ K.T
+            ll += -0.5 * (
+                v @ np.linalg.solve(S, v)
+                + np.linalg.slogdet(S)[1]
+                + len(idx) * _LOG_2PI
+            )
+        else:
+            x, P = x_pred, P_pred
+        means.append(x)
+        covs.append(P)
+    return _RowDeleted(
+        np.array(means),
+        np.array(covs),
+        np.array(pred_means),
+        np.array(pred_covs),
+        ll,
+    )
+
+
+def _rts_reference(ref, A):
+    """NumPy RTS smoother over reference filter moments."""
+    A = np.asarray(A)
+    T = ref.means.shape[0]
+    s_means = [None] * T
+    s_covs = [None] * T
+    s_means[T - 1], s_covs[T - 1] = ref.means[T - 1], ref.covs[T - 1]
+    for t in range(T - 2, -1, -1):
+        G = ref.covs[t] @ A.T @ np.linalg.inv(ref.pred_covs[t + 1])
+        s_means[t] = ref.means[t] + G @ (s_means[t + 1] - ref.pred_means[t + 1])
+        s_covs[t] = ref.covs[t] + G @ (s_covs[t + 1] - ref.pred_covs[t + 1]) @ G.T
+    return np.array(s_means), np.array(s_covs)
+
+
+def _dummy_block_ll(A, H, Q, R, y, m0, P0, mask, r_dummy, *, corrected):
+    """Masked-``H`` filter with an arbitrary dummy variance ``r_dummy``.
+
+    With ``corrected=False`` this is the naive formulation carrying the
+    likelihood bug; with ``corrected=True`` it strips the dummy block's
+    contribution per step and must agree with `kalman_filter` for
+    every ``r_dummy``.
+    """
+    A, H, Q, R, y, mask = (np.asarray(v) for v in (A, H, Q, R, y, mask))
+    M = y.shape[1]
+    x, P, ll = np.asarray(m0), np.asarray(P0), 0.0
+    for t in range(y.shape[0]):
+        x_pred = A @ x
+        P_pred = A @ P @ A.T + Q
+        mk = mask[t].astype(float)
+        H_m = H * mk[:, None]
+        R_m = R * (mk[:, None] * mk[None, :]) + np.diag(r_dummy * (1.0 - mk))
+        v = (y[t] - H_m @ x_pred) * mk
+        S = H_m @ P_pred @ H_m.T + R_m
+        K = P_pred @ H_m.T @ np.linalg.inv(S)
+        x = x_pred + K @ v
+        P = P_pred - K @ S @ K.T
+        ll += -0.5 * (
+            v @ np.linalg.solve(S, v) + np.linalg.slogdet(S)[1] + M * _LOG_2PI
+        )
+        if corrected:
+            ll += 0.5 * (M - mk.sum()) * (_LOG_2PI + np.log(r_dummy))
+    return ll
+
+
+def _dense_joint(A, H, Q, R, m0, P0, T):
+    """Mean and covariance of the dense ``(TM, TM)`` joint over ``y``."""
+    A, H, Q, R, m0, P0 = (np.asarray(v) for v in (A, H, Q, R, m0, P0))
+    N, M = A.shape[0], H.shape[0]
+    means_x = np.zeros((T, N))
+    covs_x = np.zeros((T, N, N))
+    m, P = m0, P0
+    for t in range(T):
+        m = A @ m
+        P = A @ P @ A.T + Q
+        means_x[t], covs_x[t] = m, P
+    mu = (H @ means_x.T).T.reshape(-1)
+    Sigma = np.zeros((T * M, T * M))
+    for s in range(T):
+        for t in range(s, T):
+            # Cov(x_s, x_t) = P_s (A^{t-s})^T for s <= t.
+            block = H @ covs_x[s] @ np.linalg.matrix_power(A, t - s).T @ H.T
+            if s == t:
+                block = block + R
+            Sigma[s * M : (s + 1) * M, t * M : (t + 1) * M] = block
+            Sigma[t * M : (t + 1) * M, s * M : (s + 1) * M] = block.T
+    return mu, Sigma
+
+
+def _mvn_logpdf(x, mu, Sigma):
+    residual = x - mu
+    return -0.5 * (
+        residual @ np.linalg.solve(Sigma, residual)
+        + np.linalg.slogdet(Sigma)[1]
+        + len(residual) * _LOG_2PI
+    )
+
+
+class TestRowDeletedEquivalence:
+    """The masked filter must reproduce a row-deleted filter exactly."""
+
+    def test_filtered_means(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        ref = _row_deleted_filter(A, H, Q, R, y, m0, P0, mask)
+        assert jnp.abs(out.filtered_means - ref.means).max() <= _tol(ref.means)
+
+    def test_filtered_covs(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        ref = _row_deleted_filter(A, H, Q, R, y, m0, P0, mask)
+        assert jnp.abs(out.filtered_covs - ref.covs).max() <= _tol(ref.covs)
+
+    def test_log_likelihood(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        ref = _row_deleted_filter(A, H, Q, R, y, m0, P0, mask)
+        assert abs(float(out.log_likelihood) - ref.log_likelihood) <= 1e-13
+
+    def test_matches_dense_joint_marginal(self, getkey):
+        """The exact marginal of the dense joint over observed entries."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey(), T=8)
+        T, M = y.shape
+        mask = _partial_mask(getkey(), T, M)
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+
+        mu, Sigma = _dense_joint(A, H, Q, R, m0, P0, T)
+        idx = np.where(np.asarray(mask).reshape(-1))[0]
+        exact = _mvn_logpdf(
+            np.asarray(y).reshape(-1)[idx], mu[idx], Sigma[np.ix_(idx, idx)]
+        )
+        assert abs(float(out.log_likelihood) - exact) <= 1e-13
+
+
+class TestLikelihoodCorrection:
+    """Regression tests for the dummy-block likelihood bug."""
+
+    @pytest.mark.parametrize("r_dummy", [1.0, 4.0, 100.0])
+    def test_invariant_to_dummy_variance(self, getkey, r_dummy):
+        """The corrected likelihood must not depend on the dummy variance."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        corrected = _dummy_block_ll(
+            A, H, Q, R, y, m0, P0, mask, r_dummy, corrected=True
+        )
+        assert abs(float(out.log_likelihood) - corrected) <= 1e-13
+
+    def test_gap_from_naive_is_exactly_n_missing_half_log_2pi(self, getkey):
+        """Without the correction the likelihood over-counts by a fixed offset."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        n_missing = int((~mask).sum())
+        assert n_missing > 0
+
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        naive = _dummy_block_ll(A, H, Q, R, y, m0, P0, mask, 1.0, corrected=False)
+        gap = float(out.log_likelihood) - naive
+        assert gap == pytest.approx(n_missing * 0.5 * _LOG_2PI, abs=1e-12)
+
+    def test_varying_mask_does_not_reward_incomplete_series(self, getkey):
+        """The bug makes the LL scale with the number of *missing* channels.
+
+        Under a fixed mask that is invisible (constant offset). Across a
+        batch with differing completeness it becomes a per-example bias,
+        so compare the naive gap between two masks of different density.
+        """
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        dense_mask = jnp.ones((T, M), dtype=bool).at[0, 0].set(False)
+        sparse_mask = _partial_mask(getkey(), T, M)
+
+        ll_dense = float(
+            kalman_filter(A, H, Q, R, y, m0, P0, mask=dense_mask).log_likelihood
+        )
+        ll_sparse = float(
+            kalman_filter(A, H, Q, R, y, m0, P0, mask=sparse_mask).log_likelihood
+        )
+        naive_dense = _dummy_block_ll(
+            A, H, Q, R, y, m0, P0, dense_mask, 1.0, corrected=False
+        )
+        naive_sparse = _dummy_block_ll(
+            A, H, Q, R, y, m0, P0, sparse_mask, 1.0, corrected=False
+        )
+        # The naive bias differs between the two masks; the corrected
+        # values carry no such offset.
+        naive_bias = (naive_dense - ll_dense) - (naive_sparse - ll_sparse)
+        n_gap = int((~dense_mask).sum()) - int((~sparse_mask).sum())
+        assert naive_bias == pytest.approx(-n_gap * 0.5 * _LOG_2PI, abs=1e-12)
+        assert abs(naive_bias) > 1.0
+
+
+class TestEdgeCases:
+    def test_fully_unobserved_step_is_predict_only(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        mask = jnp.ones((T, M), dtype=bool).at[3].set(False)
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+
+        assert jnp.isfinite(out.filtered_means).all()
+        assert jnp.isfinite(out.filtered_covs).all()
+        assert jnp.isfinite(out.log_likelihood)
+        assert jnp.allclose(out.filtered_means[3], out.predicted_means[3])
+        assert jnp.allclose(out.filtered_covs[3], out.predicted_covs[3])
+
+    def test_all_true_channel_mask_matches_unmasked(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        unmasked = kalman_filter(A, H, Q, R, y, m0, P0)
+        masked = kalman_filter(A, H, Q, R, y, m0, P0, mask=jnp.ones((T, M), dtype=bool))
+        assert masked.log_likelihood == unmasked.log_likelihood
+        assert jnp.array_equal(masked.filtered_means, unmasked.filtered_means)
+        assert jnp.array_equal(masked.filtered_covs, unmasked.filtered_covs)
+
+    def test_broadcast_step_mask_matches_step_gate(self, getkey):
+        """An all-False row is equivalent to a False entry in the (T,) form."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        step_mask = jnp.ones((T,), dtype=bool).at[1].set(False).at[4].set(False)
+        gated = kalman_filter(A, H, Q, R, y, m0, P0, mask=step_mask)
+        per_channel = kalman_filter(
+            A,
+            H,
+            Q,
+            R,
+            y,
+            m0,
+            P0,
+            mask=jnp.broadcast_to(step_mask[:, None], (T, M)),
+        )
+        assert abs(float(gated.log_likelihood - per_channel.log_likelihood)) <= 1e-13
+        assert jnp.abs(gated.filtered_means - per_channel.filtered_means).max() <= 1e-14
+
+    def test_masked_entries_may_be_nan(self, getkey):
+        """Unobserved slots are never read, so NaN there is harmless."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        clean = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        poisoned = kalman_filter(
+            A, H, Q, R, jnp.where(mask, y, jnp.nan), m0, P0, mask=mask
+        )
+        assert poisoned.log_likelihood == clean.log_likelihood
+        assert jnp.array_equal(poisoned.filtered_means, clean.filtered_means)
+
+    def test_wrong_shape_channel_mask_raises(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        with pytest.raises(ValueError, match=r"mask must be"):
+            kalman_filter(A, H, Q, R, y, m0, P0, mask=jnp.ones((T, M + 1), dtype=bool))
+
+    @pytest.mark.slow
+    def test_float32_tracks_row_deleted_reference(self, getkey):
+        """Tight noise in float32 is where the dummy block could bite.
+
+        The bound is set from a 30-seed sweep: relative log-likelihood
+        error is ~3e-6 median with a 1.3e-5 tail, which is float32
+        accumulation over 60 steps rather than a defect. ``5e-5`` clears
+        that tail with room to spare while staying orders of magnitude
+        below what this test exists to catch — the missing likelihood
+        correction shifts this model by ~100 nats, a relative error of
+        order 1.
+        """
+        T, M, N = 60, 6, 3
+        k = jr.split(getkey(), 4)
+        A = (0.95 * jnp.eye(N) + 0.01 * jr.normal(k[0], (N, N))).astype(jnp.float32)
+        H = jr.normal(k[1], (M, N)).astype(jnp.float32)
+        Q = (1e-4 * jnp.eye(N)).astype(jnp.float32)
+        R = (1e-3 * jnp.eye(M)).astype(jnp.float32)
+        m0 = jnp.zeros((N,), dtype=jnp.float32)
+        P0 = jnp.eye(N, dtype=jnp.float32)
+        y = (0.1 * jr.normal(k[2], (T, M))).astype(jnp.float32)
+        mask = jr.bernoulli(k[3], 0.7, (T, M))
+
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        assert out.log_likelihood.dtype == jnp.float32
+
+        ref = _row_deleted_filter(
+            *(np.asarray(v, dtype=np.float64) for v in (A, H, Q, R, y, m0, P0)),
+            np.asarray(mask),
+        )
+        ref_ll = ref.log_likelihood
+        rel = abs(float(out.log_likelihood) - ref_ll) / abs(ref_ll)
+        assert rel <= 5e-5
+        assert np.abs(np.asarray(out.filtered_means) - ref.means).mean() <= 1e-5
+
+    @pytest.mark.slow
+    def test_jit_and_grad(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+
+        def loss(H_param):
+            return -kalman_filter(A, H_param, Q, R, y, m0, P0, mask=mask).log_likelihood
+
+        grad = jax.jit(jax.grad(loss))(H)
+        assert jnp.isfinite(grad).all()
+        assert jnp.abs(grad).max() > 0.0
+
+
+class TestBackCompat:
+    def test_step_mask_path_unchanged(self, getkey):
+        """A genuinely partial (T,) mask must still take the gated path."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T = y.shape[0]
+        mask = jnp.ones((T,), dtype=bool).at[1].set(False).at[6].set(False)
+        out = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+
+        ref_mask = jnp.broadcast_to(mask[:, None], y.shape)
+        ref = _row_deleted_filter(A, H, Q, R, y, m0, P0, ref_mask)
+        assert abs(float(out.log_likelihood) - ref.log_likelihood) <= 1e-13
+        # Masked steps are predict-only.
+        for t in (1, 6):
+            assert jnp.allclose(out.filtered_means[t], out.predicted_means[t])
+
+
+class TestSmoother:
+    """`rts_smoother` needs no mask of its own — it reads only moments."""
+
+    def test_matches_row_deleted_reference(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        filtered = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        s_means, s_covs = rts_smoother(filtered, A, Q)
+
+        ref = _row_deleted_filter(A, H, Q, R, y, m0, P0, mask)
+        ref_means, ref_covs = _rts_reference(ref, A)
+        assert jnp.abs(s_means - ref_means).max() <= _tol(ref_means, 1e-12)
+        assert jnp.abs(s_covs - ref_covs).max() <= _tol(ref_covs, 1e-12)
+
+    def test_fully_unobserved_step_smooths_without_nan(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        mask = jnp.ones((T, M), dtype=bool).at[4].set(False)
+        filtered = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        s_means, s_covs = rts_smoother(filtered, A, Q)
+        assert jnp.isfinite(s_means).all()
+        assert jnp.isfinite(s_covs).all()
+
+    @pytest.mark.slow
+    def test_parallel_smoother_agrees(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        seq = rts_smoother(kalman_filter(A, H, Q, R, y, m0, P0, mask=mask), A, Q)
+        par = parallel_rts_smoother(
+            parallel_kalman_filter(A, H, Q, R, y, m0, P0, mask=mask), A, Q
+        )
+        assert jnp.abs(seq[0] - par[0]).max() <= 1e-11
+        assert jnp.abs(seq[1] - par[1]).max() <= 1e-11
+
+
+class TestParallelParity:
+    @pytest.mark.slow
+    def test_matches_sequential(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        seq = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        par = parallel_kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+
+        assert jnp.abs(seq.filtered_means - par.filtered_means).max() <= 1e-12
+        assert jnp.abs(seq.filtered_covs - par.filtered_covs).max() <= 1e-12
+        assert abs(float(seq.log_likelihood - par.log_likelihood)) <= 1e-12
+
+    @pytest.mark.slow
+    def test_partially_observed_first_step(self, getkey):
+        """Step 0 absorbs the prior, so a partial mask there is its own case."""
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        T, M = y.shape
+        mask = jnp.ones((T, M), dtype=bool).at[0].set(jnp.arange(M) % 2 == 0)
+        seq = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        par = parallel_kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        assert jnp.abs(seq.filtered_means - par.filtered_means).max() <= 1e-12
+        assert abs(float(seq.log_likelihood - par.log_likelihood)) <= 1e-12
+
+    @pytest.mark.slow
+    def test_woodbury_innovation_delegates(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        seq = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask)
+        wood = kalman_filter(A, H, Q, R, y, m0, P0, mask=mask, woodbury_innovation=True)
+        assert abs(float(seq.log_likelihood - wood.log_likelihood)) <= 1e-11
+
+    def test_sqrt_form_rejects_channel_mask(self, getkey):
+        A, H, Q, R, y, m0, P0 = _make_model(getkey())
+        mask = _partial_mask(getkey(), y.shape[0], y.shape[1])
+        with pytest.raises(NotImplementedError, match=r"per-channel"):
+            parallel_kalman_filter(A, H, Q, R, y, m0, P0, mask=mask, form="sqrt")


### PR DESCRIPTION
Closes #207. Closes #209.

The two ship together because `MaskedLGSSM.log_prob` *is* the filter's
`(T, M)` mask path — splitting them would mean landing a distribution whose
central feature has no implementation behind it.

## ssm: per-dimension observation mask (#207)

`kalman_filter` and `parallel_kalman_filter` now accept a `(T, M)` mask
alongside the existing `(T,)` per-step gate, disambiguated by `mask.ndim` so
no new keyword is needed.

`False` entries are marginalised out exactly: the row of `H_t` is zeroed, a
unit block is substituted into `R_t`, and the residual entry is zeroed. `S` is
then block-diagonal in the observed/masked split, so column `i` of the gain
`K = P Hᵀ S⁻¹` vanishes and the masked channel cannot move the state. The
posterior reproduces the row-deleted filter with no branching.

### The likelihood bug

The dummy unit block also contributes a spurious $-\tfrac12\log 2\pi$ per
masked channel to the full-vector density. That is stripped **per step**, so
`log_likelihood` is the exact marginal $\log p(y_{\mathrm{obs}})$ and is
invariant to both the mask pattern and the dummy variance.

This is worth stating plainly because of how the bug hides: under a *fixed*
mask the missing correction is a constant offset, so it never changes an
argmax and a fixed-mask test passes with it present. It only becomes a
per-example bias once the mask varies across the batch — which is the sole
reason the feature exists — and it biases the model toward whichever series
happen to be more complete. The regression tests therefore vary the mask and
pin the offset exactly.

### Notes

- `_masked_obs_inputs` in `_ssm/_utils.py` is the shared substitution. It uses
  `where` rather than a multiply, so masked entries of `observations` may be
  `NaN` — the usual encoding for "not measured".
- The `(T,)` path keeps its `lax.cond` predict-only branch and is
  **bit-identical**; both mask paths share one `_update` body.
- The parallel filter now works per-channel throughout, since a `(T,)` gate is
  just the case where a step's channels share one flag. Element 0 (which
  absorbs the prior) takes the active branch on substituted inputs when
  partially observed.
- Operator-typed `obs_model` / `obs_noise` are materialised under a `(T, M)`
  mask. Zeroing rows against a traced per-step mask is inherently dense, and
  `MaskedOperator` can't serve here — it does static sub-selection on a square
  base. Documented rather than silent.
- `form="sqrt"` raises `NotImplementedError` for `(T, M)` masks.
- `rts_smoother` needs no change (it reads only filter moments). Now
  *demonstrated* rather than asserted, via a test against a NumPy RTS run over
  the row-deleted reference.

## distributions: LGSSM / MaskedLGSSM / LGSSMFactory (#209)

State-space models as numpyro densities behind the `[numpyro]` extra,
mirroring `MultivariateNormal`. `log_prob` delegates to `kalman_filter` rather
than re-deriving the recursion; `sample` is `lax.scan` ancestral simulation;
`event_shape` is `(T, M)` so `log_prob` returns a scalar with no `.to_event()`
wrapping.

Declarative `pytree_data_fields` only. A hand-written `tree_unflatten` that
re-runs `__init__` passes `log_prob` and `sample` tests and *then* dies inside
`eqx.filter_grad`, because `eqx.partition` walks the tree with boolean
sentinel leaves and any `__init__` inferring shapes from its arguments
explodes on reconstruction. Round-trip and `eqx.partition` tests guard it.

### Two deviations from the issue spec

1. **`A`/`H`/`Q`/`R` accept lineax operators**, not just dense arrays, matching
   `kalman_filter`'s existing contract. Otherwise a user with a Kronecker `R`
   can call `kalman_filter` but not `LGSSM`. Structured `Q`/`R` keep their
   structure through the Cholesky in `sample`, `H` through the sandwich in
   `variance`. `m0`/`P0` stay dense, because `kalman_filter`'s `init_cov` is
   array-only — accepting an operator there would mean a hidden
   materialisation at the boundary.
2. **The mask field is `obs_mask`, not `mask`.** numpyro's
   `Distribution.mask` is an inherited *method* returning a
   `MaskedDistribution` (it backs `numpyro.sample(..., obs_mask=...)`).
   Shadowing it with an array would silently break that API on this subclass
   while leaving it working on `LGSSM` — an inconsistency a reader would trip
   over.

`variance` also contracts straight to the diagonal instead of forming
`H P Hᵀ` and discarding its off-diagonal.

## Testing

Verified against **two independent references**: a row-deleted filter that
physically drops unobserved rows, and the dense `(TM, TM)` joint Gaussian
restricted to the observed entries.

| check | target | measured |
|---|---|---|
| filtered means vs row-deleted | ≤ 1e-14 | 3.3e-16 |
| filtered covs vs row-deleted | ≤ 1e-14 | 3.6e-15 |
| log-likelihood vs row-deleted | ≤ 1e-13 | 7.1e-15 |
| masked LL vs dense joint marginal | ≤ 1e-13 | 1.4e-14 |
| `LGSSM.log_prob` vs dense joint | ≤ 1e-13 | ~1e-14 |
| all-`True` `(T, M)` mask vs unmasked | — | bit-identical |
| `(T,)` mask vs its `(T, M)` broadcast | — | bit-identical |

Regression tests for the correction: invariance across `r_dummy ∈ {1, 4, 100}`,
and the naive-minus-corrected gap equal to `n_missing × 0.5 × log(2π)` exactly.

### Test-time classification

Compile-heavy cases are marked `slow`, matching how `test_parallel_kalman.py`
already marks its suite. The cost here is JIT, not arithmetic — the
associative-scan trace alone is ~10s, and marking one test slow just migrates
that cost to whichever test traces the program next, so the parallel group is
marked as a unit. **Every acceptance criterion of both issues stays in the
fast lane**, which runs in ~37s (was ~90s).

### Two flakes found

- **Mine, fixed.** The float32 test's `1e-5` relative bound sat on the real
  tail. A 30-seed sweep measured ~3e-6 median with a 1.3e-5 tail — honest
  float32 accumulation over 60 steps, not a defect — so the bound is now
  `5e-5`, still ~4 orders below the ~100-nat shift the test exists to catch.
  The reasoning is in the test's docstring. Two covariance tolerances in the
  same file are likewise scaled to the reference magnitude, since `getkey`
  reseeds per run.
- **Pre-existing, untouched.**
  `test_stochastic_estimators.py::TestPivotedCholeskyViaMatfree::test_rank_deficient_request_is_nan_free`
  fails on some `getkey` seeds on `main` as well as on this branch — same
  seed-dependent-tolerance pattern. Out of scope here; worth its own issue.

## Checks

- `make test` (fast lane): 1446 passed, plus the pre-existing flake above
- New files run clean 3× consecutively under random seed ordering
- `ruff check .`, `ruff format --check .`, `ty check src/gaussx`: all clean
- All 16 new docstring examples execute correctly under `doctest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
