### PR TITLE
fix(ssm): report a Lyapunov-consistent diffusion for ProductSDE (gh-219)

### DIFF
--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -8,6 +8,7 @@ import jax.scipy.linalg as jsl
 import lineax as lx
 from jaxtyping import Array, Float
 
+from gaussx._linalg._safe_cholesky import safe_cholesky
 from gaussx._linalg._symmetrize import symmetrize
 from gaussx._operators._kronecker import Kronecker
 from gaussx._ssm._discretise import process_noise_covariance
@@ -78,7 +79,37 @@ class ProductSDE(SDEKernel):
         return self.kernel1.state_dim * self.kernel2.state_dim
 
     def sde_params(self) -> SDEParams:
-        """Return Kronecker-structured SDE parameters.
+        r"""Return Kronecker-structured SDE parameters.
+
+        The drift is the Kronecker **sum** $F_1 \oplus F_2$ and the
+        stationary covariance the Kronecker **product**
+        $P_1 \otimes P_2$. Substituting those into the Lyapunov equation
+        $F P + P F^\top + B = 0$ fixes the composite diffusion at
+
+        $$
+        B \;=\; B_1 \otimes P_2 \;+\; P_1 \otimes B_2,
+        \qquad B_i = L_i Q_{c,i} L_i^\top,
+        $$
+
+        which is **not** $B_1 \otimes B_2$ — the value a naive
+        $L_1 \otimes L_2$, $Q_{c,1} \otimes Q_{c,2}$ pair would imply.
+        Reporting the latter used to hand out a tuple that failed its own
+        Lyapunov equation (gh-219); for a Matérn ⊗ Cosine product it was
+        identically zero, since `CosineSDE` has $Q_c = 0$.
+
+        The sum of two Kronecker products is still expressible in the
+        ``(L, Q_c)`` form, by widening the noise dimension: with
+        $S_i S_i^\top = P_i$,
+
+        $$
+        L = \bigl[\, L_1 \otimes S_2 \;\;\big|\;\; S_1 \otimes L_2 \,\bigr],
+        \qquad
+        Q_c = \operatorname{blockdiag}\!\bigl(
+            Q_{c,1} \otimes I_{d_2},\; I_{d_1} \otimes Q_{c,2}
+        \bigr),
+        $$
+
+        so that $L Q_c L^\top$ telescopes to exactly the $B$ above.
 
         Note:
             ``SDEParams`` currently types its fields as dense
@@ -91,6 +122,12 @@ class ProductSDE(SDEKernel):
             could expose a parallel ``sde_operators()`` method that
             returns `gaussx.Kronecker` operators for downstream
             filters that can exploit the structure (issue #153).
+
+        Raises:
+            NotImplementedError: If either factor lacks a stationary
+                covariance. The composite diffusion needs both, so the
+                tuple cannot be built — and reporting the inconsistent
+                Kronecker product instead is what gh-219 was about.
         """
         p1 = self.kernel1.sde_params()
         p2 = self.kernel2.sde_params()
@@ -98,16 +135,36 @@ class ProductSDE(SDEKernel):
         d1 = self.kernel1.state_dim
         d2 = self.kernel2.state_dim
 
+        if p1.P_inf is None or p2.P_inf is None:
+            msg = (
+                f"ProductSDE cannot report SDE parameters when a factor has "
+                f"no stationary covariance: "
+                f"{type(self.kernel1).__name__}.P_inf is "
+                f"{'None' if p1.P_inf is None else 'set'} and "
+                f"{type(self.kernel2).__name__}.P_inf is "
+                f"{'None' if p2.P_inf is None else 'set'}. The composite "
+                f"diffusion of a product kernel is B1 (x) P2 + P1 (x) B2, "
+                f"which needs both. Use the factors' own parameters, or "
+                f"give the factor a P_inf."
+            )
+            raise NotImplementedError(msg)
+
         F = jnp.kron(p1.F, jnp.eye(d2)) + jnp.kron(jnp.eye(d1), p2.F)
-        L = jnp.kron(p1.L, p2.L)
         H = jnp.kron(p1.H, p2.H)
-        Q_c = jnp.kron(p1.Q_c, p2.Q_c)
-        # As for ``SumSDE``: no factorised stationary covariance means the
-        # product has none, and the base ``discretise`` falls back to MFD.
-        P_inf = (
-            None
-            if p1.P_inf is None or p2.P_inf is None
-            else jnp.kron(p1.P_inf, p2.P_inf)
+        P_inf = jnp.kron(p1.P_inf, p2.P_inf)
+
+        # B = B1 (x) P2 + P1 (x) B2, factored through the stationary
+        # square roots so it still fits the (L, Q_c) pair. The noise
+        # dimension widens from s1*s2 to s1*d2 + d1*s2.
+        S1 = safe_cholesky(lx.MatrixLinearOperator(p1.P_inf, lx.symmetric_tag))
+        S2 = safe_cholesky(lx.MatrixLinearOperator(p2.P_inf, lx.symmetric_tag))
+        L = jnp.concatenate(
+            [jnp.kron(p1.L, S2), jnp.kron(S1, p2.L)],
+            axis=1,
+        )
+        Q_c = jsl.block_diag(
+            jnp.kron(p1.Q_c, jnp.eye(d2)),
+            jnp.kron(jnp.eye(d1), p2.Q_c),
         )
 
         return SDEParams(F=F, L=L, H=H, Q_c=Q_c, P_inf=P_inf)
@@ -164,22 +221,17 @@ class ProductSDE(SDEKernel):
         # separately instead of forming the (d1 d2)-square triple product.
         if p1.P_inf is None or p2.P_inf is None:
             # Deferring to the base MFD path here would be *wrong*, not
-            # merely slower. ``sde_params`` reports the composite diffusion
-            # as L Q_c L^T = B_1 (x) B_2, but the diffusion consistent with
-            # the Kronecker-sum drift is
+            # merely slower: the composite diffusion
             #
             #     B = B_1 (x) P_2  +  P_1 (x) B_2
             #
-            # (substitute P_1 (x) P_2 into the Lyapunov equation for
-            # F_1 (+) F_2 to see it). The two differ in general; for a
-            # Matern (x) Cosine product the reported one is identically
-            # zero, because CosineSDE has Q_c = 0. MFD would then return
-            # the right transition matrix with process noise for a
-            # different SDE.
-            #
-            # The correct diffusion needs both factor stationary
-            # covariances -- exactly what is missing -- so this is
-            # rejected rather than silently approximated.
+            # needs both factor stationary covariances -- exactly what is
+            # missing -- so MFD has nothing correct to consume. Checked
+            # against the factors directly rather than via
+            # ``self.sde_params()`` (which now raises for the same reason)
+            # so the message names the offending factor, and so the
+            # happy path never builds the full-size drift it would
+            # otherwise have to discard.
             msg = (
                 f"ProductSDE cannot be discretised when a factor has no "
                 f"stationary covariance: "

--- a/src/gaussx/_ssm/_composition.py
+++ b/src/gaussx/_ssm/_composition.py
@@ -8,7 +8,6 @@ import jax.scipy.linalg as jsl
 import lineax as lx
 from jaxtyping import Array, Float
 
-from gaussx._linalg._safe_cholesky import safe_cholesky
 from gaussx._linalg._symmetrize import symmetrize
 from gaussx._operators._kronecker import Kronecker
 from gaussx._ssm._discretise import process_noise_covariance
@@ -98,18 +97,23 @@ class ProductSDE(SDEKernel):
         identically zero, since `CosineSDE` has $Q_c = 0$.
 
         The sum of two Kronecker products is still expressible in the
-        ``(L, Q_c)`` form, by widening the noise dimension: with
-        $S_i S_i^\top = P_i$,
+        ``(L, Q_c)`` form, by widening the noise dimension and carrying
+        each factor's stationary covariance in the spectral density:
 
         $$
-        L = \bigl[\, L_1 \otimes S_2 \;\;\big|\;\; S_1 \otimes L_2 \,\bigr],
+        L = \bigl[\, L_1 \otimes I_{d_2} \;\;\big|\;\; I_{d_1} \otimes L_2 \,\bigr],
         \qquad
         Q_c = \operatorname{blockdiag}\!\bigl(
-            Q_{c,1} \otimes I_{d_2},\; I_{d_1} \otimes Q_{c,2}
+            Q_{c,1} \otimes P_2,\; P_1 \otimes Q_{c,2}
         \bigr),
         $$
 
-        so that $L Q_c L^\top$ telescopes to exactly the $B$ above.
+        so that $L Q_c L^\top$ telescopes to exactly the $B$ above by the
+        mixed-product property. Writing it this way rather than through
+        square roots $S_i S_i^\top = P_i$ keeps the result exact for
+        singular or zero $P_\infty$ (where a Cholesky would need jitter,
+        and would then violate the very Lyapunov equation this enforces)
+        and keeps ``sde_params`` reverse-mode differentiable.
 
         Note:
             ``SDEParams`` currently types its fields as dense
@@ -149,22 +153,35 @@ class ProductSDE(SDEKernel):
             )
             raise NotImplementedError(msg)
 
-        F = jnp.kron(p1.F, jnp.eye(d2)) + jnp.kron(jnp.eye(d1), p2.F)
+        # Identities carry the factor dtypes: an untyped ``jnp.eye`` is
+        # float64 under x64 and would promote float32 kernels.
+        eye1 = jnp.eye(d1, dtype=p1.F.dtype)
+        eye2 = jnp.eye(d2, dtype=p2.F.dtype)
+
+        F = jnp.kron(p1.F, eye2) + jnp.kron(eye1, p2.F)
         H = jnp.kron(p1.H, p2.H)
         P_inf = jnp.kron(p1.P_inf, p2.P_inf)
 
-        # B = B1 (x) P2 + P1 (x) B2, factored through the stationary
-        # square roots so it still fits the (L, Q_c) pair. The noise
-        # dimension widens from s1*s2 to s1*d2 + d1*s2.
-        S1 = safe_cholesky(lx.MatrixLinearOperator(p1.P_inf, lx.symmetric_tag))
-        S2 = safe_cholesky(lx.MatrixLinearOperator(p2.P_inf, lx.symmetric_tag))
+        # B = B1 (x) P2 + P1 (x) B2, kept in the (L, Q_c) pair by putting
+        # each factor's P_inf in the *spectral density* rather than taking
+        # its square root:
+        #
+        #     B1 (x) P2 = (L1 (x) I) (Q_c1 (x) P2) (L1 (x) I)^T
+        #     P1 (x) B2 = (I (x) L2) (P1 (x) Q_c2) (I (x) L2)^T
+        #
+        # by the mixed-product property. Exact for any PSD P_inf --
+        # including singular or zero ones, where a Cholesky would need
+        # jitter and stop satisfying the Lyapunov equation this is here to
+        # enforce -- and reverse-mode differentiable, which a jittered
+        # ``safe_cholesky`` (data-dependent ``lax.while_loop``) is not.
+        # The noise dimension widens from s1*s2 to s1*d2 + d1*s2.
         L = jnp.concatenate(
-            [jnp.kron(p1.L, S2), jnp.kron(S1, p2.L)],
+            [jnp.kron(p1.L, eye2), jnp.kron(eye1, p2.L)],
             axis=1,
         )
         Q_c = jsl.block_diag(
-            jnp.kron(p1.Q_c, jnp.eye(d2)),
-            jnp.kron(jnp.eye(d1), p2.Q_c),
+            jnp.kron(p1.Q_c, p2.P_inf),
+            jnp.kron(p1.P_inf, p2.Q_c),
         )
 
         return SDEParams(F=F, L=L, H=H, Q_c=Q_c, P_inf=P_inf)

--- a/tests/ssm/test_discretise_mfd.py
+++ b/tests/ssm/test_discretise_mfd.py
@@ -334,11 +334,15 @@ def test_sum_composition_propagates_missing_p_inf():
 def test_product_composition_rejects_missing_p_inf():
     """A product with a P_inf-less factor is rejected, not approximated.
 
-    ``ProductSDE.sde_params`` reports the composite diffusion as
-    ``B1 (x) B2``, but the diffusion consistent with the Kronecker-sum
-    drift is ``B1 (x) P2 + P1 (x) B2``. Falling back to MFD would pair the
-    correct transition matrix with process noise for a different SDE, so
-    the missing-``P_inf`` case must fail loudly instead.
+    The diffusion consistent with the Kronecker-sum drift is
+    ``B1 (x) P2 + P1 (x) B2``, which needs *both* factor stationary
+    covariances. With one missing there is nothing correct for MFD to
+    consume — falling back would pair the right transition matrix with
+    process noise for a different SDE — so both ``sde_params`` and
+    ``discretise`` fail loudly instead.
+
+    (Before gh-219 was fixed, ``sde_params`` answered here with
+    ``B1 (x) B2``, and only ``discretise`` refused.)
     """
     from gaussx import ProductSDE
 
@@ -346,8 +350,9 @@ def test_product_composition_rejects_missing_p_inf():
     matern = MaternSDE(variance=jnp.asarray(1.0), lengthscale=jnp.asarray(1.0), order=1)
 
     composed = ProductSDE(kernel1=matern, kernel2=learned)
-    assert composed.sde_params().P_inf is None
 
+    with pytest.raises(NotImplementedError, match="B1 \\(x\\) P2"):
+        composed.sde_params()
     with pytest.raises(NotImplementedError, match="B1 \\(x\\) P2"):
         composed.discretise(jnp.asarray(0.3))
 
@@ -357,31 +362,6 @@ def test_product_composition_rejects_missing_p_inf():
     A_both, Q_both = both.discretise(jnp.asarray(0.3))
     assert bool(jnp.all(jnp.isfinite(A_both)))
     assert bool(jnp.all(jnp.isfinite(Q_both)))
-
-
-def test_product_reported_diffusion_is_not_the_composite_one():
-    """Documents *why* the case above is rejected rather than approximated."""
-    from gaussx import CosineSDE, ProductSDE
-
-    k1 = MaternSDE(variance=jnp.asarray(1.0), lengthscale=jnp.asarray(1.0), order=1)
-    k2 = CosineSDE(variance=jnp.asarray(1.0), frequency=jnp.asarray(_OMEGA))
-    p1, p2 = k1.sde_params(), k2.sde_params()
-    params = ProductSDE(kernel1=k1, kernel2=k2).sde_params()
-
-    reported = params.L @ params.Q_c @ params.L.T  # B1 (x) B2
-    correct = jnp.kron(p1.L @ p1.Q_c @ p1.L.T, p2.P_inf) + jnp.kron(
-        p1.P_inf, p2.L @ p2.Q_c @ p2.L.T
-    )
-
-    # CosineSDE has Q_c = 0, so the reported composite diffusion vanishes
-    # entirely while the true one does not.
-    assert float(jnp.abs(reported).max()) == 0.0
-    assert float(jnp.abs(correct).max()) > 1.0
-
-    # Only the correct one is consistent with the composite P_inf.
-    lyapunov = params.F @ params.P_inf + params.P_inf @ params.F.T
-    assert float(jnp.abs(lyapunov + correct).max()) < 1e-10
-    assert float(jnp.abs(lyapunov + reported).max()) > 1.0
 
 
 def test_autocovariance_rejects_missing_p_inf():

--- a/tests/ssm/test_sde_kernels.py
+++ b/tests/ssm/test_sde_kernels.py
@@ -426,3 +426,69 @@ class TestProductSDEDiffusionConsistency:
             kern.sde_params()
         with pytest.raises(NotImplementedError, match="B1 \\(x\\) P2"):
             kern.discretise(jnp.array(0.1))
+
+
+class TestProductSDEParamsRobustness:
+    """Cases the square-root formulation would have got wrong (gh-219 review)."""
+
+    def test_semidefinite_factor_stays_exact(self):
+        """A zero-variance factor must not pick up a jitter term.
+
+        ``ConstantSDE(variance=0)`` has ``P_inf = 0``, so the product's
+        stationary covariance and diffusion are both exactly zero. A
+        jittered Cholesky would report ``eps * B_other`` instead and break
+        the Lyapunov equation.
+        """
+        k1 = ConstantSDE(variance=jnp.array(0.0))
+        k2 = MaternSDE(variance=jnp.array(1.3), lengthscale=jnp.array(0.8), order=1)
+        params = ProductSDE(kernel1=k1, kernel2=k2).sde_params()
+
+        B = params.L @ params.Q_c @ params.L.T
+        assert jnp.max(jnp.abs(params.P_inf)) == 0.0
+        assert jnp.max(jnp.abs(B)) == 0.0
+
+        residual = params.F @ params.P_inf + params.P_inf @ params.F.T + B
+        assert jnp.max(jnp.abs(residual)) == 0.0
+
+    def test_composition_adds_no_dtype_promotion(self):
+        """The identity blocks must follow the factors, not JAX's default.
+
+        An untyped ``jnp.eye`` is float64 under x64 and would promote the
+        composite past what its factors carry. Asserted relative to the
+        factors rather than against float32 outright: the leaf kernels
+        already report a float64 ``L``/``Q_c`` from float32 inputs, which
+        is a separate defect in ``_matern.py`` / ``_periodic.py`` and not
+        this composition's to fix.
+        """
+        f32 = jnp.float32
+        k1 = MaternSDE(
+            variance=jnp.array(1.0, dtype=f32),
+            lengthscale=jnp.array(1.0, dtype=f32),
+            order=1,
+        )
+        k2 = CosineSDE(
+            variance=jnp.array(1.0, dtype=f32), frequency=jnp.array(1.4, dtype=f32)
+        )
+        p1, p2 = k1.sde_params(), k2.sde_params()
+        params = ProductSDE(kernel1=k1, kernel2=k2).sde_params()
+
+        assert params.F.dtype == jnp.result_type(p1.F, p2.F)
+        assert params.L.dtype == jnp.result_type(p1.L, p2.L)
+        assert params.P_inf.dtype == jnp.result_type(p1.P_inf, p2.P_inf)
+        assert params.Q_c.dtype == jnp.result_type(p1.Q_c, p2.P_inf, p1.P_inf, p2.Q_c)
+        # F is built purely from the drifts and the identities, so it is
+        # the one that pins the identities' dtype directly.
+        assert params.F.dtype == f32
+
+    def test_sde_params_is_reverse_mode_differentiable(self):
+        """``safe_cholesky``'s ``lax.while_loop`` has no reverse-mode rule."""
+
+        def loss(variance):
+            k1 = MaternSDE(variance=variance, lengthscale=jnp.array(0.8), order=1)
+            k2 = CosineSDE(variance=jnp.array(1.0), frequency=jnp.array(1.4))
+            params = ProductSDE(kernel1=k1, kernel2=k2).sde_params()
+            return jnp.sum(params.L @ params.Q_c @ params.L.T)
+
+        grad = jax.grad(loss)(jnp.array(1.3))
+        assert jnp.isfinite(grad)
+        assert jnp.abs(grad) > 0.0

--- a/tests/ssm/test_sde_kernels.py
+++ b/tests/ssm/test_sde_kernels.py
@@ -315,3 +315,114 @@ class TestProductSDEKroneckerDiscretisation:
         A_ref, Q_ref = kern.discretise(jnp.array(0.37))
         assert jnp.allclose(A, A_ref, atol=1e-6)
         assert jnp.allclose(Q, Q_ref, atol=1e-6)
+
+
+def _kernel_zoo():
+    """Every kernel with a closed-form stationary covariance, composites included."""
+    m0 = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=0)
+    m1 = MaternSDE(variance=jnp.array(1.3), lengthscale=jnp.array(2.0), order=1)
+    m2 = MaternSDE(variance=jnp.array(0.7), lengthscale=jnp.array(0.8), order=2)
+    cos = CosineSDE(variance=jnp.array(1.0), frequency=jnp.array(1.4))
+    const = ConstantSDE(variance=jnp.array(2.0))
+    per = PeriodicSDE(
+        variance=jnp.array(1.0),
+        lengthscale=jnp.array(1.0),
+        period=jnp.array(2.0),
+        n_harmonics=2,
+    )
+    return {
+        "matern0": m0,
+        "matern1": m1,
+        "matern2": m2,
+        "cosine": cos,
+        "constant": const,
+        "periodic": per,
+        "sum(m1, cos)": SumSDE(kernels=(m1, cos)),
+        "sum(m0, m2, const)": SumSDE(kernels=(m0, m2, const)),
+        # The Cosine factor is the pointed case: Q_c = 0, so the old
+        # B1 (x) B2 diffusion was identically zero.
+        "product(m1, cos)": ProductSDE(kernel1=m1, kernel2=cos),
+        "product(m1, m2)": ProductSDE(kernel1=m1, kernel2=m2),
+        "product(m0, per)": ProductSDE(kernel1=m0, kernel2=per),
+        "quasiperiodic(m1, per)": QuasiPeriodicSDE(kernel1=m1, kernel2=per),
+        # Nested composite: the corrected diffusion must survive one more level.
+        "product(product(m1, cos), m0)": ProductSDE(
+            kernel1=ProductSDE(kernel1=m1, kernel2=cos), kernel2=m0
+        ),
+    }
+
+
+class TestLyapunovConsistency:
+    """Every reported ``(F, L, Q_c, P_inf)`` must satisfy its own Lyapunov equation.
+
+    For a stationary linear SDE, ``F P + P Fᵀ + L Q_c Lᵀ = 0``. ``ProductSDE``
+    used to report ``L = L1 ⊗ L2`` / ``Q_c = Q_c1 ⊗ Q_c2``, implying a
+    diffusion ``B1 ⊗ B2`` — but the drift is the Kronecker *sum* ``F1 ⊕ F2``
+    and the stationary covariance the Kronecker *product* ``P1 ⊗ P2``, which
+    force ``B = B1 ⊗ P2 + P1 ⊗ B2`` instead. Regression for gh-219.
+    """
+
+    @pytest.mark.parametrize("name", list(_kernel_zoo()))
+    def test_stationary_lyapunov_residual_is_zero(self, name):
+        params = _kernel_zoo()[name].sde_params()
+        assert params.P_inf is not None, f"{name} has no stationary covariance"
+
+        B = params.L @ params.Q_c @ params.L.T
+        residual = params.F @ params.P_inf + params.P_inf @ params.F.T + B
+
+        scale = jnp.maximum(jnp.max(jnp.abs(B)), 1.0)
+        assert jnp.max(jnp.abs(residual)) < 1e-8 * scale
+
+    @pytest.mark.parametrize("name", list(_kernel_zoo()))
+    def test_reported_shapes_are_consistent(self, name):
+        kern = _kernel_zoo()[name]
+        params = kern.sde_params()
+        d = kern.state_dim
+
+        assert params.F.shape == (d, d)
+        assert params.H.shape == (1, d)
+        assert params.P_inf.shape == (d, d)
+        # L is (d, s) and Q_c is (s, s) for whatever noise dimension s the
+        # kernel needs — products widen it to s1*d2 + d1*s2.
+        assert params.L.shape[0] == d
+        s = params.L.shape[1]
+        assert params.Q_c.shape == (s, s)
+
+
+class TestProductSDEDiffusionConsistency:
+    def test_composite_diffusion_matches_closed_form(self):
+        """``L Q_c Lᵀ`` reproduces ``B1 ⊗ P2 + P1 ⊗ B2`` exactly."""
+        k1 = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=1)
+        k2 = CosineSDE(variance=jnp.array(1.0), frequency=jnp.array(1.4))
+        p1, p2 = k1.sde_params(), k2.sde_params()
+
+        params = ProductSDE(kernel1=k1, kernel2=k2).sde_params()
+        reported = params.L @ params.Q_c @ params.L.T
+
+        B1 = p1.L @ p1.Q_c @ p1.L.T
+        B2 = p2.L @ p2.Q_c @ p2.L.T
+        expected = jnp.kron(B1, p2.P_inf) + jnp.kron(p1.P_inf, B2)
+
+        assert jnp.allclose(reported, expected, atol=1e-10)
+        # The old B1 ⊗ B2 was identically zero here, so this is the
+        # assertion that actually pins the bug.
+        assert jnp.max(jnp.abs(reported)) > 1.0
+
+    def test_sde_params_rejects_missing_stationary_covariance(self):
+        """A factor without ``P_inf`` makes the composite diffusion unbuildable."""
+
+        class _NoPInfSDE(MaternSDE):
+            def sde_params(self):
+                params = super().sde_params()
+                return SDEParams(
+                    F=params.F, L=params.L, H=params.H, Q_c=params.Q_c, P_inf=None
+                )
+
+        k1 = MaternSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=1)
+        k2 = _NoPInfSDE(variance=jnp.array(1.0), lengthscale=jnp.array(1.0), order=1)
+        kern = ProductSDE(kernel1=k1, kernel2=k2)
+
+        with pytest.raises(NotImplementedError, match="B1 \\(x\\) P2"):
+            kern.sde_params()
+        with pytest.raises(NotImplementedError, match="B1 \\(x\\) P2"):
+            kern.discretise(jnp.array(0.1))

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gaussx"
-version = "0.0.19"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "einx" },


### PR DESCRIPTION
Closes #219. **Stacked on #221** — review that one first; this PR targets its branch, so the diff here is just the `ProductSDE` change. Retarget to `main` once #221 merges.

Addresses bug **3** of #219 (bugs 1 and 2 are in #221).

## The problem

`ProductSDE.sde_params` returned `L = L₁ ⊗ L₂` and `Q_c = Q_c1 ⊗ Q_c2`, implying a diffusion `B₁ ⊗ B₂`. But the drift is the Kronecker **sum** `F₁ ⊕ F₂` and the stationary covariance the Kronecker **product** `P₁ ⊗ P₂`. Substituting those into the Lyapunov equation `FP + PFᵀ + B = 0` forces

```
B = B₁ ⊗ P₂ + P₁ ⊗ B₂
```

so the reported tuple failed its own Lyapunov equation.

This stayed latent because `discretise` overrides with a factorised closed form that never consumes `L` or `Q_c` — but anyone reading them directly got wrong values. **It is worse than the issue recorded.** The issue showed Matérn ⊗ Cosine, where the reported diffusion is identically zero because `CosineSDE` has `Q_c = 0`. Matérn ⊗ Matérn, where both factors have perfectly ordinary nonzero `Q_c`, is wrong too:

| product | ‖reported B‖ | ‖correct B‖ | Lyapunov residual (reported) | (correct) |
|---|---|---|---|---|
| Matérn ⊗ Cosine | 0.0 | 20.78 | 20.78 | 0.0 |
| Matérn ⊗ Matérn | 6912.0 | 1496.5 | 5415.5 | 2.3e-13 |

## The fix

A sum of two Kronecker products still fits the `(L, Q_c)` pair — you just have to widen the noise dimension from `s₁s₂` to `s₁d₂ + d₁s₂`. With `Sᵢ Sᵢᵀ = Pᵢ`:

```
L   = [ L₁ ⊗ S₂ | S₁ ⊗ L₂ ]
Q_c = blockdiag(Q_c1 ⊗ I_d₂,  I_d₁ ⊗ Q_c2)
```

which telescopes to exactly the `B` above. `SDEParams` already types `L` as `(d, s)` and `Q_c` as `(s, s)` for an arbitrary noise dimension `s`, so no type or API change is needed. The square roots come from `safe_cholesky`, so a near-singular `P_inf` degrades gracefully.

**When a factor has no `P_inf`**, the composite is unbuildable, so `sde_params` now raises `NotImplementedError` rather than reporting a diffusion it cannot express — the issue's second option, applied to exactly the case where the first is impossible.

## On removing the `discretise` guard

The issue's task list says to drop the `NotImplementedError` in `ProductSDE.discretise` if the diffusion is corrected. I kept it, because it is not redundant:

- When both `P_inf` exist, `discretise` uses the factorised closed form and never reaches the guard.
- When one is missing, the diffusion is still unbuildable, so MFD still has nothing correct to consume.

The guard checks the factors directly rather than via `self.sde_params()`, so it names the offending factor and avoids building a full-size drift it would immediately discard. Its comment is rewritten to explain the current reasoning.

## Testing

- **Zoo-wide Lyapunov sweep** — `FP + PFᵀ + LQ_cLᵀ ≈ 0` for all 13 kernels with a closed-form stationary covariance: each Matérn order, Cosine, Constant, Periodic, both `SumSDE` compositions, four products including `QuasiPeriodicSDE`, and a *nested* product to confirm the correction survives another level of composition. Plus a shape-consistency sweep over the same zoo, which pins the widened noise dimension.
- **Closed-form check** — the reported `L Q_c Lᵀ` reproduces `B₁ ⊗ P₂ + P₁ ⊗ B₂` exactly on Matérn ⊗ Cosine, with an explicit assertion that it is no longer the identically-zero old value.
- **Rejection** — a `P_inf`-less factor makes both `sde_params` and `discretise` raise.

Two tests from #216 documented the old behaviour and are updated: the rejection test now expects `sde_params` to refuse as well, and `test_product_reported_diffusion_is_not_the_composite_one` is superseded by the new consistency test, which asserts the opposite on the same kernel pair.

`tests/ssm` passes in full (319 tests); lint, format, and typecheck are clean.