### PR TITLE
test: bound statistical assertions by their sampling distribution (gh-220)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,25 @@ automatically — trigger them on demand with the "Extended Tests" workflow:
 - `@pytest.mark.integration`: end-to-end workflows (e.g. MCMC/SVI fits
   through numpyro). Usually combined with `slow`.
 
+## Tests That Assert On Random Draws
+
+The `getkey` fixture is `equinox.internal.GetKey`, which seeds itself from
+`random.randint` unless `EQX_GETKEY_SEED` is set — so every run draws a
+different model. Reproduce a one-off failure with
+`EQX_GETKEY_SEED=<n> uv run pytest <nodeid>`, and sweep `n` to find the
+failing seeds. Two rules keep such tests from reddening CI at random:
+
+- **If the randomness is incidental** — the test checks a correctness
+  property and any model would do — pin the key (`jr.key(0)`) instead of
+  taking `getkey`. Deterministic makes the tolerance mean something.
+- **If the test is genuinely about sampling behaviour**, bound the
+  estimator by its own sampling distribution rather than a fixed `atol`:
+  `gaussx._testing.assert_sample_moments` does this for mean/covariance at
+  a default 7 sigma. A flat `atol` against a randomly drawn covariance is a
+  different number of sigmas on every run — the defect behind gh-220.
+
+Either way, say in a comment where the bound came from.
+
 ## Coding Conventions
 
 - All operators are `equinox.Module` subclasses (immutable, PyTree-compatible)

--- a/src/gaussx/_testing.py
+++ b/src/gaussx/_testing.py
@@ -132,3 +132,73 @@ def dense_diag(op: lx.AbstractLinearOperator) -> Float[Array, " n"]:
 def dense_trace(op: lx.AbstractLinearOperator) -> Float[Array, ""]:
     """Trace via dense materialization."""
     return jnp.trace(op.as_matrix())
+
+
+# ---------------------------------------------------------------------------
+# Sampling-statistics assertions
+# ---------------------------------------------------------------------------
+
+
+def assert_sample_moments(
+    samples: Float[Array, "S N"],
+    mean: Float[Array, " N"],
+    cov: Float[Array, "N N"],
+    *,
+    n_sigma: float = 7.0,
+) -> None:
+    r"""Assert empirical moments match their population values.
+
+    Bounds each entry by ``n_sigma`` standard deviations of *that
+    estimator's own sampling distribution*, rather than by a fixed
+    absolute tolerance. For ``S`` draws from $\mathcal{N}(\mu, \Sigma)$,
+
+    $$
+    \operatorname{Var}[\bar{x}_i] = \frac{\Sigma_{ii}}{S},
+    \qquad
+    \operatorname{Var}[S_{ij}]
+        \approx \frac{\Sigma_{ii}\Sigma_{jj} + \Sigma_{ij}^2}{S}.
+    $$
+
+    A fixed ``atol`` is the wrong shape for these assertions whenever the
+    covariance under test is itself random: measured in standard
+    deviations it then varies with the draw, so the test is far stricter
+    on some seeds than others. On the 3x3 Wishart-style covariances used
+    in the distribution tests, ``atol=0.5`` ranged from 1.9 to 193 sigma
+    across seeds and failed roughly 1 run in 1300 (gh-220).
+
+    The default ``n_sigma=7`` is set from a 20,000-seed sweep of those
+    same covariances, over which the largest deviation observed was
+    5.16 sigma. Seven leaves real headroom above that without weakening
+    the test in any way that matters: a genuine bias or a wrong
+    covariance moves the estimator by ``O(sqrt(S))`` standard
+    deviations — hundreds, here — not by a handful.
+
+    Args:
+        samples: Draws, shape ``(S, N)``.
+        mean: Population mean, shape ``(N,)``.
+        cov: Population covariance, shape ``(N, N)``.
+        n_sigma: Width of the acceptance band, in standard deviations of
+            the estimator. Defaults to ``6.0``.
+
+    Raises:
+        AssertionError: If any empirical moment falls outside its band.
+    """
+    n_draws = samples.shape[0]
+    sample_mean = jnp.mean(samples, axis=0)
+    sample_cov = jnp.cov(samples.T)
+
+    variances = jnp.diag(cov)
+    mean_band = n_sigma * jnp.sqrt(variances / n_draws)
+    cov_band = n_sigma * jnp.sqrt(
+        (variances[:, None] * variances[None, :] + cov**2) / n_draws
+    )
+
+    mean_excess = jnp.max(jnp.abs(sample_mean - mean) - mean_band)
+    assert mean_excess <= 0.0, (
+        f"sample mean outside its {n_sigma}-sigma band by {float(mean_excess):.3g}"
+    )
+
+    cov_excess = jnp.max(jnp.abs(sample_cov - cov) - cov_band)
+    assert cov_excess <= 0.0, (
+        f"sample covariance outside its {n_sigma}-sigma band by {float(cov_excess):.3g}"
+    )

--- a/tests/distributions/test_mvn.py
+++ b/tests/distributions/test_mvn.py
@@ -15,7 +15,7 @@ import lineax as lx
 from gaussx._distributions import MultivariateNormal
 from gaussx._operators import BlockDiag, Kronecker, LowRankUpdate
 from gaussx._strategies import AutoSolver, DenseSolver
-from gaussx._testing import tree_allclose
+from gaussx._testing import assert_sample_moments, tree_allclose
 
 
 def _make_psd(key, n):
@@ -108,11 +108,11 @@ class TestSample:
         d = MultivariateNormal(mu, op)
 
         samples = d.sample(getkey(), sample_shape=(10_000,))
-        sample_mean = jnp.mean(samples, axis=0)
-        sample_cov = jnp.cov(samples.T)
 
-        assert jnp.allclose(sample_mean, mu, atol=0.15)
-        assert jnp.allclose(sample_cov, Sigma, atol=0.5)
+        # Bounded by the estimators' own sampling distributions, not a
+        # fixed atol: ``Sigma`` is drawn per-seed, so an absolute
+        # tolerance is a different number of sigmas on every run (gh-220).
+        assert_sample_moments(samples, mu, Sigma)
 
     def test_single_sample(self, getkey):
         n = 3

--- a/tests/distributions/test_mvn_prec.py
+++ b/tests/distributions/test_mvn_prec.py
@@ -13,7 +13,7 @@ import jax.random as jr
 import lineax as lx
 
 from gaussx._distributions import MultivariateNormal, MultivariateNormalPrecision
-from gaussx._testing import tree_allclose
+from gaussx._testing import assert_sample_moments, tree_allclose
 
 
 def _make_psd(key, n):
@@ -92,11 +92,11 @@ class TestSample:
         d = MultivariateNormalPrecision(mu, op)
 
         samples = d.sample(getkey(), sample_shape=(10_000,))
-        sample_mean = jnp.mean(samples, axis=0)
-        sample_cov = jnp.cov(samples.T)
 
-        assert jnp.allclose(sample_mean, mu, atol=0.15)
-        assert jnp.allclose(sample_cov, Sigma, atol=0.5)
+        # Bounded by the estimators' own sampling distributions, not a
+        # fixed atol: ``Sigma`` is drawn per-seed, so an absolute
+        # tolerance is a different number of sigmas on every run (gh-220).
+        assert_sample_moments(samples, mu, Sigma)
 
     def test_batched_loc_sample_shape(self, getkey):
         n = 3

--- a/tests/primitives_extra/test_root.py
+++ b/tests/primitives_extra/test_root.py
@@ -9,6 +9,7 @@ import lineax as lx
 import gaussx
 from gaussx._gp._love import love_cache, love_variance
 from gaussx._primitives import root_decomposition, root_inv_decomposition
+from gaussx._testing import assert_sample_moments
 
 
 def test_root_decomposition_truncated_diagonal():
@@ -91,23 +92,18 @@ def test_root_decomposition_cholesky_ignores_rank_sentinel(getkey):
 
 def test_root_matmul_sampling_covariance(getkey):
     num_samples = 4096
-    empirical_cov_tolerance = 0.12
     diag = jnp.array([1.0, 2.0, 3.0])
     op = lx.DiagonalLinearOperator(diag)
     root = root_decomposition(op, rank=3, method="svd")
 
     eps = jax.random.normal(getkey(), (num_samples, root.rank))
     samples = root.matmul(eps)
-    centered = samples - jnp.mean(samples, axis=0)
-    empirical = centered.T @ centered / (samples.shape[0] - 1)
 
     assert samples.shape == (num_samples, 3)
-    assert jnp.allclose(
-        empirical,
-        jnp.diag(diag),
-        rtol=empirical_cov_tolerance,
-        atol=empirical_cov_tolerance,
-    )
+    # The previous flat 0.12 tolerance was only ~3.1 sigma on the
+    # largest off-diagonal entry, so it would have reddened CI on its
+    # own eventually (gh-220).
+    assert_sample_moments(samples, jnp.zeros(3), jnp.diag(diag))
 
 
 def test_whitening_reconstructs_identity(getkey):

--- a/tests/ssm/test_kalman_channel_mask.py
+++ b/tests/ssm/test_kalman_channel_mask.py
@@ -351,19 +351,25 @@ class TestEdgeCases:
             kalman_filter(A, H, Q, R, y, m0, P0, mask=jnp.ones((T, M + 1), dtype=bool))
 
     @pytest.mark.slow
-    def test_float32_tracks_row_deleted_reference(self, getkey):
+    def test_float32_tracks_row_deleted_reference(self):
         """Tight noise in float32 is where the dummy block could bite.
 
-        The bound is set from a 30-seed sweep: relative log-likelihood
-        error is ~3e-6 median with a 1.3e-5 tail, which is float32
-        accumulation over 60 steps rather than a defect. ``5e-5`` clears
-        that tail with room to spare while staying orders of magnitude
-        below what this test exists to catch — the missing likelihood
-        correction shifts this model by ~100 nats, a relative error of
-        order 1.
+        What this test exists to catch is a *structural* error — a
+        missing likelihood correction shifts this model by ~100 nats, a
+        relative error of order 1 — so the model is drawn from a fixed
+        key rather than the ``getkey`` fixture. The randomness was
+        incidental, and it was not free: the residual here is float32
+        accumulation over 60 steps, whose size varies by more than an
+        order of magnitude with the draw (~4e-6 median, but 7.3e-5 at
+        equinox ``GetKey`` seed 19), so the previous bound was a lottery
+        that reddened CI at random (gh-220).
+
+        At this key the relative log-likelihood error is 1.3e-6 and the
+        mean absolute state deviation 3.0e-7, leaving both bounds below
+        roughly 35x margin.
         """
         T, M, N = 60, 6, 3
-        k = jr.split(getkey(), 4)
+        k = jr.split(jr.key(0), 4)
         A = (0.95 * jnp.eye(N) + 0.01 * jr.normal(k[0], (N, N))).astype(jnp.float32)
         H = jr.normal(k[1], (M, N)).astype(jnp.float32)
         Q = (1e-4 * jnp.eye(N)).astype(jnp.float32)


### PR DESCRIPTION
Closes #220. **Stacked on #222** (which is stacked on #221) — the diff shown here is just the test changes. Retarget down the stack as those merge.

## The mechanism is not pytest-randomly

The issue assumed `pytest-randomly` reseeds CI each run. It doesn't — **that plugin isn't a dependency of this repo**, and neither `ci.yml` nor `tests-extended.yml` passes a seed. The actual source is the `getkey` fixture: `equinox.internal.GetKey` seeds itself from `random.randint` unless `EQX_GETKEY_SEED` is set, which equinox's own docstring calls "deliberate non-determinism."

So the reproduction recipe is `EQX_GETKEY_SEED=<n>`, not `--randomly-seed=<n>`:

```console
$ EQX_GETKEY_SEED=1833 uv run pytest tests/distributions/test_mvn.py::TestSample::test_sample_statistics
$ EQX_GETKEY_SEED=19   uv run pytest "tests/ssm/test_kalman_channel_mask.py::TestEdgeCases::test_float32_tracks_row_deleted_reference"
```

Both fail. Everything below follows from sweeping that variable.

## 1. `test_sample_statistics` — size the bound from the sampling distribution

The test drew a random `Sigma`, then compared empirical moments to it with a flat `atol=0.5`. Because the *target* is random with a heavy tail (`Sigma_ii` ranged 1 → 26 across seeds), that fixed tolerance is a different statistical bound every run. Expressed in standard deviations of the estimator it ranged from **1.9σ to 193σ** (median 12σ) — and failed **3 of 4000 seeds**, about 1 run in 1300. Exactly the "tolerance that happened to pass" the issue guessed at.

The fix is `gaussx._testing.assert_sample_moments`, which bounds each entry by that estimator's own sampling distribution:

```
Var[x̄_i] = Σ_ii / S        Var[S_ij] ≈ (Σ_ii Σ_jj + Σ_ij²) / S
```

Default `n_sigma=7`, set from a 20,000-seed sweep whose worst observed deviation was 5.16σ. This is not a loosening in the sense that matters — a genuine bias or a wrong covariance moves the estimator by `O(√S)` standard deviations, *hundreds* at `S = 10,000`, so the test still catches everything it was there to catch.

**Two other call sites adopt it**, which is the "sweep for other tests with the same latent fragility" task:

- `tests/distributions/test_mvn_prec.py::TestSample::test_sample_statistics` carried a byte-identical copy of the flaky assertion. Seed 1833 fails both.
- `tests/primitives_extra/test_root.py::test_root_matmul_sampling_covariance` used a flat `0.12`, which is only **~3.1σ** on its largest off-diagonal — roughly a 0.5% failure rate per run. Not yet observed, but it would have shown up eventually.

I checked the other statistical tests and left them alone: `test_kronecker_sum.py` uses a fixed `PRNGKey(123)` against a fixed target (fully deterministic), and `test_matheron.py` draws whitened samples with exact empirical prior moments and documents its tolerances accordingly.

## 2. `test_float32_tracks_row_deleted_reference` — pin the key

Here the randomness is **incidental**: the test checks that the masked filter tracks a row-deleted float64 reference, a structural property for which any model would do. And it wasn't free — the float32 accumulation residual varies by over an order of magnitude with the draw (~4e-6 median, **7.3e-5 at seed 19**) against a `5e-5` bound. The existing 30-seed sweep behind that bound simply undersampled the tail.

Pinned to `jr.key(0)`, where the relative log-likelihood error is `1.3e-6` and the mean absolute state deviation `3.0e-7` — about 35x margin on both bounds, and now deterministic, so the tolerance means something. The docstring records where those numbers came from.

## 3. Convention in `CLAUDE.md`

A new section under the test-tier guidance: the `EQX_GETKEY_SEED` reproduction recipe, and the rule for choosing between the two fixes — pin the key when the randomness is incidental, size the bound from the sampling distribution when the test is genuinely about sampling behaviour, and say in a comment where the bound came from either way.

## Testing

`tests/distributions/test_mvn.py`, `test_mvn_prec.py`, and `tests/primitives_extra/test_root.py` pass (53 tests); the previously-failing seeds (1833, 1645, 3805 for the sampling tests; 19 for the Kalman one) all pass now. Lint, format, and typecheck are clean. CI will run the full suite.