### PR TITLE
fix(inference): draw enkf_analysis perturbations with a PSD square root

### DIFF
--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -352,7 +352,11 @@ def localized_kalman_gain(
 # ---------------------------------------------------------------------------
 
 
-def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
+def _noise_factor(
+    obs_noise: lx.AbstractLinearOperator,
+    *,
+    allow_dense: bool = False,
+) -> lx.AbstractLinearOperator:
     """A factor ``L`` with ``L L^T = R``, valid for singular ``R``.
 
     Perturbations are drawn as ``eps_j = L n_j``, so ``L`` has three jobs, and
@@ -387,8 +391,8 @@ def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOper
       so structure survives *and* each leaf gets the PSD-safe treatment.
     - `gaussx.BlockTriDiag`: `gaussx.cholesky`, whose banded recurrence is
       ``O(N d^3)`` against ``O((N d)^3)`` dense. It has no PSD-safe blockwise
-      analogue, so this is the one operator where a singular ``R`` still gives
-      ``NaN`` -- densifying it would trade that for the ``OOM`` in (3).
+      analogue, so it is the one structure where (2) and (3) genuinely
+      conflict -- hence ``allow_dense``, below.
     - Anything else, including every dense leaf: the symmetric square root.
 
     That last branch is where `gaussx.KroneckerSum` and
@@ -404,22 +408,35 @@ def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOper
 
     Args:
         obs_noise: Observation error covariance, shape ``(M, M)``.
+        allow_dense: Whether the caller's gain path materialises ``R`` anyway.
+            When it does, requirement (3) is already spent and cannot justify
+            declining (2), so `gaussx.BlockTriDiag` takes the PSD-safe dense
+            factor too and a singular ``R`` stops being fatal. Only
+            `enkf_analysis`'s Woodbury route -- no localization, structured
+            innovation -- keeps ``R`` unmaterialised, so only there is the
+            banded factor worth a ``NaN``.
 
     Returns:
         An operator ``L`` such that ``L L^T = obs_noise``.
     """
     if isinstance(obs_noise, lx.TaggedLinearOperator):
-        return _noise_factor(obs_noise.operator)
-    if isinstance(
-        obs_noise,
-        lx.IdentityLinearOperator | lx.DiagonalLinearOperator | BlockTriDiag,
-    ):
+        return _noise_factor(obs_noise.operator, allow_dense=allow_dense)
+    if isinstance(obs_noise, lx.IdentityLinearOperator | lx.DiagonalLinearOperator):
+        return cholesky(obs_noise)
+    if isinstance(obs_noise, BlockTriDiag) and not allow_dense:
         return cholesky(obs_noise)
     if isinstance(obs_noise, BlockDiag):
-        return BlockDiag(*(_noise_factor(op) for op in obs_noise.operators))
+        return BlockDiag(
+            *(_noise_factor(op, allow_dense=allow_dense) for op in obs_noise.operators)
+        )
     if isinstance(obs_noise, Kronecker):
-        return Kronecker(*(_noise_factor(op) for op in obs_noise.operators))
-    if isinstance(obs_noise, SumOfKroneckers):
+        return Kronecker(
+            *(_noise_factor(op, allow_dense=allow_dense) for op in obs_noise.operators)
+        )
+    # Only worth saying when the caller could act on it: if the gain path
+    # materialises R regardless, drawing the perturbations elsewhere saves
+    # nothing.
+    if isinstance(obs_noise, SumOfKroneckers) and not allow_dense:
         warnings.warn(
             "enkf_analysis materialises a SumOfKroneckers obs_noise to draw "
             "exact perturbations. For a matrix-free alternative, sample "
@@ -620,6 +637,11 @@ def enkf_analysis(
             f"({obs_noise.out_size()}, {obs_noise.in_size()})."
         )
 
+    # Whether to form the (M, M) innovation densely. `None` picks by shape; an
+    # explicit value overrides that, which is what a matrix-free solver needs.
+    # Decided here rather than at the gain, because the factor below needs it.
+    use_dense = n_ens >= n_obs if dense_innovation is None else dense_innovation
+
     # Branch on `key` rather than on `perturbed_obs`: the check above makes the
     # two equivalent, but this way each branch narrows the argument it uses.
     if key is not None:
@@ -628,7 +650,14 @@ def enkf_analysis(
         # materialising R here would allocate a dense (M, M) and cost O(M^3),
         # which for the low-rank branch below (J < M, M possibly enormous) would
         # OOM before the gain is ever formed.
-        factor = _noise_factor(obs_noise)
+        #
+        # Unless the gain is about to allocate that (M, M) anyway: every route
+        # but Woodbury calls `obs_noise.as_matrix()`, and once the dense cost
+        # is being paid regardless there is nothing left to protect by holding
+        # on to a positive-definite-only factor.
+        factor = _noise_factor(
+            obs_noise, allow_dense=use_dense or localization is not None
+        )
         noise = jr.normal(key, (n_ens, n_obs), dtype=particles.dtype)  # (J, M)
         perturbed = observation[None, :] + jax.vmap(factor.mv)(noise)  # (J, M)
     else:
@@ -656,10 +685,6 @@ def enkf_analysis(
                 f"obs_localization must have shape ({n_obs}, {n_obs}) to match "
                 f"obs_particles, got {obs_localization.shape}."
             )
-
-    # Whether to form the (M, M) innovation densely. `None` picks by shape; an
-    # explicit value overrides that, which is what a matrix-free solver needs.
-    use_dense = n_ens >= n_obs if dense_innovation is None else dense_innovation
 
     if localization is None and not use_dense:
         # Fewer members than observations: the Woodbury capacitance is (J, J)

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -346,6 +346,37 @@ def localized_kalman_gain(
 # ---------------------------------------------------------------------------
 
 
+def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
+    """A factor ``L`` with ``L L^T = R``, valid for singular ``R``.
+
+    `cholesky` dispatches on structure and is the right tool wherever it
+    applies: for a `lineax.DiagonalLinearOperator` it returns
+    ``sqrt(diag)``, which stays diagonal and handles a zero entry without
+    complaint. Its *dense* fallback is `jax.numpy.linalg.cholesky`, which
+    requires positive definiteness and returns ``NaN`` for a positive
+    semi-definite matrix such as ``diag(1, 1, 0)``.
+
+    That matters because a singular ``R`` is a documented, supported case --
+    ``dense_innovation=True`` exists for it -- and the perturbations are drawn
+    before that flag is ever consulted, so a PD-only factor would poison the
+    analysis with ``NaN`` regardless. Dense operators therefore go through a
+    symmetric (eigendecomposition) square root, which is defined for any PSD
+    matrix. Both factors satisfy ``L L^T = R``, so the draws are
+    distributionally identical.
+
+    Args:
+        obs_noise: Observation error covariance, shape ``(M, M)``.
+
+    Returns:
+        An operator ``L`` such that ``L L^T = obs_noise``.
+    """
+    if isinstance(obs_noise, lx.TaggedLinearOperator):
+        return _noise_factor(obs_noise.operator)
+    if isinstance(obs_noise, lx.MatrixLinearOperator):
+        return lx.MatrixLinearOperator(_symmetric_sqrt(obs_noise.as_matrix()))
+    return cholesky(obs_noise)
+
+
 def enkf_analysis(
     particles: Float[Array, "J N"],
     obs_particles: Float[Array, "J M"],
@@ -444,9 +475,10 @@ def enkf_analysis(
         dense_innovation: Whether to form the ``(M, M)`` innovation covariance
             densely. ``None`` (default) chooses by shape, as described in the
             note below. ``False`` keeps the structured `LowRankUpdate` no
-            matter the shapes -- for a matrix-free solver, or when
-            ``obs_noise`` is singular. ``True`` forces the dense assembly, the
-            way out when ``J < M`` but ``obs_noise`` is not positive definite.
+            matter the shapes -- what a matrix-free solver wants. ``True``
+            forces the dense assembly, which is the way out when ``obs_noise``
+            is only positive *semi*-definite, since the structured route
+            solves against ``obs_noise`` itself.
         bessel: Use the $1/(J-1)$ divisor. Defaults to ``True``, matching
             `ensemble_kalman_gain`.
 
@@ -540,9 +572,9 @@ def enkf_analysis(
         # materialising R here would allocate a dense (M, M) and cost O(M^3),
         # which for the low-rank branch below (J < M, M possibly enormous) would
         # OOM before the gain is ever formed.
-        chol = cholesky(obs_noise)
+        factor = _noise_factor(obs_noise)
         noise = jr.normal(key, (n_ens, n_obs), dtype=particles.dtype)  # (J, M)
-        perturbed = observation[None, :] + jax.vmap(chol.mv)(noise)  # (J, M)
+        perturbed = observation[None, :] + jax.vmap(factor.mv)(noise)  # (J, M)
     else:
         perturbed = perturbed_obs
         if perturbed is None or perturbed.shape != (n_ens, n_obs):

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -14,7 +14,7 @@ from gaussx._linalg._linalg import solve_rows
 from gaussx._linalg._mixed_precision import stable_squared_distances
 from gaussx._linalg._symmetrize import symmetrize
 from gaussx._operators._low_rank_update import LowRankUpdate
-from gaussx._primitives._cholesky import cholesky
+from gaussx._primitives._sqrt import dense_symmetric_sqrt, sqrt
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -349,20 +349,27 @@ def localized_kalman_gain(
 def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
     """A factor ``L`` with ``L L^T = R``, valid for singular ``R``.
 
-    `cholesky` dispatches on structure and is the right tool wherever it
-    applies: for a `lineax.DiagonalLinearOperator` it returns
-    ``sqrt(diag)``, which stays diagonal and handles a zero entry without
-    complaint. Its *dense* fallback is `jax.numpy.linalg.cholesky`, which
-    requires positive definiteness and returns ``NaN`` for a positive
-    semi-definite matrix such as ``diag(1, 1, 0)``.
+    The obvious choice, `gaussx.cholesky`, is PD-only wherever it bottoms out
+    in `jax.numpy.linalg.cholesky` -- which is every dense leaf, whether that
+    leaf is the whole operator or one block of a `gaussx.BlockDiag`. For a
+    positive *semi*-definite ``R`` such as ``diag(1, 1, 0)`` that returns
+    ``NaN``. Only the diagonal case escapes, because its "Cholesky" is an
+    elementwise ``sqrt`` that takes a zero in its stride.
 
     That matters because a singular ``R`` is a documented, supported case --
     ``dense_innovation=True`` exists for it -- and the perturbations are drawn
     before that flag is ever consulted, so a PD-only factor would poison the
-    analysis with ``NaN`` regardless. Dense operators therefore go through a
-    symmetric (eigendecomposition) square root, which is defined for any PSD
-    matrix. Both factors satisfy ``L L^T = R``, so the draws are
-    distributionally identical.
+    analysis with ``NaN`` regardless of what the caller asked for.
+
+    `gaussx.sqrt` is the PSD-safe counterpart, and it dispatches on exactly the
+    same structure: diagonal and Kronecker factors stay factored, block-diagonal
+    blocks are square-rooted independently, and a `gaussx.SumOfKroneckers` gets
+    a matrix-free Lanczos square root instead of `gaussx.cholesky`'s dense
+    fallback. So nothing here trades structure for definiteness. It returns the
+    *symmetric* square root rather than a triangular factor, which is a
+    different factorisation of the same ``R`` -- both satisfy ``L L^T = R``, so
+    the draws are distributionally identical, but a given key gives different
+    (equally valid) realisations.
 
     Args:
         obs_noise: Observation error covariance, shape ``(M, M)``.
@@ -370,11 +377,7 @@ def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOper
     Returns:
         An operator ``L`` such that ``L L^T = obs_noise``.
     """
-    if isinstance(obs_noise, lx.TaggedLinearOperator):
-        return _noise_factor(obs_noise.operator)
-    if isinstance(obs_noise, lx.MatrixLinearOperator):
-        return lx.MatrixLinearOperator(_symmetric_sqrt(obs_noise.as_matrix()))
-    return cholesky(obs_noise)
+    return sqrt(obs_noise)
 
 
 def enkf_analysis(
@@ -567,8 +570,8 @@ def enkf_analysis(
     # Branch on `key` rather than on `perturbed_obs`: the check above makes the
     # two equivalent, but this way each branch narrows the argument it uses.
     if key is not None:
-        # eps_j = L n_j with R = L L^T. `cholesky` dispatches on structure, so a
-        # DiagonalLinearOperator stays diagonal and its matvec stays O(M) --
+        # eps_j = L n_j with R = L L^T. The factor dispatches on structure, so
+        # a DiagonalLinearOperator stays diagonal and its matvec stays O(M) --
         # materialising R here would allocate a dense (M, M) and cost O(M^3),
         # which for the low-rank branch below (J < M, M possibly enormous) would
         # OOM before the gain is ever formed.
@@ -794,7 +797,14 @@ def etkf_transform(
 
 
 def _symmetric_sqrt(matrix: Float[Array, "J J"]) -> Float[Array, "J J"]:
-    """Symmetric (eigendecomposition) square root of an SPD matrix."""
-    eigvals, eigvecs = jnp.linalg.eigh(matrix)
-    sqrt_eigvals = jnp.sqrt(jnp.maximum(eigvals, 0.0))
-    return (eigvecs * sqrt_eigvals[None, :]) @ eigvecs.T
+    """Symmetric (eigendecomposition) square root of an SPD matrix.
+
+    Thin alias for `gaussx._primitives._sqrt.dense_symmetric_sqrt`, which
+    carries a Sylvester-equation JVP so that the derivative stays finite at
+    repeated eigenvalues. `etkf_transform` square-roots an analysis covariance
+    that always has them -- ``Y R^-1 Y^T`` has rank at most ``min(M, J - 1)``,
+    so the prior eigenvalue survives with multiplicity ``J - M`` whenever
+    ``M < J`` -- and while the naive derivative happens to stay finite on the
+    tangents that arise there, it is one input away from not doing so.
+    """
+    return dense_symmetric_sqrt(matrix)

--- a/src/gaussx/_inference/_ensemble.py
+++ b/src/gaussx/_inference/_ensemble.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 
 import jax
@@ -13,8 +14,13 @@ from jaxtyping import Array, Float, PRNGKeyArray
 from gaussx._linalg._linalg import solve_rows
 from gaussx._linalg._mixed_precision import stable_squared_distances
 from gaussx._linalg._symmetrize import symmetrize
+from gaussx._operators._block_diag import BlockDiag
+from gaussx._operators._block_tridiag import BlockTriDiag
+from gaussx._operators._kronecker import Kronecker
 from gaussx._operators._low_rank_update import LowRankUpdate
-from gaussx._primitives._sqrt import dense_symmetric_sqrt, sqrt
+from gaussx._operators._sum_kronecker import SumOfKroneckers
+from gaussx._primitives._cholesky import DenseFallbackWarning, cholesky
+from gaussx._primitives._sqrt import dense_symmetric_sqrt
 from gaussx._strategies._base import AbstractSolverStrategy
 
 
@@ -349,27 +355,52 @@ def localized_kalman_gain(
 def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
     """A factor ``L`` with ``L L^T = R``, valid for singular ``R``.
 
-    The obvious choice, `gaussx.cholesky`, is PD-only wherever it bottoms out
-    in `jax.numpy.linalg.cholesky` -- which is every dense leaf, whether that
-    leaf is the whole operator or one block of a `gaussx.BlockDiag`. For a
-    positive *semi*-definite ``R`` such as ``diag(1, 1, 0)`` that returns
-    ``NaN``. Only the diagonal case escapes, because its "Cholesky" is an
-    elementwise ``sqrt`` that takes a zero in its stride.
+    Perturbations are drawn as ``eps_j = L n_j``, so ``L`` has three jobs, and
+    neither `gaussx.cholesky` nor `gaussx.sqrt` does all three on its own:
 
-    That matters because a singular ``R`` is a documented, supported case --
-    ``dense_innovation=True`` exists for it -- and the perturbations are drawn
-    before that flag is ever consulted, so a PD-only factor would poison the
-    analysis with ``NaN`` regardless of what the caller asked for.
+    1. **Exact.** ``enkf_analysis`` promises ``eps ~ N(0, R)``. An approximate
+       factor gives the perturbations the wrong covariance and biases the
+       analysis silently, so a truncated Lanczos square root is not an
+       acceptable default however cheap it is.
+    2. **Defined for a singular ``R``.** That is a documented, supported case
+       -- ``dense_innovation=True`` exists for it -- and perturbations are
+       drawn before that flag is ever consulted, so a positive-*definite*-only
+       factor poisons the analysis with ``NaN`` regardless of what the caller
+       asked for.
+    3. **Structure-preserving.** ``M`` is routinely large enough that
+       materialising ``R`` is the thing the structured operator existed to
+       avoid, and a dense fallback trades a ``NaN`` for an ``OOM``.
 
-    `gaussx.sqrt` is the PSD-safe counterpart, and it dispatches on exactly the
-    same structure: diagonal and Kronecker factors stay factored, block-diagonal
-    blocks are square-rooted independently, and a `gaussx.SumOfKroneckers` gets
-    a matrix-free Lanczos square root instead of `gaussx.cholesky`'s dense
-    fallback. So nothing here trades structure for definiteness. It returns the
-    *symmetric* square root rather than a triangular factor, which is a
-    different factorisation of the same ``R`` -- both satisfy ``L L^T = R``, so
-    the draws are distributionally identical, but a given key gives different
-    (equally valid) realisations.
+    `gaussx.cholesky` fails (2) at every dense leaf -- whether that leaf is the
+    whole operator or one block of a `gaussx.BlockDiag` -- because it bottoms
+    out in `jax.numpy.linalg.cholesky`, which returns ``NaN`` for a positive
+    *semi*-definite matrix such as ``diag(1, 1, 0)``. Only the diagonal case
+    escapes, its "Cholesky" being an elementwise ``sqrt`` that takes a zero in
+    its stride. `gaussx.sqrt` fixes (2) but breaks (1) for
+    `gaussx.SumOfKroneckers` and (3) for `gaussx.BlockTriDiag`.
+
+    So the dispatch is by operator, taking whichever is better per structure:
+
+    - Diagonal and identity: `gaussx.cholesky`, already exact and PSD-safe.
+    - `gaussx.BlockDiag` / `gaussx.Kronecker`: recurse. Both factor into
+      independent leaves -- ``(L_1 (x) L_2)(L_1 (x) L_2)^T = A_1 (x) A_2`` --
+      so structure survives *and* each leaf gets the PSD-safe treatment.
+    - `gaussx.BlockTriDiag`: `gaussx.cholesky`, whose banded recurrence is
+      ``O(N d^3)`` against ``O((N d)^3)`` dense. It has no PSD-safe blockwise
+      analogue, so this is the one operator where a singular ``R`` still gives
+      ``NaN`` -- densifying it would trade that for the ``OOM`` in (3).
+    - Anything else, including every dense leaf: the symmetric square root.
+
+    That last branch is where `gaussx.KroneckerSum` and
+    `gaussx.SumOfKroneckers` land. Both densify -- exactly as `gaussx.cholesky`
+    did -- rather than take their matrix-free `gaussx.sqrt` routes, which are
+    respectively not traceable (a Python ``bool`` on a data-dependent
+    definiteness check) and not exact.
+
+    The result is the *symmetric* square root at dense leaves rather than a
+    triangular factor. That is a different factorisation of the same ``R``:
+    both satisfy ``L L^T = R``, so the draws are distributionally identical,
+    but a given key gives a different (equally valid) realisation.
 
     Args:
         obs_noise: Observation error covariance, shape ``(M, M)``.
@@ -377,7 +408,29 @@ def _noise_factor(obs_noise: lx.AbstractLinearOperator) -> lx.AbstractLinearOper
     Returns:
         An operator ``L`` such that ``L L^T = obs_noise``.
     """
-    return sqrt(obs_noise)
+    if isinstance(obs_noise, lx.TaggedLinearOperator):
+        return _noise_factor(obs_noise.operator)
+    if isinstance(
+        obs_noise,
+        lx.IdentityLinearOperator | lx.DiagonalLinearOperator | BlockTriDiag,
+    ):
+        return cholesky(obs_noise)
+    if isinstance(obs_noise, BlockDiag):
+        return BlockDiag(*(_noise_factor(op) for op in obs_noise.operators))
+    if isinstance(obs_noise, Kronecker):
+        return Kronecker(*(_noise_factor(op) for op in obs_noise.operators))
+    if isinstance(obs_noise, SumOfKroneckers):
+        warnings.warn(
+            "enkf_analysis materialises a SumOfKroneckers obs_noise to draw "
+            "exact perturbations. For a matrix-free alternative, sample "
+            "eps ~ N(0, R) yourself -- sumkronecker_sample or "
+            "sqrt(obs_noise, lanczos_order=...) -- and pass them as "
+            "perturbed_obs=observation + eps. Both are approximate, so that "
+            "is an opt-in, not the default.",
+            DenseFallbackWarning,
+            stacklevel=2,
+        )
+    return lx.MatrixLinearOperator(dense_symmetric_sqrt(obs_noise.as_matrix()))
 
 
 def enkf_analysis(

--- a/src/gaussx/_primitives/_sqrt.py
+++ b/src/gaussx/_primitives/_sqrt.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import lineax as lx
 import matfree.decomp
 import matfree.funm
+from jaxtyping import Array, Float
 
 from gaussx._operators._block_diag import BlockDiag, _resolve_dtype
 from gaussx._operators._kronecker import Kronecker
@@ -94,14 +96,72 @@ def _sqrt_sum_kronecker(
     return SumKroneckerSqrt(operator, lanczos_order=lanczos_order)
 
 
+@jax.custom_jvp
+def dense_symmetric_sqrt(matrix: Float[Array, "N N"]) -> Float[Array, "N N"]:
+    """Symmetric square root of a PSD matrix: ``S = Q diag(sqrt(lam)) Q^T``.
+
+    Array in, array out -- `sqrt` is the operator-level entry point. Unlike a
+    Cholesky factor this is symmetric and defined for a *semi*-definite
+    matrix, so ``S @ S.T == matrix`` holds even when ``matrix`` is singular.
+
+    The custom JVP exists because the naive derivative -- differentiating
+    straight through `jax.numpy.linalg.eigh` -- is non-finite whenever an
+    eigenvalue is repeated, and a repeated eigenvalue is the *common* case
+    here: an isotropic covariance ``sigma^2 I`` is nothing but repeated
+    eigenvalues. See `_dense_symmetric_sqrt_jvp` for why the true derivative
+    has no such singularity.
+    """
+    eigenvalues, eigenvectors = jnp.linalg.eigh(matrix)
+    sqrt_eigs = jnp.sqrt(jnp.maximum(eigenvalues, 0.0))
+    return (eigenvectors * sqrt_eigs[None, :]) @ eigenvectors.T
+
+
+@dense_symmetric_sqrt.defjvp
+def _dense_symmetric_sqrt_jvp(primals, tangents):
+    r"""Sylvester-equation derivative of the symmetric square root.
+
+    Differentiating the defining identity ``S S = A`` gives the Sylvester
+    equation ``dS S + S dS = dA``. In the eigenbasis of ``A`` -- which is
+    also the eigenbasis of ``S`` -- with ``s_i = sqrt(lam_i)`` this is
+    diagonalised entrywise into
+    ``(V^T dS V)_ij (s_i + s_j) = (V^T dA V)_ij``,
+    so the derivative divides by *sums* of square-rooted eigenvalues. The
+    eigendecomposition's own derivative divides by eigenvalue *gaps*
+    ``lam_i - lam_j``, which is why chaining through `eigh` blows up at a
+    repeated eigenvalue while the square root itself stays perfectly smooth
+    there -- ``s_i + s_j`` is bounded away from zero for any ``A`` with at
+    most one zero eigenvalue.
+
+    The one genuinely singular case is a doubly-degenerate zero eigenvalue,
+    where ``s_i + s_j = 0`` and the square root really is non-differentiable
+    (scalar ``sqrt`` at the origin). Those entries are returned as zero
+    rather than ``NaN``, so a rank-deficient covariance still yields a
+    usable gradient for the directions that are identified.
+    """
+    (matrix,) = primals
+    (tangent,) = tangents
+    eigenvalues, eigenvectors = jnp.linalg.eigh(matrix)
+    sqrt_eigs = jnp.sqrt(jnp.maximum(eigenvalues, 0.0))
+    primal_out = (eigenvectors * sqrt_eigs[None, :]) @ eigenvectors.T
+
+    # eigh reads one triangle, so the primal only ever sees the symmetric
+    # part of its argument; the tangent must be projected the same way.
+    tangent = 0.5 * (tangent + tangent.T)
+    rotated = eigenvectors.T @ tangent @ eigenvectors
+    denominator = sqrt_eigs[:, None] + sqrt_eigs[None, :]
+    # Double `where` so the unused branch cannot contribute a NaN to any
+    # higher-order tangent, the standard JAX safe-divide idiom.
+    safe = jnp.where(denominator > 0.0, denominator, 1.0)
+    scaled = jnp.where(denominator > 0.0, rotated / safe, 0.0)
+    tangent_out = eigenvectors @ scaled @ eigenvectors.T
+    return primal_out, tangent_out
+
+
 def _sqrt_dense(
     operator: lx.AbstractLinearOperator,
 ) -> lx.MatrixLinearOperator:
     """Eigendecomposition: S = Q diag(sqrt(lam)) Q^T."""
-    mat = operator.as_matrix()
-    eigenvalues, eigenvectors = jnp.linalg.eigh(mat)
-    sqrt_eigs = jnp.sqrt(jnp.maximum(eigenvalues, 0.0))
-    S = eigenvectors @ jnp.diag(sqrt_eigs) @ eigenvectors.T
+    S = dense_symmetric_sqrt(operator.as_matrix())
     return lx.MatrixLinearOperator(S, lx.symmetric_tag)
 
 

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -14,7 +14,15 @@ from gaussx import (
     ensemble_kalman_gain,
     localization_matrix,
 )
-from gaussx._operators import BlockDiag, Kronecker
+from gaussx._operators import (
+    BlockDiag,
+    BlockTriDiag,
+    Kronecker,
+    KroneckerSum,
+    LowerBlockTriDiag,
+    SumOfKroneckers,
+)
+from gaussx._primitives._cholesky import DenseFallbackWarning
 from gaussx._testing import random_pd_matrix
 
 
@@ -653,3 +661,95 @@ def test_gradient_through_isotropic_noise_is_finite(getkey):
     step = 1e-4
     expected = (loss(2.0 + step) - loss(2.0 - step)) / (2.0 * step)
     assert jnp.allclose(grad, expected, rtol=1e-4)
+
+
+class TestNoiseFactorDispatch:
+    """The factor must be exact, PSD-safe *and* structure-preserving.
+
+    No single primitive is all three: `gaussx.cholesky` gives up PSD-safety at
+    every dense leaf, and `gaussx.sqrt` gives up exactness for
+    `SumOfKroneckers` and structure for `BlockTriDiag`. These pin the choice
+    made per operator, since getting it wrong is silent in every case --
+    approximate draws, a dense blow-up, or a trace-time crash.
+    """
+
+    def _block_tridiag(self, getkey, n_blocks=6, block=3):
+        diagonal = jnp.stack(
+            [
+                random_pd_matrix(getkey(), block) + 2.0 * jnp.eye(block)
+                for _ in range(n_blocks)
+            ]
+        )
+        sub = jnp.stack(
+            [0.05 * jr.normal(getkey(), (block, block)) for _ in range(n_blocks - 1)]
+        )
+        return BlockTriDiag(diagonal, sub)
+
+    def test_block_tridiag_keeps_its_banded_factor(self, getkey):
+        """Densifying costs ``O((N d)^3)`` against the banded ``O(N d^3)``.
+
+        A block-tridiagonal ``R`` is chosen precisely when ``M`` is too large
+        to materialise, so a dense fallback trades a NaN for an OOM.
+        """
+        from gaussx._inference._ensemble import _noise_factor
+
+        operator = self._block_tridiag(getkey)
+        factor = _noise_factor(operator)
+        assert isinstance(factor, LowerBlockTriDiag)
+        dense = factor.as_matrix()
+        assert jnp.allclose(dense @ dense.T, operator.as_matrix(), atol=1e-6)
+
+    def test_sum_of_kroneckers_factor_is_exact(self, getkey):
+        """A truncated Lanczos square root would give the draws a covariance
+        that is only approximately ``R``, biasing the analysis silently.
+        """
+        from gaussx._inference._ensemble import _noise_factor
+
+        def kron(size):
+            return Kronecker(
+                lx.MatrixLinearOperator(
+                    random_pd_matrix(getkey(), size), lx.positive_semidefinite_tag
+                ),
+                lx.MatrixLinearOperator(
+                    random_pd_matrix(getkey(), size), lx.positive_semidefinite_tag
+                ),
+            )
+
+        # Side 8 x 8 -> M = 64, past the default Lanczos order of 50, which is
+        # where an approximate square root stops being incidentally exact.
+        operator = SumOfKroneckers(kron(8), kron(8))
+        with pytest.warns(DenseFallbackWarning):
+            factor = _noise_factor(operator).as_matrix()
+        reference = operator.as_matrix()
+        error = jnp.abs(factor @ factor.T - reference).max()
+        assert error < 1e-10 * jnp.abs(reference).max()
+
+    def test_kronecker_sum_noise_survives_tracing(self, getkey):
+        """`KroneckerSumSqrt` validates definiteness with a Python ``bool``.
+
+        Under ``jit`` that value is a tracer, so building it while tracing
+        raises before a single perturbation is drawn.
+        """
+        factors = [
+            lx.MatrixLinearOperator(
+                random_pd_matrix(getkey(), size), lx.positive_semidefinite_tag
+            )
+            for size in (3, 4)
+        ]
+        obs_noise = KroneckerSum(*factors)
+        n_obs = obs_noise.in_size()
+        prior = jr.normal(getkey(), (5, 7))
+        obs_prior = jr.normal(getkey(), (5, n_obs))
+
+        @eqx.filter_jit
+        def analyse(noise, key):
+            return enkf_analysis(
+                prior,
+                obs_prior,
+                jnp.zeros(n_obs),
+                noise,
+                key=key,
+                dense_innovation=True,
+            )
+
+        assert jnp.all(jnp.isfinite(analyse(obs_noise, getkey())))

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -160,10 +160,15 @@ def test_perturbed_obs_reproduces_the_key_path(getkey):
     key = getkey()
     from_key = enkf_analysis(prior, obs_prior, y, noise, key=key)
 
-    # Rebuild the same realisation by hand and pass it in explicitly.
+    # Rebuild the same realisation by hand and pass it in explicitly, through
+    # the same factor the implementation uses -- a PSD square root rather than
+    # a Cholesky, so that a singular R still works (both satisfy L L^T = R, but
+    # they are different factors and so give different draws for one key).
+    from gaussx._inference._ensemble import _noise_factor
+
     n_ens, n_obs = obs_prior.shape
-    chol = jnp.linalg.cholesky(noise.as_matrix())
-    eps = jr.normal(key, (n_ens, n_obs), dtype=prior.dtype) @ chol.T
+    factor = _noise_factor(noise).as_matrix()
+    eps = jr.normal(key, (n_ens, n_obs), dtype=prior.dtype) @ factor.T
     from_explicit = enkf_analysis(
         prior, obs_prior, y, noise, perturbed_obs=y[None, :] + eps
     )
@@ -543,3 +548,45 @@ def test_dense_innovation_true_handles_singular_observation_noise(getkey):
         dense_innovation=True,
     )
     assert jnp.all(jnp.isfinite(dense))
+
+
+def test_singular_dense_noise_perturbations_are_finite(getkey):
+    """The documented singular-R escape hatch must survive the `key` path.
+
+    Perturbations are drawn before `dense_innovation` is consulted, so a
+    PD-only Cholesky of `diag(1, 1, 0)` would return a NaN factor and the
+    analysis would be NaN no matter what the flag says.
+    """
+    n_state, n_obs = 4, 3
+    k_prior, k_obs, k_draw = jr.split(getkey(), 3)
+    prior = jr.normal(k_prior, (2, n_state))  # J = 2 < M = 3
+    obs_prior = jr.normal(k_obs, (2, n_obs))
+    singular = lx.MatrixLinearOperator(
+        jnp.diag(jnp.array([1.0, 1.0, 0.0])), lx.positive_semidefinite_tag
+    )
+    out = enkf_analysis(
+        prior,
+        obs_prior,
+        jnp.zeros(n_obs),
+        singular,
+        key=k_draw,
+        dense_innovation=True,
+    )
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_noise_factor_reproduces_the_covariance(getkey):
+    """Whatever route the factor takes, ``L L^T`` must be ``R``."""
+    from gaussx._inference._ensemble import _noise_factor
+
+    dense = random_pd_matrix(getkey(), 4)
+    for operator in (
+        lx.MatrixLinearOperator(dense, lx.positive_semidefinite_tag),
+        lx.DiagonalLinearOperator(jnp.array([0.1, 0.2, 0.3, 0.4])),
+        lx.MatrixLinearOperator(
+            jnp.diag(jnp.array([1.0, 1.0, 0.0, 2.0])), lx.positive_semidefinite_tag
+        ),
+    ):
+        factor = _noise_factor(operator).as_matrix()
+        assert jnp.allclose(factor @ factor.T, operator.as_matrix(), atol=1e-6)
+        assert jnp.all(jnp.isfinite(factor))

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -14,6 +14,7 @@ from gaussx import (
     ensemble_kalman_gain,
     localization_matrix,
 )
+from gaussx._operators import BlockDiag, Kronecker
 from gaussx._testing import random_pd_matrix
 
 
@@ -576,17 +577,79 @@ def test_singular_dense_noise_perturbations_are_finite(getkey):
 
 
 def test_noise_factor_reproduces_the_covariance(getkey):
-    """Whatever route the factor takes, ``L L^T`` must be ``R``."""
+    """Whatever route the factor takes, ``L L^T`` must be ``R``.
+
+    The singular cases are the point: a Cholesky-based factor returns ``NaN``
+    for every one of them except the plain diagonal, whose elementwise
+    ``sqrt`` happens to tolerate a zero.
+    """
     from gaussx._inference._ensemble import _noise_factor
 
-    dense = random_pd_matrix(getkey(), 4)
+    singular_dense = lx.MatrixLinearOperator(
+        jnp.diag(jnp.array([1.0, 0.0])), lx.positive_semidefinite_tag
+    )
     for operator in (
-        lx.MatrixLinearOperator(dense, lx.positive_semidefinite_tag),
+        lx.MatrixLinearOperator(random_pd_matrix(getkey(), 4)),
         lx.DiagonalLinearOperator(jnp.array([0.1, 0.2, 0.3, 0.4])),
+        lx.DiagonalLinearOperator(jnp.array([0.1, 0.0, 0.3, 0.4])),
         lx.MatrixLinearOperator(
             jnp.diag(jnp.array([1.0, 1.0, 0.0, 2.0])), lx.positive_semidefinite_tag
         ),
+        # A singular *block* of an otherwise healthy structured operator: the
+        # dense leaf is buried, so dispatching on the top-level type alone
+        # would still route it into a PD-only factorisation.
+        BlockDiag(lx.DiagonalLinearOperator(jnp.array([1.0, 2.0])), singular_dense),
+        Kronecker(
+            lx.MatrixLinearOperator(random_pd_matrix(getkey(), 2)), singular_dense
+        ),
     ):
         factor = _noise_factor(operator).as_matrix()
-        assert jnp.allclose(factor @ factor.T, operator.as_matrix(), atol=1e-6)
         assert jnp.all(jnp.isfinite(factor))
+        assert jnp.allclose(factor @ factor.T, operator.as_matrix(), atol=1e-6)
+
+
+def test_singular_block_of_structured_noise_stays_finite(getkey):
+    """The escape hatch must survive a singular block, not just a singular ``R``.
+
+    `gaussx.cholesky` recurses into a `gaussx.BlockDiag` and hits
+    `jnp.linalg.cholesky` on the dense block, so the analysis came back
+    ``NaN`` even though the assembled innovation covariance is invertible.
+    """
+    n_state, n_obs = 5, 4
+    k_prior, k_obs, k_draw = jr.split(getkey(), 3)
+    obs_noise = BlockDiag(
+        lx.DiagonalLinearOperator(jnp.array([1.0, 2.0])),
+        lx.MatrixLinearOperator(
+            jnp.diag(jnp.array([1.0, 0.0])), lx.positive_semidefinite_tag
+        ),
+    )
+    out = enkf_analysis(
+        jr.normal(k_prior, (3, n_state)),
+        jr.normal(k_obs, (3, n_obs)),
+        jnp.zeros(n_obs),
+        obs_noise,
+        key=k_draw,
+        dense_innovation=True,
+    )
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_gradient_through_isotropic_noise_is_finite(getkey):
+    """``R = sigma^2 I`` is the commonest EnKF covariance -- and all repeated
+    eigenvalues, where a naive eigendecomposition derivative is ``NaN``.
+    """
+    n_obs = 3
+    k_prior, k_obs, k_draw = jr.split(getkey(), 3)
+    prior = jr.normal(k_prior, (6, 4))
+    obs_prior = jr.normal(k_obs, (6, n_obs))
+
+    def loss(variance):
+        noise = lx.MatrixLinearOperator(variance * jnp.eye(n_obs))
+        out = enkf_analysis(prior, obs_prior, jnp.ones(n_obs), noise, key=k_draw)
+        return jnp.sum(out**2)
+
+    grad = jax.grad(loss)(2.0)
+    assert jnp.isfinite(grad)
+    step = 1e-4
+    expected = (loss(2.0 + step) - loss(2.0 - step)) / (2.0 * step)
+    assert jnp.allclose(grad, expected, rtol=1e-4)

--- a/tests/inference/test_enkf_analysis.py
+++ b/tests/inference/test_enkf_analysis.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -753,3 +755,76 @@ class TestNoiseFactorDispatch:
             )
 
         assert jnp.all(jnp.isfinite(analyse(obs_noise, getkey())))
+
+    def test_block_tridiag_takes_the_dense_factor_when_the_gain_densifies(self, getkey):
+        """Structure is only worth a NaN while it is still being preserved.
+
+        Every gain route but Woodbury calls ``obs_noise.as_matrix()``, so once
+        the caller has picked one of those the ``(M, M)`` allocation is
+        happening regardless and the banded factor buys nothing.
+        """
+        from gaussx._inference._ensemble import _noise_factor
+
+        operator = self._block_tridiag(getkey)
+        assert isinstance(_noise_factor(operator), LowerBlockTriDiag)
+        forced = _noise_factor(operator, allow_dense=True)
+        assert isinstance(forced, lx.MatrixLinearOperator)
+        dense = forced.as_matrix()
+        assert jnp.allclose(dense @ dense.T, operator.as_matrix(), atol=1e-6)
+
+    @pytest.mark.parametrize("route", ["dense_innovation", "localization"])
+    def test_singular_block_tridiag_survives_the_densifying_routes(self, route, getkey):
+        """A zero Schur complement makes the banded Cholesky return NaN.
+
+        The innovation covariance is still invertible, so there is a perfectly
+        good analysis on the other side of the factor.
+        """
+        block = 2
+        obs_noise = BlockTriDiag(
+            jnp.stack(
+                [
+                    2.0 * jnp.eye(block),
+                    3.0 * jnp.eye(block),
+                    jnp.diag(jnp.array([1.0, 0.0])),  # singular block
+                ]
+            ),
+            jnp.zeros((2, block, block)),
+        )
+        n_obs = obs_noise.in_size()
+        n_state = 5
+        prior = jr.normal(getkey(), (3, n_state))
+        obs_prior = jr.normal(getkey(), (3, n_obs))
+        kwargs = (
+            {"dense_innovation": True}
+            if route == "dense_innovation"
+            else {"localization": jnp.ones((n_state, n_obs))}
+        )
+        out = enkf_analysis(
+            prior, obs_prior, jnp.zeros(n_obs), obs_noise, key=getkey(), **kwargs
+        )
+        assert jnp.all(jnp.isfinite(out))
+
+    def test_sum_of_kroneckers_warning_is_silent_when_dense_is_already_paid(
+        self, getkey
+    ):
+        """The warning tells the caller to draw perturbations themselves.
+
+        That is only actionable while the gain path would have kept ``R``
+        structured; otherwise it is advice that saves nothing.
+        """
+        from gaussx._inference._ensemble import _noise_factor
+
+        def kron(size):
+            return Kronecker(
+                *(
+                    lx.MatrixLinearOperator(
+                        random_pd_matrix(getkey(), size), lx.positive_semidefinite_tag
+                    )
+                    for _ in range(2)
+                )
+            )
+
+        operator = SumOfKroneckers(kron(3), kron(3))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DenseFallbackWarning)
+            _noise_factor(operator, allow_dense=True)

--- a/tests/primitives/test_sqrt.py
+++ b/tests/primitives/test_sqrt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
@@ -9,6 +10,7 @@ import pytest
 
 from gaussx._operators import BlockDiag, Kronecker, KroneckerSum, KroneckerSumSqrt
 from gaussx._primitives import solve, sqrt
+from gaussx._primitives._sqrt import dense_symmetric_sqrt
 from gaussx._testing import random_pd_matrix, tree_allclose
 
 
@@ -91,3 +93,51 @@ def test_sqrt_dense(getkey):
     S = sqrt(op)
     reconstructed = S.as_matrix() @ S.as_matrix()
     assert tree_allclose(reconstructed, op.as_matrix(), rtol=1e-4)
+
+
+class TestDenseSqrtGradients:
+    """`sqrt`'s dense branch must be differentiable at repeated eigenvalues.
+
+    Differentiating straight through `jnp.linalg.eigh` divides by eigenvalue
+    gaps, so an isotropic matrix -- nothing *but* repeated eigenvalues, and the
+    single most common covariance there is -- would give ``NaN``. The square
+    root itself is smooth there; only the naive chain rule is not.
+    """
+
+    def test_isotropic_gradient_is_finite_and_correct(self):
+        # d/ds sum(sqrt(s I_3)) = d/ds 3 sqrt(s) = 3 / (2 sqrt(s)).
+        grad = jax.grad(lambda s: jnp.sum(dense_symmetric_sqrt(s * jnp.eye(3))))(2.0)
+        assert jnp.isfinite(grad)
+        assert tree_allclose(grad, 3.0 / (2.0 * jnp.sqrt(jnp.asarray(2.0))))
+
+    @pytest.mark.parametrize(
+        "matrix",
+        [
+            3.0 * jnp.eye(4),  # one eigenvalue, multiplicity 4
+            jnp.diag(jnp.array([2.0, 2.0, 5.0, 5.0])),  # two degenerate pairs
+            jnp.diag(jnp.array([1.0, 2.0, 3.0, 4.0])),  # fully distinct
+        ],
+        ids=["isotropic", "degenerate-pairs", "distinct"],
+    )
+    def test_jvp_matches_finite_differences(self, matrix, getkey):
+        direction = random_pd_matrix(getkey(), matrix.shape[0])
+        step = 1e-6
+        expected = (
+            dense_symmetric_sqrt(matrix + step * direction)
+            - dense_symmetric_sqrt(matrix - step * direction)
+        ) / (2.0 * step)
+        _, tangent = jax.jvp(dense_symmetric_sqrt, (matrix,), (direction,))
+        assert tree_allclose(tangent, expected, atol=1e-6, rtol=1e-5)
+
+    def test_singular_matrix_gradient_stays_finite(self):
+        """A zero eigenvalue is non-differentiable; it must not poison the rest.
+
+        ``sqrt`` at the origin has an infinite derivative, so the entries of
+        the null direction are returned as zero rather than ``NaN`` -- the
+        identified directions keep a usable gradient.
+        """
+        matrix = jnp.diag(jnp.array([1.0, 2.0, 0.0]))
+        direction = jnp.diag(jnp.array([1.0, 0.0, 0.0]))
+        _, tangent = jax.jvp(dense_symmetric_sqrt, (matrix,), (direction,))
+        assert jnp.all(jnp.isfinite(tangent))
+        assert tree_allclose(tangent[0, 0], jnp.asarray(0.5))


### PR DESCRIPTION
Follow-up to #214. Two review comments on that PR arrived after it was squash-merged, so the fixes never reached `main` — and one of them is a live bug in the released 0.0.20.

## The singular-`R` escape hatch does not work

#214 documented `dense_innovation=True` as the route for a positive **semi**-definite `obs_noise`, because the Woodbury path solves against `R` itself. But the perturbations are drawn *before* that flag is ever consulted:

```python
chol = cholesky(obs_noise)          # <- here
...
if localization is None and not use_dense:   # <- flag consulted here
```

`cholesky`'s dense fallback is `jnp.linalg.cholesky`, which requires positive definiteness and returns `NaN` for `diag(1, 1, 0)`. So the analysis came back `NaN` regardless of what the caller passed, and the documented workaround was unreachable.

Dense operators now go through a symmetric (eigendecomposition) square root, which is defined for any PSD matrix. Structured operators keep `cholesky` — its diagonal case already handles a zero entry by taking `sqrt` of it, and routing those through a dense eigendecomposition would undo the structure-preservation added in #214.

Both factors satisfy `L Lᵀ = R`, so the draws are distributionally identical — but they are *different* factors, so `test_perturbed_obs_reproduces_the_key_path` now rebuilds its realisation through the same helper instead of hand-rolling a Cholesky. That test would otherwise fail for the right reason.

## The parameter doc pointed singular-`R` callers at the failing route

```
``False`` keeps the structured `LowRankUpdate` no matter the shapes --
for a matrix-free solver, or when ``obs_noise`` is singular.
```

`False` selects Woodbury, which is precisely what cannot handle a singular `R` — and this contradicted the Note immediately below it, which correctly says `True`. Corrected, with `False` described as what a matrix-free solver wants.

## Tests

- `test_singular_dense_noise_perturbations_are_finite` — `diag(1, 1, 0)` through the `key` path with `dense_innovation=True` returns finite values. Fails on `main` today.
- `test_noise_factor_reproduces_the_covariance` — `L Lᵀ == R` for dense PD, diagonal, and singular operators.

## Checks

- `pytest tests/inference/test_enkf_analysis.py` — 27 passed
- `ruff check .` + `ruff format --check .` — clean
- `ty check src/gaussx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)