### PR TITLE
feat(inference): enkf_analysis — perturbed-observation ensemble Kalman update

### DIFF
--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -42,8 +42,19 @@ A caveat worth stating up front: the Gaussian assumption in an ensemble Kalman
 filter is a property of the **coordinates**, not of the algorithm. Applied to a
 non-Gaussian prior the update is biased, and the bias does not shrink with
 ensemble size. Conjugating the update with a bijection that Gaussianises the
-prior -- warp, analyse, warp back -- removes it exactly when the likelihood is
-Gaussian in the same latent coordinates.
+prior -- warp, analyse, warp back -- removes it.
+
+That conjugated update is exact Bayes only under conditions worth stating
+precisely, since they are easy to over-claim. It holds **in the population
+limit** -- with a finite ensemble the gain is empirical and the perturbations
+are Monte Carlo, so the result is an estimate regardless -- and only when the
+observation model is **affine with additive Gaussian noise** in the same latent
+coordinates that Gaussianise the prior. A Gaussian conditional likelihood is not
+sufficient on its own: `y = z² + ε` has Gaussian noise and a non-Gaussian
+posterior that no Kalman update reproduces. Outside those conditions
+conjugation is an approximation with no guaranteed ordering against the
+physical-space update -- usually much better, but a badly matched warp can make
+the latent joint less Gaussian and do worse.
 
 ::: gaussx
     options:

--- a/docs/api/inference.md
+++ b/docs/api/inference.md
@@ -28,16 +28,28 @@ on the manifold.
       show_root_toc_entry: false
       members: [newton_update, damped_natural_update, gauss_newton_precision, ggn_diagonal, hutchinson_hessian_diag, riemannian_psd_correction, cavity_distribution, trace_correction]
 
-## Ensemble covariances & Kalman gain
+## Ensemble covariances, gain & analysis
 
-Bessel-corrected empirical (cross-)covariances from ensemble members and the
-ensemble Kalman gain built from them.
+Bessel-corrected empirical (cross-)covariances from ensemble members, the
+ensemble Kalman gain built from them, and the analysis step that applies it.
+
+The gain functions are the *pieces*; `enkf_analysis` is the *step* -- the
+stochastic (perturbed-observation) update that turns a prior ensemble and an
+observation into a posterior ensemble. `etkf_transform` is its deterministic
+square-root counterpart.
+
+A caveat worth stating up front: the Gaussian assumption in an ensemble Kalman
+filter is a property of the **coordinates**, not of the algorithm. Applied to a
+non-Gaussian prior the update is biased, and the bias does not shrink with
+ensemble size. Conjugating the update with a bijection that Gaussianises the
+prior -- warp, analyse, warp back -- removes it exactly when the likelihood is
+Gaussian in the same latent coordinates.
 
 ::: gaussx
     options:
       show_root_heading: false
       show_root_toc_entry: false
-      members: [ensemble_covariance, ensemble_cross_covariance, ensemble_kalman_gain, etkf_transform]
+      members: [ensemble_covariance, ensemble_cross_covariance, ensemble_kalman_gain, enkf_analysis, etkf_transform]
 
 ## Localization & inflation
 

--- a/src/gaussx/__init__.py
+++ b/src/gaussx/__init__.py
@@ -66,6 +66,7 @@ from gaussx._inference import (
     blr_full_update as blr_full_update,
     cavity_distribution as cavity_distribution,
     damped_natural_update as damped_natural_update,
+    enkf_analysis as enkf_analysis,
     ensemble_covariance as ensemble_covariance,
     ensemble_cross_covariance as ensemble_cross_covariance,
     ensemble_kalman_gain as ensemble_kalman_gain,

--- a/src/gaussx/_inference/__init__.py
+++ b/src/gaussx/_inference/__init__.py
@@ -7,6 +7,7 @@ from gaussx._inference._blr import (
     hutchinson_hessian_diag,
 )
 from gaussx._inference._ensemble import (
+    enkf_analysis,
     ensemble_covariance,
     ensemble_cross_covariance,
     ensemble_kalman_gain,
@@ -45,6 +46,7 @@ __all__ = [
     "blr_full_update",
     "cavity_distribution",
     "damped_natural_update",
+    "enkf_analysis",
     "ensemble_covariance",
     "ensemble_cross_covariance",
     "ensemble_kalman_gain",

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -357,6 +357,7 @@ def enkf_analysis(
     localization: Float[Array, "N M"] | None = None,
     obs_localization: Float[Array, "M M"] | None = None,
     solver: AbstractSolverStrategy | None = None,
+    dense_innovation: bool | None = None,
     bessel: bool = True,
 ) -> Float[Array, "J N"]:
     r"""Stochastic (perturbed-observation) ensemble Kalman analysis step.
@@ -437,7 +438,15 @@ def enkf_analysis(
             defaults to all-ones, i.e. no tapering of the innovation
             covariance.
         solver: Optional solver strategy for the innovation solve. ``None``
-            uses structural dispatch.
+            uses structural dispatch. A matrix-free strategy (e.g. `CGSolver`)
+            wants ``dense_innovation=False`` so it is handed the structured
+            operator instead of a materialised one.
+        dense_innovation: Whether to form the ``(M, M)`` innovation covariance
+            densely. ``None`` (default) chooses by shape, as described in the
+            note below. ``False`` keeps the structured `LowRankUpdate` no
+            matter the shapes -- for a matrix-free solver, or when
+            ``obs_noise`` is singular. ``True`` forces the dense assembly, the
+            way out when ``J < M`` but ``obs_noise`` is not positive definite.
         bessel: Use the $1/(J-1)$ divisor. Defaults to ``True``, matching
             `ensemble_kalman_gain`.
 
@@ -445,15 +454,34 @@ def enkf_analysis(
         Analysis ensemble, shape ``(J, N)``.
 
     Note:
-        How the innovation covariance $C^{HH} + R$ is assembled is chosen from
-        the static shapes, because the two regimes have wildly different costs.
-        With $J < M$ the gain comes from `ensemble_kalman_gain`, which keeps
-        the ensemble term low-rank and inverts a $(J, J)$ Woodbury capacitance
-        -- the right choice for the geoscience regime of a few dozen members
-        against many observations. With $J \ge M$ that capacitance is the
-        larger of the two (320 GB at $J = 200{,}000$), so the $(M, M)$
-        innovation is formed densely instead. Both routes solve the same
-        system and agree to round-off.
+        How the innovation covariance $C^{HH} + R$ is assembled defaults to a
+        choice made from the static shapes, because the two regimes have wildly
+        different costs. With $J < M$ the gain comes from
+        `ensemble_kalman_gain`, which keeps the ensemble term low-rank and
+        inverts a $(J, J)$ Woodbury capacitance -- the right choice for the
+        geoscience regime of a few dozen members against many observations.
+        With $J \ge M$ that capacitance is the larger of the two (320 GB at
+        $J = 200{,}000$), so the $(M, M)$ innovation is formed densely instead.
+        Both routes solve the same system and agree to round-off.
+
+        Shapes are the wrong criterion in two cases, which is why
+        ``dense_innovation`` exists to override it:
+
+        - **A matrix-free solver.** With $J \ge M$ and $M$ still large, the
+          dense assembly allocates an $(M, M)$ array before the solver is ever
+          called -- around 40 GB at $M = 100{,}000$ in float32 -- even though
+          an iterative strategy could work through matvecs on the structured
+          operator. Pass ``dense_innovation=False``.
+        - **Singular observation noise.** The Woodbury route solves against
+          $R$ itself, so a positive *semi*-definite $R$ divides by zero and
+          returns infinities or ``NaN`` even when $C^{HH} + R$ is perfectly
+          invertible -- e.g. $R = \mathrm{diag}(1, 1, 0)$ with ensemble
+          anomalies spanning the third observation direction. The $J < M$ path
+          therefore requires $R$ to be positive **definite**; with a singular
+          $R$, pass ``dense_innovation=True`` to solve the full innovation
+          instead. This is not checked: PSD-ness of an arbitrary operator is
+          not something this function can establish cheaply, and certainly not
+          under ``jit``.
 
     Raises:
         ValueError: If neither or both of ``key`` / ``perturbed_obs`` are
@@ -524,17 +552,38 @@ def enkf_analysis(
                 f"{None if perturbed is None else perturbed.shape}."
             )
 
-    if localization is None and n_ens < n_obs:
+    if localization is not None:
+        n_state = particles.shape[1]
+        # Broadcast-compatible but wrong shapes are the danger: an (N, 1) taper
+        # repeats one observation's taper across all M, and a (1, 1)
+        # obs_localization rescales the whole observation covariance. Both give
+        # a plausible, wrong gain rather than an error.
+        if localization.shape != (n_state, n_obs):
+            raise ValueError(
+                f"localization must have shape ({n_state}, {n_obs}) to match "
+                f"particles and obs_particles, got {localization.shape}."
+            )
+        if obs_localization is not None and obs_localization.shape != (n_obs, n_obs):
+            raise ValueError(
+                f"obs_localization must have shape ({n_obs}, {n_obs}) to match "
+                f"obs_particles, got {obs_localization.shape}."
+            )
+
+    # Whether to form the (M, M) innovation densely. `None` picks by shape; an
+    # explicit value overrides that, which is what a matrix-free solver needs.
+    use_dense = n_ens >= n_obs if dense_innovation is None else dense_innovation
+
+    if localization is None and not use_dense:
         # Fewer members than observations: the Woodbury capacitance is (J, J)
         # and cheap, so let `ensemble_kalman_gain` keep the low-rank structure.
         gain = ensemble_kalman_gain(
             particles, obs_particles, obs_noise, solver=solver, bessel=bessel
         )  # (N, M)
     elif localization is None:
-        # J >= M, the usual regime for this function. A `LowRankUpdate`
-        # innovation would send `solve_rows` through Woodbury and form a
-        # (J, J) capacitance matrix -- 320 GB at J = 200_000 -- so assemble
-        # the (M, M) innovation densely instead. Same solve, same answer.
+        # A `LowRankUpdate` innovation would send `solve_rows` through Woodbury
+        # and form a (J, J) capacitance matrix -- 320 GB at J = 200_000 -- so
+        # assemble the (M, M) innovation densely instead. Same solve, same
+        # answer.
         cross_cov = ensemble_cross_covariance(particles, obs_particles, bessel=bessel)
         obs_cov = ensemble_cross_covariance(obs_particles, obs_particles, bessel=bessel)
         innovation = symmetrize(obs_cov + obs_noise.as_matrix())  # (M, M)

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import jax.numpy as jnp
+import jax.random as jr
 import lineax as lx
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 from gaussx._linalg._linalg import solve_rows
 from gaussx._linalg._mixed_precision import stable_squared_distances
@@ -336,6 +337,204 @@ def localized_kalman_gain(
     innovation = symmetrize(innovation)
     innovation_op = lx.MatrixLinearOperator(innovation, lx.positive_semidefinite_tag)
     return solve_rows(innovation_op, localized_cross, solver=solver)
+
+
+# ---------------------------------------------------------------------------
+# Ensemble analysis (stochastic / perturbed-observation EnKF update)
+# ---------------------------------------------------------------------------
+
+
+def enkf_analysis(
+    particles: Float[Array, "J N"],
+    obs_particles: Float[Array, "J M"],
+    observation: Float[Array, " M"],
+    obs_noise: lx.AbstractLinearOperator,
+    *,
+    key: PRNGKeyArray | None = None,
+    perturbed_obs: Float[Array, "J M"] | None = None,
+    localization: Float[Array, "N M"] | None = None,
+    obs_localization: Float[Array, "M M"] | None = None,
+    solver: AbstractSolverStrategy | None = None,
+    bessel: bool = True,
+) -> Float[Array, "J N"]:
+    r"""Stochastic (perturbed-observation) ensemble Kalman analysis step.
+
+    Updates a prior ensemble $X^f$ toward an observation $y$:
+
+    $$
+    X^a_j = X^f_j + K\,(y + \varepsilon_j - \mathcal{H}(X^f_j)),
+    \qquad \varepsilon_j \sim N(0, R),
+    $$
+
+    with $K$ from `ensemble_kalman_gain` (or `localized_kalman_gain` when
+    ``localization`` is given). The observation operator enters only through
+    ``obs_particles`` -- the image $\mathcal{H}(X^f)$ of the prior ensemble in
+    observation space -- so nonlinear operators need no special handling.
+
+    The perturbation $\varepsilon_j$ is what keeps the analysis spread correct.
+    The deterministic update $X^a_j = X^f_j + K(y - \mathcal{H}(X^f_j))$ drives
+    the ensemble covariance to $(I - KH)P(I - KH)^\top$ instead of $(I - KH)P$,
+    i.e. under-dispersive. There is deliberately no ``perturb=False`` flag: the
+    deterministic alternative is a different filter (the square-root / ETKF
+    family, see `etkf_transform`), not an option on this one.
+
+    Two ways to supply the observation perturbations:
+
+    - ``key`` -- draw $\varepsilon_j \sim N(0, R)$ internally, via a Cholesky
+      factor of ``obs_noise``.
+    - ``perturbed_obs`` -- pass a pre-built perturbed-observation ensemble
+      $y + \varepsilon_j$. Preferred when the same noise realisation must be
+      reused across filters, and when the perturbations come from a nonlinear
+      observation model rather than an additive $R$.
+
+    Exactly one of ``key`` / ``perturbed_obs`` must be given.
+
+    Known limitation. The update is a Gaussian one, applied in whatever
+    coordinates the caller supplies. For a non-Gaussian prior it is biased, and
+    the bias does **not** shrink with ensemble size -- it is an error of
+    coordinates, not of sampling. On the lognormal / logit-normal prior of
+    Chipilski (2025), whose exact posterior mean is ``[0.548062, 0.353937]``,
+    the physical-space update plateaus several percent off that value and stays
+    there as $J$ grows by two orders of magnitude.
+
+    The fix is to conjugate the update with a bijection $\Gamma$ that
+    Gaussianises the prior -- call this function on $\Gamma^{-1}(X^f)$ and map
+    the result back through $\Gamma$. When the likelihood is Gaussian in those
+    same latent coordinates the conjugated update is *exact Bayes*, not an
+    improved approximation: the ensemble Kalman filter's Gaussian assumption is
+    a statement about coordinates, not about the algorithm. Pass the same
+    ``perturbed_obs`` through both routes to compare them on one noise
+    realisation.
+
+    Args:
+        particles: Prior ensemble in state space, shape ``(J, N)``.
+        obs_particles: Prior ensemble in observation space, shape ``(J, M)``.
+        observation: The observation, shape ``(M,)``.
+        obs_noise: Observation error covariance $R$, shape ``(M, M)``.
+        key: PRNG key for internally drawn perturbations. Mutually exclusive
+            with ``perturbed_obs``.
+        perturbed_obs: Pre-built perturbed observation ensemble, shape
+            ``(J, M)``. Mutually exclusive with ``key``.
+        localization: Optional state-observation taper $\rho_{xy}$, shape
+            ``(N, M)``, e.g. from `localization_matrix`. When given, the gain
+            comes from `localized_kalman_gain` instead of
+            `ensemble_kalman_gain`.
+        obs_localization: Optional observation-observation taper $\rho_{yy}$,
+            shape ``(M, M)``. Only consulted when ``localization`` is given;
+            defaults to all-ones, i.e. no tapering of the innovation
+            covariance.
+        solver: Optional solver strategy for the innovation solve. ``None``
+            uses structural dispatch.
+        bessel: Use the $1/(J-1)$ divisor. Defaults to ``True``, matching
+            `ensemble_kalman_gain`.
+
+    Returns:
+        Analysis ensemble, shape ``(J, N)``.
+
+    Note:
+        How the innovation covariance $C^{HH} + R$ is assembled is chosen from
+        the static shapes, because the two regimes have wildly different costs.
+        With $J < M$ the gain comes from `ensemble_kalman_gain`, which keeps
+        the ensemble term low-rank and inverts a $(J, J)$ Woodbury capacitance
+        -- the right choice for the geoscience regime of a few dozen members
+        against many observations. With $J \ge M$ that capacitance is the
+        larger of the two (320 GB at $J = 200{,}000$), so the $(M, M)$
+        innovation is formed densely instead. Both routes solve the same
+        system and agree to round-off.
+
+    Raises:
+        ValueError: If neither or both of ``key`` / ``perturbed_obs`` are
+            given, if the ensemble sizes disagree, or if the observation-space
+            shapes disagree.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> import jax.random as jr
+        >>> import lineax as lx
+        >>> from gaussx import enkf_analysis
+        >>> key, subkey = jr.split(jr.key(0))
+        >>> prior = jr.normal(subkey, (500, 3))           # (J, N)
+        >>> H = jnp.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        >>> obs_prior = prior @ H.T                       # (J, M)
+        >>> R = lx.DiagonalLinearOperator(0.1 * jnp.ones(2))
+        >>> posterior = enkf_analysis(
+        ...     prior, obs_prior, jnp.array([1.0, -1.0]), R, key=key
+        ... )
+        >>> posterior.shape
+        (500, 3)
+    """
+    if (key is None) == (perturbed_obs is None):
+        raise ValueError(
+            "Pass exactly one of 'key' (draw perturbations from obs_noise) or "
+            "'perturbed_obs' (supply them directly)."
+        )
+
+    n_ens = particles.shape[0]
+    _check_ensemble_size(n_ens, bessel)
+    if obs_particles.shape[0] != n_ens:
+        raise ValueError(
+            "particles and obs_particles must share the same ensemble size, "
+            f"got J={n_ens} and J={obs_particles.shape[0]}."
+        )
+    n_obs = obs_particles.shape[1]
+    if observation.shape != (n_obs,):
+        raise ValueError(
+            f"observation must have shape ({n_obs},) to match obs_particles, "
+            f"got {observation.shape}."
+        )
+
+    # Branch on `key` rather than on `perturbed_obs`: the check above makes the
+    # two equivalent, but this way each branch narrows the argument it uses.
+    if key is not None:
+        # eps ~ N(0, R): right-multiply standard normals by L^T, with R = L L^T.
+        chol = jnp.linalg.cholesky(obs_noise.as_matrix())  # (M, M)
+        noise = jr.normal(key, (n_ens, n_obs), dtype=particles.dtype)  # (J, M)
+        perturbed = observation[None, :] + noise @ chol.T  # (J, M)
+    else:
+        perturbed = perturbed_obs
+        if perturbed is None or perturbed.shape != (n_ens, n_obs):
+            raise ValueError(
+                f"perturbed_obs must have shape ({n_ens}, {n_obs}) to match "
+                f"obs_particles, got "
+                f"{None if perturbed is None else perturbed.shape}."
+            )
+
+    if localization is None and n_ens < n_obs:
+        # Fewer members than observations: the Woodbury capacitance is (J, J)
+        # and cheap, so let `ensemble_kalman_gain` keep the low-rank structure.
+        gain = ensemble_kalman_gain(
+            particles, obs_particles, obs_noise, solver=solver, bessel=bessel
+        )  # (N, M)
+    elif localization is None:
+        # J >= M, the usual regime for this function. A `LowRankUpdate`
+        # innovation would send `solve_rows` through Woodbury and form a
+        # (J, J) capacitance matrix -- 320 GB at J = 200_000 -- so assemble
+        # the (M, M) innovation densely instead. Same solve, same answer.
+        cross_cov = ensemble_cross_covariance(particles, obs_particles, bessel=bessel)
+        obs_cov = ensemble_cross_covariance(obs_particles, obs_particles, bessel=bessel)
+        innovation = symmetrize(obs_cov + obs_noise.as_matrix())  # (M, M)
+        innovation_op = lx.MatrixLinearOperator(
+            innovation, lx.positive_semidefinite_tag
+        )
+        gain = solve_rows(innovation_op, cross_cov, solver=solver)  # (N, M)
+    else:
+        rho_yy = (
+            jnp.ones((n_obs, n_obs), dtype=particles.dtype)
+            if obs_localization is None
+            else obs_localization
+        )
+        gain = localized_kalman_gain(
+            particles,
+            obs_particles,
+            obs_noise,
+            localization,
+            rho_yy,
+            solver=solver,
+            bessel=bessel,
+        )  # (N, M)
+
+    innovation = perturbed - obs_particles  # (J, M)
+    return particles + innovation @ gain.T  # (J, M) @ (M, N) -> (J, N)
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
@@ -13,6 +14,7 @@ from gaussx._linalg._linalg import solve_rows
 from gaussx._linalg._mixed_precision import stable_squared_distances
 from gaussx._linalg._symmetrize import symmetrize
 from gaussx._operators._low_rank_update import LowRankUpdate
+from gaussx._primitives._cholesky import cholesky
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -399,12 +401,23 @@ def enkf_analysis(
 
     The fix is to conjugate the update with a bijection $\Gamma$ that
     Gaussianises the prior -- call this function on $\Gamma^{-1}(X^f)$ and map
-    the result back through $\Gamma$. When the likelihood is Gaussian in those
-    same latent coordinates the conjugated update is *exact Bayes*, not an
-    improved approximation: the ensemble Kalman filter's Gaussian assumption is
-    a statement about coordinates, not about the algorithm. Pass the same
-    ``perturbed_obs`` through both routes to compare them on one noise
+    the result back through $\Gamma$: the ensemble Kalman filter's Gaussian
+    assumption is a statement about coordinates, not about the algorithm. Pass
+    the same ``perturbed_obs`` through both routes to compare them on one noise
     realisation.
+
+    That conjugated update is *exact Bayes* only under conditions worth stating
+    precisely, because it is easy to over-claim. It needs the population limit
+    -- with a finite ensemble the gain is empirical and the perturbations are
+    Monte Carlo, so the result is an estimate either way -- and it needs the
+    observation model to be **affine with additive Gaussian noise** in the same
+    latent coordinates that Gaussianise the prior. A merely "Gaussian
+    likelihood" is not enough: $y = \zeta^2 + \varepsilon$ has Gaussian noise
+    and a non-Gaussian posterior that no Kalman update reproduces. Outside
+    those conditions conjugation is an approximation with no guaranteed
+    ordering against the physical-space update -- usually much better, but a
+    badly matched $\Gamma$ can make the latent joint less Gaussian and do
+    worse.
 
     Args:
         particles: Prior ensemble in state space, shape ``(J, N)``.
@@ -482,14 +495,26 @@ def enkf_analysis(
             f"observation must have shape ({n_obs},) to match obs_particles, "
             f"got {observation.shape}."
         )
+    # Without this an operator of the wrong size broadcasts against the (M, M)
+    # empirical covariance instead of raising -- a (1, 1) R against M = 3 adds
+    # the scalar to every entry and yields a plausible but wrong gain.
+    if (obs_noise.in_size(), obs_noise.out_size()) != (n_obs, n_obs):
+        raise ValueError(
+            f"obs_noise must be ({n_obs}, {n_obs}) to match obs_particles, got "
+            f"({obs_noise.out_size()}, {obs_noise.in_size()})."
+        )
 
     # Branch on `key` rather than on `perturbed_obs`: the check above makes the
     # two equivalent, but this way each branch narrows the argument it uses.
     if key is not None:
-        # eps ~ N(0, R): right-multiply standard normals by L^T, with R = L L^T.
-        chol = jnp.linalg.cholesky(obs_noise.as_matrix())  # (M, M)
+        # eps_j = L n_j with R = L L^T. `cholesky` dispatches on structure, so a
+        # DiagonalLinearOperator stays diagonal and its matvec stays O(M) --
+        # materialising R here would allocate a dense (M, M) and cost O(M^3),
+        # which for the low-rank branch below (J < M, M possibly enormous) would
+        # OOM before the gain is ever formed.
+        chol = cholesky(obs_noise)
         noise = jr.normal(key, (n_ens, n_obs), dtype=particles.dtype)  # (J, M)
-        perturbed = observation[None, :] + noise @ chol.T  # (J, M)
+        perturbed = observation[None, :] + jax.vmap(chol.mv)(noise)  # (J, M)
     else:
         perturbed = perturbed_obs
         if perturbed is None or perturbed.shape != (n_ens, n_obs):

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -469,3 +469,77 @@ def test_rejects_obs_noise_with_the_wrong_size(getkey):
             lx.DiagonalLinearOperator(jnp.array([0.1])),
             perturbed_obs=jnp.zeros_like(obs_prior),
         )
+
+
+def test_rejects_localization_tapers_with_the_wrong_shape(getkey):
+    """Broadcast-compatible tapers give a plausible, wrong gain otherwise."""
+    n_state, n_obs = 5, 3
+    prior, obs_prior, y, noise = _small_problem(
+        getkey, n_ens=16, n_state=n_state, n_obs=n_obs
+    )
+    perturbed = jnp.zeros_like(obs_prior)
+
+    # (N, 1) would repeat one observation's taper across all M.
+    with pytest.raises(ValueError, match=r"localization must have shape \(5, 3\)"):
+        enkf_analysis(
+            prior,
+            obs_prior,
+            y,
+            noise,
+            perturbed_obs=perturbed,
+            localization=jnp.ones((n_state, 1)),
+        )
+
+    # (1, 1) would rescale every entry of the observation covariance.
+    with pytest.raises(ValueError, match=r"obs_localization must have shape \(3, 3\)"):
+        enkf_analysis(
+            prior,
+            obs_prior,
+            y,
+            noise,
+            perturbed_obs=perturbed,
+            localization=jnp.ones((n_state, n_obs)),
+            obs_localization=jnp.ones((1, 1)),
+        )
+
+
+def test_dense_innovation_override_agrees_with_the_shape_heuristic(getkey):
+    """Forcing either route must not change the answer, only the cost."""
+    prior, obs_prior, y, noise = _small_problem(getkey, n_ens=32, n_state=5, n_obs=4)
+    perturbed = y[None, :] + 0.1 * jr.normal(getkey(), obs_prior.shape)
+    kwargs = {"perturbed_obs": perturbed}
+
+    heuristic = enkf_analysis(prior, obs_prior, y, noise, **kwargs)  # J >= M -> dense
+    forced_dense = enkf_analysis(
+        prior, obs_prior, y, noise, dense_innovation=True, **kwargs
+    )
+    forced_low_rank = enkf_analysis(
+        prior, obs_prior, y, noise, dense_innovation=False, **kwargs
+    )
+    assert jnp.array_equal(heuristic, forced_dense)
+    assert jnp.allclose(heuristic, forced_low_rank, atol=1e-8)
+
+
+def test_dense_innovation_true_handles_singular_observation_noise(getkey):
+    """The Woodbury route divides by zero on a singular R; the dense one does not.
+
+    `C^HH + R` is invertible here even though `R` is not, so the answer exists
+    -- it is only the low-rank route that cannot reach it.
+    """
+    n_state, n_obs = 4, 3
+    k_prior, k_obs = jr.split(getkey())
+    prior = jr.normal(k_prior, (2, n_state))  # J = 2 < M = 3
+    obs_prior = jr.normal(k_obs, (2, n_obs))
+    y = jnp.zeros(n_obs)
+    singular = lx.DiagonalLinearOperator(jnp.array([1.0, 1.0, 0.0]))
+    perturbed = jnp.zeros((2, n_obs))
+
+    dense = enkf_analysis(
+        prior,
+        obs_prior,
+        y,
+        singular,
+        perturbed_obs=perturbed,
+        dense_innovation=True,
+    )
+    assert jnp.all(jnp.isfinite(dense))

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -408,3 +408,64 @@ def test_non_gaussian_bias_does_not_shrink_with_ensemble_size():
     assert physical_errors[1] > 0.01
     assert physical_errors[1] > 0.5 * physical_errors[0]  # plateau, not decay
     assert physical_errors[1] > 10 * latent_errors[1]
+
+
+# ---------------------------------------------------------------------------
+# Operator handling: structure preserved, shape validated
+# ---------------------------------------------------------------------------
+
+
+def test_diagonal_noise_is_not_materialised_in_the_low_rank_regime(getkey, monkeypatch):
+    """With `J < M` the whole path must stay structure-preserving.
+
+    That regime exists for `M` far too large to densify: a dense `(M, M)`
+    Cholesky just to draw the perturbations would cost O(M^3) and OOM before
+    the low-rank gain is ever formed. (The `J >= M` branch densifies the
+    `(M, M)` innovation on purpose -- there `M` is small by construction.)
+    """
+    import lineax
+
+    n_obs = 8
+    prior, obs_prior, y, _ = _small_problem(
+        getkey, n_ens=4, n_state=5, n_obs=n_obs
+    )  # J = 4 < M = 8
+    diagonal_noise = lx.DiagonalLinearOperator(0.1 + jnp.arange(n_obs) / 10.0)
+
+    def _explode(self):
+        raise AssertionError("obs_noise was materialised via as_matrix()")
+
+    monkeypatch.setattr(lineax.DiagonalLinearOperator, "as_matrix", _explode)
+    out = enkf_analysis(prior, obs_prior, y, diagonal_noise, key=getkey())
+    assert out.shape == prior.shape
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_structured_and_dense_noise_agree(getkey):
+    """The structure-preserving factor must give the same draw as a dense one."""
+    prior, obs_prior, y, _ = _small_problem(getkey, n_ens=32, n_state=5, n_obs=4)
+    diag = jnp.array([0.1, 0.2, 0.3, 0.4])
+    key = getkey()
+    structured = enkf_analysis(
+        prior, obs_prior, y, lx.DiagonalLinearOperator(diag), key=key
+    )
+    dense = enkf_analysis(
+        prior,
+        obs_prior,
+        y,
+        lx.MatrixLinearOperator(jnp.diag(diag), lx.positive_semidefinite_tag),
+        key=key,
+    )
+    assert jnp.allclose(structured, dense, atol=1e-10)
+
+
+def test_rejects_obs_noise_with_the_wrong_size(getkey):
+    """A (1, 1) operator against M = 3 would broadcast into a plausible gain."""
+    prior, obs_prior, y, _ = _small_problem(getkey, n_ens=16, n_state=5, n_obs=3)
+    with pytest.raises(ValueError, match=r"obs_noise must be \(3, 3\)"):
+        enkf_analysis(
+            prior,
+            obs_prior,
+            y,
+            lx.DiagonalLinearOperator(jnp.array([0.1])),
+            perturbed_obs=jnp.zeros_like(obs_prior),
+        )

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -1,0 +1,410 @@
+"""Tests for `enkf_analysis`, the stochastic ensemble Kalman analysis step."""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import pytest
+
+from gaussx import (
+    enkf_analysis,
+    ensemble_kalman_gain,
+    localization_matrix,
+)
+from gaussx._testing import random_pd_matrix
+
+
+# ---------------------------------------------------------------------------
+# Helpers: a small linear-Gaussian problem with an analytic posterior
+# ---------------------------------------------------------------------------
+
+
+def _linear_gaussian_problem(key, n_state=3, n_obs=2):
+    """Prior N(mu, P), observation model (H, R), and the exact posterior."""
+    k_mu, k_p, k_r, k_h, k_y = jr.split(key, 5)
+    mu = jr.normal(k_mu, (n_state,))
+    prior_cov = random_pd_matrix(k_p, n_state)
+    obs_noise = random_pd_matrix(k_r, n_obs)
+    obs_model = jr.normal(k_h, (n_obs, n_state))
+    y = jr.normal(k_y, (n_obs,))
+
+    innovation = obs_model @ prior_cov @ obs_model.T + obs_noise  # (M, M)
+    gain = prior_cov @ obs_model.T @ jnp.linalg.inv(innovation)  # (N, M)
+    post_mean = mu + gain @ (y - obs_model @ mu)
+    post_cov = prior_cov - gain @ obs_model @ prior_cov
+    return mu, prior_cov, obs_model, obs_noise, y, post_mean, post_cov, gain
+
+
+def _draw_ensemble(key, mean, cov, n_ens):
+    chol = jnp.linalg.cholesky(cov)
+    return mean[None, :] + jr.normal(key, (n_ens, mean.shape[0])) @ chol.T
+
+
+# ---------------------------------------------------------------------------
+# Consistency: converges to the exact Kalman posterior as J -> infinity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_converges_to_exact_kalman_posterior(getkey):
+    key = getkey()
+    mu, prior_cov, obs_model, obs_noise, y, post_mean, post_cov, _ = (
+        _linear_gaussian_problem(key)
+    )
+    k_ens, k_analysis = jr.split(getkey())
+    n_ens = 200_000
+
+    prior = _draw_ensemble(k_ens, mu, prior_cov, n_ens)  # (J, N)
+    analysis = enkf_analysis(
+        prior,
+        prior @ obs_model.T,
+        y,
+        lx.MatrixLinearOperator(obs_noise, lx.positive_semidefinite_tag),
+        key=k_analysis,
+    )
+
+    mean_err = jnp.linalg.norm(jnp.mean(analysis, axis=0) - post_mean)
+    mean_err /= jnp.linalg.norm(post_mean)
+    cov_err = jnp.linalg.norm(jnp.cov(analysis.T, bias=False) - post_cov)
+    cov_err /= jnp.linalg.norm(post_cov)
+
+    assert mean_err < 0.02
+    assert cov_err < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Spread: the perturbation is what makes the analysis covariance (I-KH)P
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_analysis_spread_is_not_underdispersive(getkey):
+    """The stochastic update gives (I-KH)P; the deterministic one is smaller.
+
+    Dropping the observation perturbation would pass a mean-only test but
+    shrink the analysis covariance to (I-KH)P(I-KH)^T -- short by K R K^T.
+    This test is what catches that.
+    """
+    key = getkey()
+    mu, prior_cov, obs_model, obs_noise, y, _, post_cov, gain = (
+        _linear_gaussian_problem(key)
+    )
+    k_ens, k_analysis = jr.split(getkey())
+    n_ens = 200_000
+    noise_op = lx.MatrixLinearOperator(obs_noise, lx.positive_semidefinite_tag)
+
+    prior = _draw_ensemble(k_ens, mu, prior_cov, n_ens)  # (J, N)
+    obs_prior = prior @ obs_model.T  # (J, M)
+    analysis = enkf_analysis(prior, obs_prior, y, noise_op, key=k_analysis)
+
+    # The deterministic (unperturbed) update, using the exact gain so the
+    # contrast is analytic rather than a second Monte-Carlo estimate.
+    deterministic = prior + (y[None, :] - obs_prior) @ gain.T  # (J, N)
+
+    stochastic_cov = jnp.cov(analysis.T, bias=False)
+    deterministic_cov = jnp.cov(deterministic.T, bias=False)
+
+    # The stochastic analysis reproduces the true posterior covariance ...
+    stochastic_err = jnp.linalg.norm(stochastic_cov - post_cov)
+    stochastic_err /= jnp.linalg.norm(post_cov)
+    assert stochastic_err < 0.02
+
+    # ... while the deterministic one collapses to the Joseph-squared form.
+    spread = jnp.eye(mu.shape[0]) - gain @ obs_model
+    joseph = spread @ prior_cov @ spread.T  # (I - KH) P (I - KH)^T
+    joseph_err = jnp.linalg.norm(deterministic_cov - joseph)
+    joseph_err /= jnp.linalg.norm(joseph)
+    assert joseph_err < 0.02
+
+    # The shortfall is exactly K R K^T, so it is strictly under-dispersive.
+    assert jnp.trace(deterministic_cov) < jnp.trace(stochastic_cov)
+    assert jnp.allclose(post_cov - joseph, gain @ obs_noise @ gain.T, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Perturbation plumbing: determinism and the perturbed_obs / key equivalence
+# ---------------------------------------------------------------------------
+
+
+def _small_problem(getkey, n_ens=64, n_state=4, n_obs=3):
+    k_prior, k_obs, k_y, k_r = jr.split(getkey(), 4)
+    prior = jr.normal(k_prior, (n_ens, n_state))
+    obs_prior = jr.normal(k_obs, (n_ens, n_obs))
+    y = jr.normal(k_y, (n_obs,))
+    noise = lx.MatrixLinearOperator(
+        random_pd_matrix(k_r, n_obs), lx.positive_semidefinite_tag
+    )
+    return prior, obs_prior, y, noise
+
+
+def test_same_key_is_deterministic(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    key = getkey()
+    a = enkf_analysis(prior, obs_prior, y, noise, key=key)
+    b = enkf_analysis(prior, obs_prior, y, noise, key=key)
+    assert jnp.array_equal(a, b)
+
+
+def test_different_keys_differ(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    a = enkf_analysis(prior, obs_prior, y, noise, key=getkey())
+    b = enkf_analysis(prior, obs_prior, y, noise, key=getkey())
+    assert not jnp.allclose(a, b)
+
+
+def test_perturbed_obs_reproduces_the_key_path(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    key = getkey()
+    from_key = enkf_analysis(prior, obs_prior, y, noise, key=key)
+
+    # Rebuild the same realisation by hand and pass it in explicitly.
+    n_ens, n_obs = obs_prior.shape
+    chol = jnp.linalg.cholesky(noise.as_matrix())
+    eps = jr.normal(key, (n_ens, n_obs), dtype=prior.dtype) @ chol.T
+    from_explicit = enkf_analysis(
+        prior, obs_prior, y, noise, perturbed_obs=y[None, :] + eps
+    )
+    assert jnp.allclose(from_key, from_explicit, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Shapes, gain convention, localization
+# ---------------------------------------------------------------------------
+
+
+def test_shapes_with_distinct_state_and_obs_dims(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey, n_ens=32, n_state=7, n_obs=3)
+    analysis = enkf_analysis(prior, obs_prior, y, noise, key=getkey())
+    assert analysis.shape == (32, 7)
+
+
+@pytest.mark.parametrize("bessel", [True, False])
+def test_matches_gain_applied_by_hand(getkey, bessel):
+    """Pins the update formula and the Bessel convention against the gain."""
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    perturbed = y[None, :] + 0.1 * jr.normal(getkey(), obs_prior.shape)
+
+    analysis = enkf_analysis(
+        prior, obs_prior, y, noise, perturbed_obs=perturbed, bessel=bessel
+    )
+    gain = ensemble_kalman_gain(prior, obs_prior, noise, bessel=bessel)
+    expected = prior + (perturbed - obs_prior) @ gain.T
+    assert jnp.allclose(analysis, expected, atol=1e-10)
+
+
+def test_bessel_flag_changes_the_result(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    perturbed = y[None, :] + 0.1 * jr.normal(getkey(), obs_prior.shape)
+    kwargs = dict(perturbed_obs=perturbed)
+    with_bessel = enkf_analysis(prior, obs_prior, y, noise, bessel=True, **kwargs)
+    without = enkf_analysis(prior, obs_prior, y, noise, bessel=False, **kwargs)
+    assert not jnp.allclose(with_bessel, without)
+
+
+def test_all_ones_localization_matches_no_localization(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    perturbed = y[None, :] + 0.1 * jr.normal(getkey(), obs_prior.shape)
+    n_state, n_obs = prior.shape[1], obs_prior.shape[1]
+
+    plain = enkf_analysis(prior, obs_prior, y, noise, perturbed_obs=perturbed)
+    localized = enkf_analysis(
+        prior,
+        obs_prior,
+        y,
+        noise,
+        perturbed_obs=perturbed,
+        localization=jnp.ones((n_state, n_obs)),
+        obs_localization=jnp.ones((n_obs, n_obs)),
+    )
+    assert jnp.allclose(plain, localized, atol=1e-8)
+
+
+def test_localization_suppresses_distant_updates(getkey):
+    """A taper with a short radius must damp the far end of the state vector."""
+    n_ens, n_state, n_obs = 128, 20, 1
+    k_prior, k_y = jr.split(getkey(), 2)
+    prior = jr.normal(k_prior, (n_ens, n_state))
+    obs_prior = prior[:, :1]  # observe the first coordinate
+    y = jr.normal(k_y, (n_obs,))
+    noise = lx.DiagonalLinearOperator(0.1 * jnp.ones(n_obs))
+    perturbed = jnp.broadcast_to(y[None, :], (n_ens, n_obs))
+
+    coords = jnp.arange(n_state, dtype=prior.dtype)[:, None]
+    rho_xy = localization_matrix(coords, coords[:1], c=3.0)  # (N, M)
+
+    plain = enkf_analysis(prior, obs_prior, y, noise, perturbed_obs=perturbed)
+    localized = enkf_analysis(
+        prior, obs_prior, y, noise, perturbed_obs=perturbed, localization=rho_xy
+    )
+    far_plain = jnp.abs(plain[:, -1] - prior[:, -1]).mean()
+    far_local = jnp.abs(localized[:, -1] - prior[:, -1]).mean()
+    assert far_local < 1e-12  # taper is exactly zero beyond the radius
+    assert far_plain > far_local
+
+
+# ---------------------------------------------------------------------------
+# Errors and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_requires_exactly_one_perturbation_source(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    with pytest.raises(ValueError, match="exactly one of 'key'"):
+        enkf_analysis(prior, obs_prior, y, noise)
+    with pytest.raises(ValueError, match="exactly one of 'key'"):
+        enkf_analysis(
+            prior,
+            obs_prior,
+            y,
+            noise,
+            key=getkey(),
+            perturbed_obs=jnp.zeros_like(obs_prior),
+        )
+
+
+def test_rejects_mismatched_ensemble_size(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    with pytest.raises(ValueError, match="same ensemble size"):
+        enkf_analysis(prior, obs_prior[:-1], y, noise, key=getkey())
+
+
+def test_rejects_mismatched_observation_shape(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    with pytest.raises(ValueError, match="observation must have shape"):
+        enkf_analysis(prior, obs_prior, y[:-1], noise, key=getkey())
+
+
+def test_rejects_mismatched_perturbed_obs_shape(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    with pytest.raises(ValueError, match="perturbed_obs must have shape"):
+        enkf_analysis(
+            prior, obs_prior, y, noise, perturbed_obs=jnp.zeros((obs_prior.shape[0], 1))
+        )
+
+
+def test_two_members_run_one_raises(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey, n_ens=2)
+    assert jnp.all(
+        jnp.isfinite(enkf_analysis(prior, obs_prior, y, noise, key=getkey()))
+    )
+
+    single_prior, single_obs = prior[:1], obs_prior[:1]
+    with pytest.raises(ValueError, match="Bessel correction requires"):
+        enkf_analysis(single_prior, single_obs, y, noise, key=getkey())
+
+
+def test_jit(getkey):
+    prior, obs_prior, y, noise = _small_problem(getkey)
+    key = getkey()
+    jitted = eqx.filter_jit(enkf_analysis)
+    out = jitted(prior, obs_prior, y, noise, key=key)
+    assert out.shape == prior.shape
+    assert jnp.all(jnp.isfinite(out))
+
+
+# ---------------------------------------------------------------------------
+# The documented limitation: non-Gaussian bias that does not shrink with J
+# ---------------------------------------------------------------------------
+
+
+def _chipilski_problem():
+    """The lognormal / logit-normal test case of Chipilski (2025).
+
+    The latent state is ``zeta ~ N(mu, Sigma)``; the physical state is
+    ``x = (exp(zeta_0), logistic(zeta_1))``. The first latent coordinate is
+    observed with additive Gaussian noise of variance ``r``, i.e. the physical
+    observation carries multiplicative lognormal noise.
+
+    ``Sigma`` and ``r`` are recovered exactly from the latent posterior
+    covariance the paper reports. ``mu`` and the observation are fixed by its
+    reported posterior mean up to one free parameter, taken here as
+    ``mu[0] = 0``. The resulting exact posterior mean in physical space
+    reproduces the paper's ``[0.548062, 0.353937]`` to seven figures, which is
+    what the assertions below anchor on.
+    """
+    prior_cov = jnp.array([[0.6, 0.25], [0.25, 0.4]])
+    obs_var = 0.05
+    mu = jnp.array([0.0, -23.0 / 60.0])
+    y_latent = jnp.array([-0.6764811])
+
+    gain = prior_cov[:, :1] / (prior_cov[0, 0] + obs_var)  # (2, 1)
+    post_mean = mu + gain[:, 0] * (y_latent[0] - mu[0])
+    post_cov = prior_cov - gain @ prior_cov[:1, :]
+
+    # Exact posterior mean in physical space: closed form for the lognormal
+    # coordinate, fine-grid quadrature for the logit-normal one.
+    grid = jnp.linspace(-12.0, 12.0, 200_001)
+    weights = jnp.exp(-0.5 * (grid - post_mean[1]) ** 2 / post_cov[1, 1])
+    weights = weights / weights.sum()
+    exact = jnp.array(
+        [
+            jnp.exp(post_mean[0] + post_cov[0, 0] / 2),
+            (jax.nn.sigmoid(grid) * weights).sum(),
+        ]
+    )
+    return mu, prior_cov, obs_var, y_latent, exact
+
+
+def _to_physical(latent):
+    return jnp.stack([jnp.exp(latent[:, 0]), jax.nn.sigmoid(latent[:, 1])], axis=1)
+
+
+def test_chipilski_setup_reproduces_the_published_posterior():
+    """Guards the test fixture itself against a silent drift in the constants."""
+    *_, exact = _chipilski_problem()
+    assert jnp.allclose(exact, jnp.array([0.548062, 0.353937]), atol=1e-6)
+
+
+@pytest.mark.slow
+def test_non_gaussian_bias_does_not_shrink_with_ensemble_size():
+    """The physical-space update plateaus; the latent-space one converges.
+
+    This is the limitation stated in the `enkf_analysis` docstring, and the
+    property the downstream conjugate-transform filter exists to remove. A
+    single-`J` mean test would not show it -- the point is the *plateau*.
+    """
+    mu, prior_cov, obs_var, y_latent, exact = _chipilski_problem()
+    noise = lx.DiagonalLinearOperator(jnp.array([obs_var]))
+    chol = jnp.linalg.cholesky(prior_cov)
+
+    physical_errors, latent_errors = [], []
+    for n_ens in (20_000, 200_000):
+        k_prior, k_noise = jr.split(jr.key(0))
+        latent = mu + jr.normal(k_prior, (n_ens, 2)) @ chol.T  # (J, 2)
+        # One noise realisation, shared by both routes.
+        perturbed_latent = y_latent[None, :] + jnp.sqrt(obs_var) * jr.normal(
+            k_noise, (n_ens, 1)
+        )  # (J, 1)
+
+        # Latent coordinates: the prior is Gaussian there, so this is exact.
+        latent_analysis = enkf_analysis(
+            latent, latent[:, :1], y_latent, noise, perturbed_obs=perturbed_latent
+        )
+        latent_errors.append(
+            jnp.linalg.norm(_to_physical(latent_analysis).mean(axis=0) - exact)
+        )
+
+        # Physical coordinates: the prior is lognormal / logit-normal there.
+        physical = _to_physical(latent)  # (J, 2)
+        perturbed_physical = jnp.exp(perturbed_latent)  # (J, 1)
+        physical_noise = lx.DiagonalLinearOperator(
+            jnp.array([jnp.var(perturbed_physical[:, 0])])
+        )
+        physical_analysis = enkf_analysis(
+            physical,
+            physical[:, :1],
+            jnp.exp(y_latent),
+            physical_noise,
+            perturbed_obs=perturbed_physical,
+        )
+        physical_errors.append(jnp.linalg.norm(physical_analysis.mean(axis=0) - exact))
+
+    # The latent-space error shrinks with J; the physical-space error does not.
+    assert latent_errors[1] < latent_errors[0]
+    assert latent_errors[1] < 0.001
+    assert physical_errors[1] > 0.01
+    assert physical_errors[1] > 0.5 * physical_errors[0]  # plateau, not decay
+    assert physical_errors[1] > 10 * latent_errors[1]

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "einx" },


### PR DESCRIPTION
gaussx had every ingredient of an ensemble Kalman filter — `ensemble_covariance`, `ensemble_cross_covariance`, `ensemble_kalman_gain`, `localized_kalman_gain` — but no **analysis step**, leaving callers to re-derive the perturbed-observation update and its Bessel convention in every script. `ensemble_kalman_gain` already defaults to `bessel=True` while the lower-level helpers default to `False`; the analysis function now owns that convention.

Originally filed as jejjohnson/gauss_flows#143, which was closed not-planned as misfiled — it is gaussx-scoped. It unblocks `ConjugateTransformFilter` downstream (jejjohnson/gauss_flows#144), which is literally this function called on a warped ensemble.

## The perturbations are not optional

The deterministic update drives the analysis covariance to `(I − KH)P(I − KH)ᵀ` instead of `(I − KH)P` — short by `K R Kᵀ`, i.e. under-dispersive. There is deliberately **no `perturb=False` flag**: the deterministic alternative is a different filter (`etkf_transform`), not an option on this one.

Perturbations come from either `key` (drawn from `R` via a Cholesky factor) or an explicit `perturbed_obs` ensemble. The latter matters for reusing one noise realisation across two filters, which is exactly what the downstream comparison needs.

## A 320 GB trap in the default dispatch

How the innovation covariance is assembled is now chosen from the static shapes:

- **`J < M`** — the gain comes from `ensemble_kalman_gain`, keeping the ensemble term low-rank and inverting a `(J, J)` Woodbury capacitance. Right for the geoscience regime: a few dozen members against many observations.
- **`J >= M`** — that capacitance is the *larger* of the two. At `J = 200_000` it is a 320 GB allocation, which is how I found this: the convergence test OOM'd. The `(M, M)` innovation is formed densely instead.

Both routes solve the same system and agree to round-off. No API change — `ensemble_kalman_gain` is untouched.

## The limitation the docstring states

The update is Gaussian in whatever coordinates the caller supplies. On a non-Gaussian prior it is biased, and **the bias does not shrink with ensemble size** — it is an error of coordinates, not of sampling. The docstring says so, and points at conjugating the update with a Gaussianising bijection as the fix.

`test_non_gaussian_bias_does_not_shrink_with_ensemble_size` pins that as a plateau rather than as a single number: over a 10× increase in `J` the latent-space error decays while the physical-space error stays put.

### On the fixture

`Σ = [[0.6, 0.25], [0.25, 0.4]]` and `r = 0.05` are recovered exactly from the latent posterior covariance Chipilski (2025) reports; `mu` and the observation are fixed by its reported posterior mean up to one free parameter, taken as `mu[0] = 0`. The resulting exact posterior mean reproduces the paper's `[0.548062, 0.353937]` **to seven figures**, and `test_chipilski_setup_reproduces_the_published_posterior` guards that so a drift in the constants fails loudly.

What I could **not** recover is the paper's physical-space EnKF numbers (`[0.607391, 0.388017]`, +10.8% / +9.6%): their choice of `R` in physical coordinates is not derivable from what the paper states. So the test asserts the phenomenon — plateau vs. convergence — rather than digits I cannot reproduce. Flagging that rather than hardcoding numbers that would look verified and would not be.

## Tests

New `tests/inference/test_enkf_analysis.py`, 19 tests. Beyond the above:

- convergence of the analysis mean **and covariance** to the exact Kalman posterior at `J = 200_000` (< 2% relative)
- the spread test — the deterministic contrast uses the *exact* gain so `post_cov − joseph == K R Kᵀ` is checked analytically, not as a second Monte-Carlo estimate
- `perturbed_obs` reproduces the `key` path on the same realisation; determinism across keys
- the update formula and Bessel convention pinned against `ensemble_kalman_gain` for both flag values
- all-ones localization ≡ no localization; a short taper zeroes the far end of the state vector
- error paths (neither/both perturbation sources, shape mismatches), `J = 2` runs / `J = 1` raises, JIT

## Checks

- `pytest` — **1522 passed** (full suite)
- `ruff check .` + `ruff format --check .` — clean
- `ty check src/gaussx` — clean
- `enkf_analysis` added to `docs/api/inference.md`, required by `tests/test_docs_api_coverage.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)