### PR TITLE
fix(ssm,quadrature): preserve input dtype under x64 (gh-219)

### DIFF
--- a/src/gaussx/_quadrature/_adf.py
+++ b/src/gaussx/_quadrature/_adf.py
@@ -84,7 +84,7 @@ class AssumedDensityFilter(AbstractIntegrator):
 
         # Sample from input Gaussian
         L = cholesky(state.cov).as_matrix()
-        eps = jr.normal(key, (self.n_samples, N))
+        eps = jr.normal(key, (self.n_samples, N), dtype=mu.dtype)
         x_samples = mu[None, :] + eps @ L.T
 
         # Propagate samples
@@ -101,7 +101,7 @@ class AssumedDensityFilter(AbstractIntegrator):
             eps_reg = self.regularization * jnp.trace(Sigma_y) / M
         else:
             eps_reg = self.regularization
-        Sigma_y = Sigma_y + eps_reg * jnp.eye(M)
+        Sigma_y = Sigma_y + eps_reg * jnp.eye(M, dtype=Sigma_y.dtype)
         Sigma_y = symmetrize(Sigma_y)
 
         # Cross-covariance

--- a/src/gaussx/_quadrature/_gauss_hermite.py
+++ b/src/gaussx/_quadrature/_gauss_hermite.py
@@ -67,8 +67,9 @@ class GaussHermiteIntegrator(AbstractIntegrator):
         mu = state.mean
         N = mu.shape[0]
 
-        # GH points in standard normal space
-        z, w = gauss_hermite_points(self.order, N)
+        # GH points in standard normal space, in the input dtype so a
+        # float32 belief is not promoted under x64.
+        z, w = gauss_hermite_points(self.order, N, dtype=mu.dtype)
 
         # Transform to input space: xᵢ = μ + S zᵢ
         S = sqrt(state.cov).as_matrix()

--- a/src/gaussx/_quadrature/_monte_carlo.py
+++ b/src/gaussx/_quadrature/_monte_carlo.py
@@ -58,7 +58,7 @@ class MonteCarloIntegrator(AbstractIntegrator):
         M = Y.shape[1]
         import lineax as lx
 
-        Sigma_y = Sigma_y + self.regularization * jnp.eye(M)
+        Sigma_y = Sigma_y + self.regularization * jnp.eye(M, dtype=Sigma_y.dtype)
         cov_y = lx.MatrixLinearOperator(Sigma_y, lx.positive_semidefinite_tag)
         out_state = GaussianState(mean=result.state.mean, cov=cov_y)
 
@@ -93,15 +93,17 @@ class MonteCarloIntegrator(AbstractIntegrator):
 
         key = self.key if self.key is not None else jr.key(0)
 
-        # Sample from input Gaussian: xᵢ = μ + L εᵢ
+        # Sample from input Gaussian: xᵢ = μ + L εᵢ. Draws and weights are
+        # built in the input dtype: the defaults would otherwise land in
+        # float64 under x64 and promote the whole transform.
         L = cholesky(state.cov).as_matrix()
-        eps = jr.normal(key, (self.n_samples, N))
+        eps = jr.normal(key, (self.n_samples, N), dtype=mu.dtype)
         chi = mu[None, :] + eps @ L.T  # (S, N)
 
         # Uniform weights = 1/S for empirical moments
         # Use 1/(S−1) Bessel correction via covariance weights
         S = self.n_samples
-        w_m = jnp.full(S, 1.0 / S)
-        w_c = jnp.full(S, 1.0 / (S - 1))
+        w_m = jnp.full(S, 1.0 / S, dtype=mu.dtype)
+        w_c = jnp.full(S, 1.0 / (S - 1), dtype=mu.dtype)
 
         return chi, w_m, w_c

--- a/src/gaussx/_quadrature/_quadrature.py
+++ b/src/gaussx/_quadrature/_quadrature.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import lineax as lx
 import numpy as np
+from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
 from gaussx._einx import rearrange, reduce
@@ -14,6 +15,7 @@ from gaussx._primitives._sqrt import sqrt
 def gauss_hermite_points(
     order: int,
     dim: int,
+    dtype: DTypeLike | None = None,
 ) -> tuple[Float[Array, "P D"], Float[Array, " P"]]:
     r"""Gauss-Hermite quadrature points and weights.
 
@@ -25,6 +27,11 @@ def gauss_hermite_points(
     Args:
         order: Number of quadrature points per dimension.
         dim: Dimensionality of the integration domain.
+        dtype: Floating dtype of the returned points and weights.
+            Defaults to JAX's default float dtype. Unlike the other rules
+            here this one has no mean to take a dtype from, so callers
+            propagating an input dtype must pass it explicitly —
+            `gaussx.GaussHermiteIntegrator` does.
 
     Returns:
         Tuple ``(points, weights)`` where points has shape
@@ -32,8 +39,8 @@ def gauss_hermite_points(
     """
     # 1D probabilists' Gauss-Hermite (weight = exp(-x^2/2))
     x1d_np, w1d_np = np.polynomial.hermite_e.hermegauss(order)
-    x1d = jnp.array(x1d_np)
-    w1d = jnp.array(w1d_np)
+    x1d = jnp.array(x1d_np, dtype=dtype)
+    w1d = jnp.array(w1d_np, dtype=dtype)
 
     if dim == 1:
         return x1d[:, None], w1d
@@ -94,13 +101,17 @@ def sigma_points(
     chi_minus = mean[None, :] - S_scaled.T  # (N, N)
     chi = jnp.concatenate([chi_0, chi_plus, chi_minus], axis=0)  # (2N+1, N)
 
+    # Weights are built in the input dtype: Python floats would otherwise
+    # land in float64 under x64 and promote the whole downstream transform.
+    dtype = mean.dtype
+
     # Mean weights
     w_m_0 = lam / c
     w_m_i = 1.0 / (2.0 * c)
     w_m = jnp.concatenate(
         [
-            jnp.array([w_m_0]),
-            jnp.full(2 * N, w_m_i),
+            jnp.array([w_m_0], dtype=dtype),
+            jnp.full(2 * N, w_m_i, dtype=dtype),
         ]
     )
 
@@ -108,8 +119,8 @@ def sigma_points(
     w_c_0 = lam / c + (1.0 - alpha**2 + beta)
     w_c = jnp.concatenate(
         [
-            jnp.array([w_c_0]),
-            jnp.full(2 * N, w_m_i),
+            jnp.array([w_c_0], dtype=dtype),
+            jnp.full(2 * N, w_m_i, dtype=dtype),
         ]
     )
 
@@ -146,7 +157,7 @@ def cubature_points(
     chi_minus = mean[None, :] - S_scaled.T  # (N, N)
     chi = jnp.concatenate([chi_plus, chi_minus], axis=0)  # (2N, N)
 
-    weights = jnp.full(2 * N, 1.0 / (2.0 * N))
+    weights = jnp.full(2 * N, 1.0 / (2.0 * N), dtype=mean.dtype)
 
     return chi, weights
 
@@ -194,14 +205,20 @@ def fifth_order_cubature_points(
     """
     N = mean.shape[0]
 
-    r1 = np.sqrt(N + 2.0)
-    r2 = np.sqrt((N + 2.0) / 2.0)
+    # Python floats, not numpy scalars: a np.float64 radius is strongly
+    # typed and would promote the points it scales back to float64.
+    r1 = float(np.sqrt(N + 2.0))
+    r2 = float(np.sqrt((N + 2.0) / 2.0))
     w0 = 2.0 / (N + 2.0)
     w1 = (4.0 - N) / (2.0 * (N + 2.0) ** 2)
     w2 = 1.0 / (N + 2.0) ** 2
 
-    eye = jnp.eye(N)
-    origin = jnp.zeros((1, N))
+    # Points and weights are built in the input dtype: the defaults would
+    # otherwise land in float64 under x64 and promote the whole transform.
+    dtype = mean.dtype
+
+    eye = jnp.eye(N, dtype=dtype)
+    origin = jnp.zeros((1, N), dtype=dtype)
     axis = jnp.concatenate([r1 * eye, -r1 * eye], axis=0)  # (2N, N)
 
     # Diagonal shell: all four sign combinations of ±eᵢ ± eⱼ for i < j.
@@ -226,9 +243,9 @@ def fifth_order_cubature_points(
 
     weights = jnp.concatenate(
         [
-            jnp.array([w0]),
-            jnp.full(2 * N, w1),
-            jnp.full(4 * n_pairs, w2),
+            jnp.array([w0], dtype=dtype),
+            jnp.full(2 * N, w1, dtype=dtype),
+            jnp.full(4 * n_pairs, w2, dtype=dtype),
         ]
     )
 

--- a/src/gaussx/_ssm/_kalman.py
+++ b/src/gaussx/_ssm/_kalman.py
@@ -237,7 +237,10 @@ def kalman_filter(
                 return _update(H_innov, R_innov, v, 0.0)
 
             def _skip_update(_):
-                return x_pred, P_pred, jnp.array(0.0)
+                # Match the update branch's dtype: a bare ``jnp.array(0.0)``
+                # is float64 under x64 and makes ``lax.cond`` reject the
+                # branches on float32 inputs.
+                return x_pred, P_pred, jnp.zeros((), dtype=P_pred.dtype)
 
             x_filt_new, P_filt_new, ll_inc = jax.lax.cond(
                 mask_t, _do_update, _skip_update, operand=None
@@ -248,7 +251,7 @@ def kalman_filter(
         outputs = (x_filt_new, P_filt_new, x_pred, P_pred)
         return carry_new, outputs
 
-    init_carry = (init_mean, init_cov, jnp.array(0.0))
+    init_carry = (init_mean, init_cov, jnp.zeros((), dtype=init_cov.dtype))
     final_carry, (f_means, f_covs, p_means, p_covs) = jax.lax.scan(
         step, init_carry, (A_seq, H_seq, Q_seq, R_seq, observations, mask_seq)
     )

--- a/tests/quadrature/test_integrators.py
+++ b/tests/quadrature/test_integrators.py
@@ -4,8 +4,12 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import lineax as lx
+import pytest
 
 from gaussx._quadrature._adf import AssumedDensityFilter
+from gaussx._quadrature._cubature import CubatureIntegrator
+from gaussx._quadrature._fifth_order import FifthOrderCubatureIntegrator
+from gaussx._quadrature._gauss_hermite import GaussHermiteIntegrator
 from gaussx._quadrature._monte_carlo import MonteCarloIntegrator
 from gaussx._quadrature._taylor import TaylorIntegrator
 from gaussx._quadrature._types import GaussianState
@@ -425,3 +429,71 @@ def test_moment_transform_default_is_float32_safe():
     matrix = jnp.array([[2.0, 1.0], [0.0, 3.0]])
     exact = matrix @ state.cov.as_matrix() @ matrix.T
     assert jnp.abs(safe_cov - exact).max() < jnp.abs(classic[1] - exact).max()
+
+
+class TestFloat32Preservation:
+    """A float32 belief must stay float32 through every integrator.
+
+    The suite runs under ``jax_enable_x64``, so a rule that builds its
+    points or weights without a dtype silently promotes the propagated
+    moments to float64. Regression coverage for gh-219.
+    """
+
+    @staticmethod
+    def _fn32(x):
+        """Affine map whose constants follow ``x``'s dtype.
+
+        ``_linear_fn`` hardcodes float64 literals under x64, which would
+        promote the output regardless of the rule under test.
+        """
+        A = jnp.array([[2.0, 1.0], [0.0, 3.0]], dtype=x.dtype)
+        b = jnp.array([1.0, -1.0], dtype=x.dtype)
+        return A @ x + b
+
+    def _state32(self):
+        mean = jnp.array([1.0, 2.0], dtype=jnp.float32)
+        cov = lx.MatrixLinearOperator(
+            jnp.array([[1.0, 0.3], [0.3, 0.5]], dtype=jnp.float32),
+            lx.positive_semidefinite_tag,
+        )
+        return GaussianState(mean=mean, cov=cov)
+
+    @pytest.mark.parametrize(
+        "integrator",
+        [
+            TaylorIntegrator(order=1),
+            TaylorIntegrator(order=2),
+            UnscentedIntegrator(alpha=1.0),
+            CubatureIntegrator(),
+            FifthOrderCubatureIntegrator(),
+            GaussHermiteIntegrator(order=3),
+            MonteCarloIntegrator(n_samples=32),
+            AssumedDensityFilter(n_samples=32),
+        ],
+        ids=lambda i: type(i).__name__,
+    )
+    def test_integrate_preserves_float32(self, integrator):
+        state = self._state32()
+        result = integrator.integrate(self._fn32, state)
+
+        assert result.state.mean.dtype == jnp.float32
+        assert result.state.cov.as_matrix().dtype == jnp.float32
+        if result.cross_cov is not None:
+            assert result.cross_cov.dtype == jnp.float32
+
+    @pytest.mark.parametrize(
+        "integrator",
+        [
+            UnscentedIntegrator(alpha=1.0),
+            CubatureIntegrator(),
+            FifthOrderCubatureIntegrator(),
+            GaussHermiteIntegrator(order=3),
+            MonteCarloIntegrator(n_samples=32),
+        ],
+        ids=lambda i: type(i).__name__,
+    )
+    def test_points_and_weights_preserve_float32(self, integrator):
+        chi, w_m, w_c = integrator.points_and_weights(self._state32())
+        assert chi.dtype == jnp.float32
+        assert w_m.dtype == jnp.float32
+        assert w_c.dtype == jnp.float32

--- a/tests/quadrature/test_quadrature.py
+++ b/tests/quadrature/test_quadrature.py
@@ -5,6 +5,7 @@ import lineax as lx
 
 from gaussx._quadrature._quadrature import (
     cubature_points,
+    fifth_order_cubature_points,
     gauss_hermite_points,
     sigma_points,
 )
@@ -125,3 +126,49 @@ class TestCubaturePoints:
         chi, wts = cubature_points(mean, cov)
         recovered_mean = jnp.sum(wts[:, None] * chi, axis=0)
         assert jnp.allclose(recovered_mean, mean, atol=1e-6)
+
+
+class TestFloat32Preservation:
+    """Quadrature rules must not promote a float32 belief under x64.
+
+    The test suite runs with ``jax_enable_x64`` on (see ``tests/conftest``),
+    so any rule building points or weights from Python/NumPy scalars without
+    a dtype lands in float64 and drags the whole downstream transform with
+    it. Regression coverage for gh-219.
+    """
+
+    def _state(self, N=3):
+        mean = jnp.zeros(N, dtype=jnp.float32)
+        cov = lx.MatrixLinearOperator(
+            jnp.eye(N, dtype=jnp.float32), lx.positive_semidefinite_tag
+        )
+        return mean, cov
+
+    def test_sigma_points_stay_float32(self):
+        mean, cov = self._state()
+        chi, w_m, w_c = sigma_points(mean, cov)
+        assert chi.dtype == jnp.float32
+        assert w_m.dtype == jnp.float32
+        assert w_c.dtype == jnp.float32
+
+    def test_cubature_points_stay_float32(self):
+        mean, cov = self._state()
+        chi, wts = cubature_points(mean, cov)
+        assert chi.dtype == jnp.float32
+        assert wts.dtype == jnp.float32
+
+    def test_fifth_order_points_stay_float32(self):
+        mean, cov = self._state()
+        chi, wts = fifth_order_cubature_points(mean, cov)
+        assert chi.dtype == jnp.float32
+        assert wts.dtype == jnp.float32
+
+    def test_gauss_hermite_honours_dtype(self):
+        """``gauss_hermite_points`` has no mean, so dtype is explicit."""
+        pts32, wts32 = gauss_hermite_points(3, 2, dtype=jnp.float32)
+        assert pts32.dtype == jnp.float32
+        assert wts32.dtype == jnp.float32
+
+        # Default is unchanged: JAX's default float dtype.
+        pts_default, _ = gauss_hermite_points(3, 2)
+        assert pts_default.dtype == jnp.zeros(()).dtype

--- a/tests/ssm/test_kalman.py
+++ b/tests/ssm/test_kalman.py
@@ -524,3 +524,53 @@ def test_mixed_numpy_3d_with_operator_raises(getkey):
     y = jr.normal(getkey(), (T, M))
     with pytest.raises(TypeError, match="Time-varying"):
         kalman_filter(A_seq_np, H, Q_op, R, y, jnp.zeros(N), jnp.eye(N))
+
+
+def test_kalman_filter_float32_inputs_stay_float32():
+    """float32 inputs must survive the ``lax.cond`` gate under x64.
+
+    The predict-only branch used to return a bare ``jnp.array(0.0)`` — a
+    float64 scalar under ``jax_enable_x64`` — which made ``lax.cond``
+    reject the branches outright on float32 inputs. Regression for
+    gh-219.
+    """
+    f32 = jnp.float32
+    N, M, T = 3, 2, 5
+
+    state = kalman_filter(
+        jnp.eye(N, dtype=f32) * 0.9,
+        jnp.eye(M, N, dtype=f32),
+        (0.05 * jnp.eye(N)).astype(f32),
+        (0.1 * jnp.eye(M)).astype(f32),
+        jnp.zeros((T, M), dtype=f32),
+        jnp.zeros(N, dtype=f32),
+        jnp.eye(N, dtype=f32),
+    )
+
+    assert state.filtered_means.dtype == f32
+    assert state.filtered_covs.dtype == f32
+    assert state.predicted_means.dtype == f32
+    assert state.predicted_covs.dtype == f32
+    assert state.log_likelihood.dtype == f32
+
+
+def test_kalman_filter_float32_with_partial_mask():
+    """The gated path is the one that broke; exercise it explicitly."""
+    f32 = jnp.float32
+    N, M, T = 3, 2, 6
+    mask = jnp.array([True, False, True, True, False, True])
+
+    state = kalman_filter(
+        jnp.eye(N, dtype=f32) * 0.9,
+        jnp.eye(M, N, dtype=f32),
+        (0.05 * jnp.eye(N)).astype(f32),
+        (0.1 * jnp.eye(M)).astype(f32),
+        jnp.zeros((T, M), dtype=f32),
+        jnp.zeros(N, dtype=f32),
+        jnp.eye(N, dtype=f32),
+        mask=mask,
+    )
+
+    assert state.filtered_means.dtype == f32
+    assert state.log_likelihood.dtype == f32
+    assert jnp.isfinite(state.log_likelihood)

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.19"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "einx" },

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.21"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "einx" },


### PR DESCRIPTION
Addresses bugs **1 and 2** of #219. Bug 3 (`ProductSDE` diffusion) follows in a stacked PR on top of this one.

## The problem

Two independent float64 promotions that together made float32 unusable end to end under `jax_enable_x64`. Pure float32 (x64 off) was unaffected, so this bit mixed-precision users rather than the default path.

**1. `kalman_filter` rejected float32 inputs outright.** The predict-only branch returned a bare `jnp.array(0.0)` — float64 under x64 — while the update branch's log-likelihood accumulator followed the float32 inputs, so `lax.cond` refused the mismatched branches:

```
TypeError: cond branches must have equal output types but they differ.
The output of true_fun at path [2] has type float32[] but the corresponding
output of false_fun has type float64[]
```

**2. The quadrature rules silently promoted everything downstream.** Points and weights were built from Python/NumPy scalars, so a float32 belief came back float64 from every point-based integrator.

## The fix

Carry the input dtype through in both places. `nonlinear_kalman_filter` already did this correctly, so the Kalman side is only the linear path.

The audit called for in the issue turned up more than the three sites it named:

| Site | Promotion |
|---|---|
| `kalman_filter` | `_skip_update` and `init_carry` accumulators |
| `sigma_points` | mean and covariance weights |
| `cubature_points` | weights |
| `fifth_order_cubature_points` | weights **and the shell points** — the `np.sqrt` radii are strongly-typed `np.float64` and promoted what they scaled |
| `gauss_hermite_points` | points and weights |
| `MonteCarloIntegrator` | draws, weights, jitter |
| `AssumedDensityFilter` | draws, jitter |

`gauss_hermite_points` is the one rule with no `mean` to key a dtype off, so it takes an explicit `dtype` argument instead. The default is unchanged (JAX's default float dtype); `GaussHermiteIntegrator` passes the input dtype. `TaylorIntegrator`, `UnscentedIntegrator`, `CubatureIntegrator` and `FifthOrderCubatureIntegrator` needed no changes of their own once the underlying rules were fixed.

## Testing

- `kalman_filter` on float32 inputs under x64 returns float32 throughout — both the unmasked path and the `lax.cond`-gated masked path that actually broke.
- A float32 `GaussianState` stays float32 through all eight integrators, and every point-based rule returns float32 points and weights.
- The rule-level tests pin `gauss_hermite_points`' unchanged default alongside the new explicit dtype.

`tests/ssm` and `tests/quadrature` pass in full (470 tests); lint, format, and typecheck are clean.

One incidental change: `uv.lock` picks up the `0.0.19` → `0.0.21` version sync it had drifted from.

Closes nothing on its own — #219 stays open for bug 3.